### PR TITLE
[Action] L: Remove redundant 'npm run build'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,4 +8,3 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
       - run: npm install
-      - run: npm run build


### PR DESCRIPTION
Delete 'npm run build' from workflow as the repo automatically builds after 'npm install'