### PR TITLE
refactor(storybook): storybook prop tables

### DIFF
--- a/src/Card/index.stories.js
+++ b/src/Card/index.stories.js
@@ -1,11 +1,14 @@
 import React, { useRef, useState } from "react";
-import { Button, Card, PlainButton } from "dist";
+import Card from "./";
+import Button from "../Button";
+import PlainButton from "../PlainButton";
 
 export default {
   title: "Components/Card",
+  component: Card,
 };
 
-export const ContentVarieties = () => {
+export const Overview = () => {
   const [selected, setSelected] = useState("nothing");
   return (
     <div className="nds-typography">

--- a/src/CheckBox/index.stories.js
+++ b/src/CheckBox/index.stories.js
@@ -1,11 +1,14 @@
 import React from "react";
-import { CheckBox, Button, Modal } from "dist";
+import CheckBox from "./";
+import Button from "../Button";
+import Modal from "../Modal";
 
 export default {
   title: "Components/Check",
+  component: CheckBox,
 };
 
-export const SampleCheckBox = () => {
+export const Overview = () => {
   const [checkData, setCheckData] = React.useState({
     cb1: true,
     cb2: false,

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -1,11 +1,15 @@
 import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import Input from "Input";
+import Input from "../Input";
 import { english } from "flatpickr/dist/l10n/default";
 import flatpickr from "flatpickr";
 import moment from "moment";
 import "flatpickr/dist/themes/airbnb.css";
 
+/**
+ * Single day picker.
+ * Composes NDS input with a [flatpickr](http://flatpickrjs.org) calendar UI.
+ */
 const DateInput = ({
   disableDates,
   minDate,

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -1,23 +1,31 @@
 import React from "react";
-import { DateInput } from "dist";
+import DateInput from "./";
 
-export default {
-  title: "Components/DateInput",
+// formats native date object to the format flatpickr expects
+const toFPString = (date, dayOffset = 0) => {
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${
+    date.getDate() + dayOffset
+  }`;
 };
 
-export const BasicDateInput = () => {
-  return <DateInput label={"Date of Birth"} />;
+const Template = (args) => <DateInput {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  label: "Date of Birth",
 };
 
-export const WithDisabledDates = () => {
-  return (
-    <DateInput
-      label={"Select a date that is not 2021-10-22"}
-      disableDates={["2021-10-22"]}
-    />
-  );
+export const WithDisabledDates = Template.bind({});
+WithDisabledDates.args = {
+  label: "Select any date (except for today or tomorrow)",
+  disableDates: [toFPString(new Date()), toFPString(new Date(), 1)],
 };
 
 export const WithDefaultDate = () => {
   return <DateInput label={"Select a date"} defaultDate="2021-10-22" />;
+};
+
+export default {
+  title: "Components/DateInput",
+  component: DateInput,
 };

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import TextInput from "TextInput";
+import TextInput from "../TextInput";
 import PropTypes from "prop-types";
 
 const Chevron = ({ open, setOpen }) => {

--- a/src/Dropdown/index.stories.js
+++ b/src/Dropdown/index.stories.js
@@ -1,11 +1,16 @@
 import React, { useState } from "react";
-import { Modal, PlainButton, Dropdown, TextInput, Button } from "dist";
+import Dropdown from "./";
+import Modal from "../Modal";
+import PlainButton from "../PlainButton";
+import TextInput from "../TextInput";
+import Button from "../Button";
 
 export default {
   title: "Components/Dropdown",
+  component: Dropdown,
 };
 
-export const BasicDropdown = () => {
+export const Overview = () => {
   const [modalOpen, setModalOpen] = useState(false);
   return (
     <div>

--- a/src/Modal/index.stories.js
+++ b/src/Modal/index.stories.js
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
-import { Modal, Button, PlainButton, RadioButtons } from "dist";
+import Modal from "./";
+import Button from "../Button";
+import PlainButton from "../PlainButton";
+import RadioButtons from "../RadioButtons";
 
 export default {
   title: "Components/Modal",
+  component: Modal,
 };
 
-export const SimpleModal = () => {
+export const Overview = () => {
   const [open, setOpen] = useState(false);
   return (
     <div className="nds-typography">

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
-import Input from "Input";
+import Input from "../Input";
 
 const TextInput = (props) => {
   const {

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -1,14 +1,14 @@
 import React, { useRef, useState } from "react";
-import { TextInput } from "dist";
+import TextInput from "./";
 
 export default {
   title: "Components/TextInput",
+  component: TextInput,
 };
 
-export const Variations = () => {
+export const Overview = () => {
   return (
     <div className={"nds-typography"}>
-      <h1 style={{ marginBottom: "1em" }}>Text Inputs</h1>
       <div className="storybook-4col">
         <TextInput label={"Label"} />
         <TextInput />

--- a/src/scss/Icons.stories.js
+++ b/src/scss/Icons.stories.js
@@ -8,7 +8,6 @@ export default {
 export const Icons = () => {
   return (
     <div className="nds-typography">
-      <h4 className="nds-sans">Our Icons</h4>
       <div className="icon-demo">
         {IconSelection.icons.map((icon) => (
           <div className="icon-demo-box">

--- a/storybook/.storybook/Layout.jsx
+++ b/storybook/.storybook/Layout.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import {
+  Title,
+  Description,
+  ArgsTable,
+  Primary,
+  Stories,
+  PRIMARY_STORY,
+} from "@storybook/addon-docs";
+
+/**
+ * `preview.js` is configured to use this layout instead of
+ * the default `addon-docs` configuration.
+ *
+ * This allows us to insert custom elements or change the order
+ * of doc blocks as we see fit.
+ */
+const Layout = () => (
+  <>
+    <Title />
+    <Description />
+    <Primary />
+    <ArgsTable story={PRIMARY_STORY} />
+    <Stories />
+  </>
+);
+
+export default Layout;

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -6,7 +6,6 @@ module.exports = {
     "../../src/**/*.stories.@(js|jsx|ts|tsx)",
   ],
   addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
-
   webpackFinal: (config) => {
     config.resolve.alias = {
       dist: path.resolve(__dirname, "../../dist"),

--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -1,13 +1,19 @@
+import React from "react";
 import "../story-styles.css";
 import "../../dist/style.css";
 import { NdsStyles } from "./decorators";
+import Layout from "./Layout";
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  previewTabs: {
+    "storybook/docs/panel": { index: -1 },
+  },
+  docs: {
+    page: () => <Layout />,
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,
-      date: /Date$/,
     },
   },
 };

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -4768,16 +4768,16 @@
       "dev": true
     },
     "c8": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-7.8.0.tgz",
-      "integrity": "sha512-x2Bx+IIEd608B1LmjiNQ/kizRPkCWo5XzuV57J9afPjAHSnYXALwbCSOkQ7cSaNXBNblfqcvdycj+klmL+j6yA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-7.10.0.tgz",
+      "integrity": "sha512-OAwfC5+emvA6R7pkYFVBTOtI5ruf9DahffGmIqUc9l6wEh0h7iAFP6dt/V9Ioqlr2zW5avX9U9/w1I4alTRHkA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@istanbuljs/schema": "^0.1.2",
         "find-up": "^5.0.0",
         "foreground-child": "^2.0.0",
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.0.1",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-reports": "^3.0.2",
         "rimraf": "^3.0.0",
@@ -4785,6 +4785,14 @@
         "v8-to-istanbul": "^8.0.0",
         "yargs": "^16.2.0",
         "yargs-parser": "^20.2.7"
+      },
+      "dependencies": {
+        "istanbul-lib-coverage": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+          "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+          "dev": true
+        }
       }
     },
     "cacache": {
@@ -5154,18 +5162,18 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -8666,9 +8674,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
+      "integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -13234,9 +13242,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
-      "integrity": "sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
+      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -14104,9 +14112,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -14119,12 +14127,12 @@
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         }
       }


### PR DESCRIPTION
#### ⚠️ For a cleaner diff, this PR should merge first:

- https://github.com/narmi/design_system/pull/258 

--------

- Updated component imports in all stories to read from `src/` instead of `dist/`, which preserves jsDoc comments
- Configured storybook to open docs panel by default
- Set up a custom doc page layout
- Added `component` config to every story to ensure props are generated from source


<img width="1064" alt="Screen Shot 2021-10-21 at 6 03 17 PM" src="https://user-images.githubusercontent.com/231252/138363266-b10dc02d-2661-4c53-9b01-8cdb304baf42.png">

