### PR TITLE
ci: rename Jest job name to be more accurate

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -1,7 +1,7 @@
 name: Jest
 on: [pull_request]
 jobs:
-  Build-design_system:
+  Run-jest-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Doesn't have an issue but noticed while looking at https://github.com/narmi/design_system/pull/250, I was concerned Jest tests weren't being run on CI but they are! Renaming action job for clarity. 