### PR TITLE
fix: remove optimizeLegibility for headers

### DIFF
--- a/src/scss/typography.scss
+++ b/src/scss/typography.scss
@@ -2,14 +2,18 @@
   font-family: var(--nds-font-family);
   text-rendering: geometricPrecision;
 
-  h1,h2,h3,h4 {
+  h1,
+  h2,
+  h3,
+  h4 {
     font-family: var(--nds-header-font);
     color: var(--nds-black);
     font-weight: 700;
-    text-rendering: optimizeLegibility; /* enables Matiere ligatures */
   }
 
-  h1,h2,h3 {
+  h1,
+  h2,
+  h3 {
     margin-top: 0;
     margin-bottom: 0;
   }
@@ -64,11 +68,11 @@
       line-height: 20px;
 
       &.nds-light {
-        font-weight: 600
+        font-weight: 600;
       }
 
       &.nds-lighter {
-        font-weight: 400
+        font-weight: 400;
       }
     }
 
@@ -78,7 +82,7 @@
       font-weight: 600;
 
       &.nds-light {
-        font-weight: 400
+        font-weight: 400;
       }
     }
 
@@ -88,7 +92,7 @@
       font-weight: 600;
 
       &.nds-light {
-        font-weight: 400
+        font-weight: 400;
       }
     }
   }


### PR DESCRIPTION
for the likes of https://github.com/narmi/banking/issues/12097

the only meaningful change is the removal of `text-rendering: optimizeLegibility; /* enables Matiere ligatures */`

According to @hillarypollak , this is what we want to do. 
