### PR TITLE
L: Export CSS and JS map

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "⚡ A consistent look-and-feel and extensible interface for Narmi experiences 🔥",
   "main": "dist/index.js",
   "files": [
-    "dist/*.js"
+    "dist/*"
   ],
   "scripts": {
     "watch": "watch 'npm run build' src",


### PR DESCRIPTION
Turns out we need to change the `files` property in package.json so that we correctly export our `styles.css` and `index.js.map` when someone `npm installs` from GitHub.