### PR TITLE
docs: add button story

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,18 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Button = ({ disabled, type, ...props }) => {
+const Button = ({ disabled, type, children, ...props }) => {
   const className = `nds-button nds-typography ${type}${
     disabled ? " disabled" : ""
   }`;
   return (
     <a className={className} {...props}>
-      <div className="nds-button-content">{props.children}</div>
+      <div className="nds-button-content">{children}</div>
     </a>
   );
 };
 
 Button.propTypes = {
+  /** The children passed to `Button` are rendered as the button label */
+  children: PropTypes.node.isRequired,
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
   /** type of button to render */

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -1,0 +1,14 @@
+import React from "react";
+import Button from "./";
+
+const Template = (args) => <Button {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  children: "Submit",
+};
+
+export default {
+  title: "Components/Button",
+  component: Button,
+};


### PR DESCRIPTION
Adds basic story for button; makes prop types more clear

<img width="1061" alt="Screen Shot 2021-10-28 at 5 43 31 PM" src="https://user-images.githubusercontent.com/231252/139340688-f27e2239-8091-4133-bdeb-1499d5d380d9.png">

