### PR TITLE
feat(Modal): add styles and support for wide detail modals

### DIFF
--- a/src/Details/index.js
+++ b/src/Details/index.js
@@ -15,7 +15,7 @@ Chevron.propTypes = {
   setOpen: PropTypes.func,
 };
 
-const Details = ({ summary, children, React }) => {
+const Details = ({ summary, children, React, type }) => {
   const [open, setOpen] = React.useState(false);
 
   return (
@@ -28,7 +28,7 @@ const Details = ({ summary, children, React }) => {
       >
         {summary}
       </div>
-      <Modal classes="details" open={open} setOpen={setOpen}>
+      <Modal classes={type} open={open} setOpen={setOpen} React={React}>
         <div className="nds-details-container">{children}</div>
       </Modal>
       <Chevron open={open} setOpen={setOpen} />
@@ -39,10 +39,12 @@ const Details = ({ summary, children, React }) => {
 Details.propTypes = {
   summary: PropTypes.node,
   children: PropTypes.node,
+  type: PropTypes.oneOf(["details", "wide details"]),
 };
 
 Details.defaultProps = {
   summary: null,
+  type: "details",
   React,
 };
 

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -71,7 +71,7 @@ Modal.propTypes = {
   /** JSX content to render within the actions area of the Modal */
   actions: PropTypes.node,
   /** Additional classes to pass to the root Modal element */
-  classes: PropTypes.string,
+  classes: PropTypes.oneOf(["center", "right", "details", "wide details"]),
   /** Sets a max-width for the Modal container */
   maxWidth: PropTypes.oneOf([PropTypes.number, PropTypes.string])
 };

--- a/src/NavBar/index.js
+++ b/src/NavBar/index.js
@@ -21,7 +21,7 @@ const NavBar = (props) => {
           <ButtonBar className="nds-navbar-usermenu">
             <Details
               summary={
-                <Button type="menu">{props.user.email || "User"}</Button>
+                <Button type="menu">{props.user.username || "User"}</Button>
               }
               key={name}
               React={props.React}

--- a/src/scss/Button.scss
+++ b/src/scss/Button.scss
@@ -44,6 +44,7 @@
     color: RGB(var(--nds-black));
     padding: 10px 0;
     display: block;
+    font-size: 20px;
 
     &::before {
       display: none;
@@ -53,6 +54,7 @@
       margin: 0 12px;
       font-weight: 600;
       display: inline-block;
+      font-size: 16px;
     }
   }
 

--- a/src/scss/Details.scss
+++ b/src/scss/Details.scss
@@ -24,6 +24,13 @@
       width: min-content;
       transform: translate(-50%, 40px);
     }
+    .nds-modal.wide > .nds-modal-container {
+      width: 100vw;
+      transform: none;
+      position: fixed;
+      left: 0;
+      top: 80px;
+    }
     & .nds-details-container {
       margin: 0;
       padding: 20px 40px;

--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -37,13 +37,6 @@
     }
   }
 
-  & > .nds-modal-container {
-    display: none;
-    z-index: 1;
-    position: fixed;
-    background: RGB(var(--nds-white));
-  }
-
   .nds-modal-dismiss {
     display: none;
     position: absolute;
@@ -52,18 +45,31 @@
     cursor: pointer;
   }
 
+  /* non-center styles */
+  &:not(.center) {
+    & > .nds-modal-container {
+      top: 0;
+      right: 0;
+      transform: none;
+      overflow: initial;
+    }
+  }
+
   /* right styles */
-  &.right > .nds-modal-container {
-    top: 0;
-    right: 0;
-    transform: none;
-    bottom: 0;
-    left: initial;
-    padding: 40px 25px 40px 20px;
-    border-radius: 0;
-    width: 335px;
+  &.right {
     @media (min-width: $desktop-small) {
-      width: initial;
+      height: 40px;
+    }
+    & > .nds-modal-container {
+      bottom: 0;
+      max-height: 100vh;
+      left: initial;
+      padding: 40px 25px 40px 20px;
+      border-radius: 0;
+      width: 335px;
+      @media (min-width: $desktop-small) {
+        width: initial;
+      }
     }
   }
   /* details styles */
@@ -74,11 +80,12 @@
     display: none;
   }
   &.details > .nds-modal-container {
-    top: 0;
-    right: 0;
-    transform: none;
     position: static;
     padding: 0;
+    background: none;
+    & > .nds-details-container{
+      background: RGB(var(--nds-white));
+    }
   }
 
   .nds-modal-action-row {

--- a/src/scss/NavBar.scss
+++ b/src/scss/NavBar.scss
@@ -27,9 +27,10 @@
   }
 
   @media (min-width: $desktop-small) {
+    border-bottom: 1px solid RGB(var(--nds-lightest-grey));
+    box-shadow: 0px 2px 12px rgba(80, 80, 80, 0.05);
     position: static;
-    padding: 0;
-    justify-content: normal;
+    align-items: center;
 
     .nds-details {
       padding-right: 30px;
@@ -50,7 +51,7 @@
       & > .nds-modal-container {
         display: block;
         position: static;
-        padding: 16px 25px;
+        padding: 0px 25px;
         & > .nds-modal-dismiss {
           display: none;
         }
@@ -61,11 +62,11 @@
     }
     // underline while hover
     .nds-navbar-container {
-      .nds-navbar-mainmenu, .nds-navbar-usermenu, .nds-details-container {
-        & > * {
+      .nds-navbar-mainmenu, .nds-navbar-usermenu, .nds-details-container, .accountMenu-container {
+        & > .nds-button.menu, & > .nds-details {
           border-bottom: 3px solid transparent;
         }
-        & > *:hover {
+        & > .nds-button.menu:hover, & > .nds-details:hover {
           border-bottom: 3px solid RGB(var(--nds-primary-color));
         }
       }


### PR DESCRIPTION
![navigation](https://user-images.githubusercontent.com/1649289/138781101-1624f56e-71aa-4432-8418-7fe0ea44ffc1.gif)

The "Accounts" menu is full-screen-width on desktop regardless of it's contents. Adding a "wide" Details type to accommodate this!