### PR TITLE
fix: remove tooltip from dist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ const Card = require("./Card").default;
 const Dropdown = require("./Dropdown").default;
 const RadioButtons = require("./RadioButtons").default;
 const CheckBox = require("./CheckBox").default;
-const Tooltip = require("./Tooltip").default;
 const components = {
   Input,
   DateInput,
@@ -30,7 +29,6 @@ const components = {
   RadioButtons,
   CheckBox,
   Card,
-  Tooltip,
 };
 
 let styleString = require("global").styles;
@@ -54,5 +52,4 @@ export {
   Card,
   CheckBox,
   Dropdown,
-  Tooltip,
 };


### PR DESCRIPTION
Restores NDS to a working state in `banking` until we can figure out how to support `radix-ui` components in a webpack v3 project