### PR TITLE
fix(Modal): condition showing action row element on if actions are passed in

### DIFF
--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -47,7 +47,7 @@ const Modal = ({
           ""
         )}
         {children}
-        <div className="nds-modal-action-row">{actions}</div>
+        {actions && <div className="nds-modal-action-row">{actions}</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
part of https://github.com/narmi/banking/issues/12334

We shouldn't render container elements if we don't have anything to put in them, and the styling around this container is causing spooky extra space at the bottom of modals