### PR TITLE
fix(Modal): hide scrollbar space if not needed

### DIFF
--- a/src/scss/Modal.scss
+++ b/src/scss/Modal.scss
@@ -11,7 +11,7 @@
     right: 0;
   }
   & > .nds-modal-container {
-    overflow: scroll;
+    overflow: auto;
     max-height: 80vh;
     left: 50%;
     top: 50%;


### PR DESCRIPTION
part of https://github.com/narmi/banking/issues/12098

my mistake on an earlier, change, this should allow the modal to be scrollable if needed but not show the shadow/space of the scrollbar if it's not needed. 