### PR TITLE
style: more styling fixes for Checkbox

### DIFF
--- a/src/scss/CheckBox.scss
+++ b/src/scss/CheckBox.scss
@@ -2,7 +2,7 @@
     display: flex;
     width: fit-content;
     position: relative;
-    padding-left: 32px;
+    padding-left: 28px;
     margin-bottom: 12px;
     cursor: pointer;
     font-size: 16px;
@@ -17,7 +17,7 @@
       width: 0;
       &:checked ~ .narmi-icon-check {
         background-color: RGB(var(--nds-primary-color));
-        border: 2px solid RGB(var(--nds-primary-color));
+        border: 1px solid RGB(var(--nds-primary-color));
         &:after {
           display: block;
         }
@@ -27,14 +27,16 @@
     .narmi-icon-check {
       position: absolute;
       left: 0;
-      height: 24px;
-      width: 24px;
+      height: 18px;
+      width: 18px;
       background-color: white;
       font-weight: bold;
       border-radius: 3px;
-      border: 2px solid RGB(var(--nds-lightest-grey));
+      border: 1px solid RGB(var(--nds-lightest-grey));
       color: white;
-      font-size: 24px;
+      font-size: 15px;
+      text-align: center;
+      line-height: 18px;
       box-sizing: content-box;
       &:hover {
         border: 2px solid RGB(var(--nds-primary-color));


### PR DESCRIPTION
resolves https://github.com/narmi/design_system/issues/207

after this change:
<img width="72" alt="Screen Shot 2021-10-15 at 10 14 48 AM" src="https://user-images.githubusercontent.com/54218373/137502111-facab92e-ac11-4e57-b984-96dde3dbc3d6.png">

design:
 <img width="20" alt="checkbox prototype" src="https://user-images.githubusercontent.com/54218373/134702295-014baa4e-2e75-40cc-a52a-437399b00eda.png">

the checkbox icon is still off though.. not sure how to change that