### PR TITLE
build(Tokens): add distribution of color vars for RGBA composition

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "semantic-release": "^18.0.0",
     "style-dictionary": "^3.0.3",
     "style-loader": "^0.23.1",
+    "tinycolor2": "^1.4.2",
     "watch": "^1.0.2",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.8.0",

--- a/tokens/config.js
+++ b/tokens/config.js
@@ -4,13 +4,19 @@
 const path = require("path");
 const StyleDictionary = require("style-dictionary");
 const transforms = require("./util/transforms");
+const filters = require("./util/filters");
 
 //  we call this config from repo root, so __dirname will be root.
 const getBuildPath = (subdir) => `${path.resolve("./dist/tokens")}/${subdir}/`;
 
-// register all custom transforms with style dictionary
+// register all custom transforms
 transforms.forEach((transform) => {
   StyleDictionary.registerTransform(transform);
+});
+
+// register all custom filters
+filters.forEach((filter) => {
+  StyleDictionary.registerFilter(filter);
 });
 
 const config = {
@@ -37,6 +43,26 @@ const config = {
         },
       ],
       options: { outputReferences: true },
+    },
+
+    /**
+     * Custom properties for RGB lists in a CSS file
+     * (only includes colors where rgba composition is permissable)
+     */
+    cssRgbColors: {
+      transforms: [
+        "attribute/cti",
+        "custom/name/rgbList",
+        "custom/value/rgbList",
+      ],
+      buildPath: getBuildPath("css"),
+      files: [
+        {
+          filter: "rgbColorFilter",
+          destination: "rgbColors.css",
+          format: "css/variables",
+        },
+      ],
     },
   },
 };

--- a/tokens/util/filters.js
+++ b/tokens/util/filters.js
@@ -1,0 +1,23 @@
+/**
+ * style-dictionary filters used in config
+ */
+
+const filters = [
+  // filter that passes only the tokens that should be in rgbColor.css dist
+  // includes: color tokens
+  // excludes: denylist colors, brand offset colors, theme colors, text colors
+  {
+    name: "rgbColorFilter",
+    matcher: ({ attributes }) => {
+      const { category, type, item } = attributes;
+      const isColor = category === "color";
+      const isThemeColor = type === "theme";
+      const isOffsetColor = new RegExp(/[0-9]/).test(item);
+      const isDeniedColor = type === "background" && item === "white"; // avoids naming collision with base color white
+
+      return isColor && !isOffsetColor && !isThemeColor && !isDeniedColor;
+    },
+  },
+];
+
+module.exports = filters;

--- a/tokens/util/transforms.js
+++ b/tokens/util/transforms.js
@@ -5,6 +5,8 @@
  * and are registered/referenced in the style dictionary config file.
  */
 
+const tinycolor = require("tinycolor2");
+
 /**
  * Used for filtering tokens in transform `matcher` functions.
  * Checks to see if any of the attribues in `arr` match the given token attribute.
@@ -68,6 +70,17 @@ const nameTransforms = [
       return `bgColor-${item}`;
     },
   },
+  {
+    // custom naming RGB list colors
+    // (color only)
+    name: "custom/name/rgbList",
+    type: "name",
+    matcher: ({ attributes }) => attributes.category === "color",
+    transformer: ({ attributes }) => {
+      const { item } = attributes;
+      return `rgb-${item}`;
+    },
+  },
 ];
 
 /**
@@ -80,6 +93,16 @@ const valueTransforms = [
     type: "value",
     matcher: ({ attributes }) => attributes.type === "alpha",
     transformer: ({ original }) => original.value,
+  },
+  {
+    // transforms a solid color into a list of its RGB components
+    name: "custom/value/rgbList",
+    type: "value",
+    matcher: ({ attributes }) => attributes.category === "color",
+    transformer: ({ original }) => {
+      const { r, g, b } = tinycolor(original.value).toRgb();
+      return `${r}, ${g}, ${b}`;
+    },
   },
 ];
 


### PR DESCRIPTION
fixes #321 

Adds appropriate configs and transforms to build RGB vars to be used in RGBA composition.

### Output in `dist/tokens/css/rgbaColors.css`

```
/**
 * Do not edit directly
 * Generated on Wed, 03 Nov 2021 20:07:43 GMT
 */

:root {
  --rgb-blueGrey: 244, 246, 250;
  --rgb-cloudGrey: 233, 233, 233;
  --rgb-neutralGrey: 249, 249, 249;
  --rgb-smokeGrey: 243, 243, 243;
  --rgb-snowGrey: 251, 251, 251;
  --rgb-scrimLight: 255, 255, 255;
  --rgb-scrimDark: 80, 80, 80;
  --rgb-moss: 0, 101, 83;
  --rgb-pine: 26, 67, 56;
  --rgb-cove: 0, 92, 178;
  --rgb-azul: 0, 62, 160;
  --rgb-pistachio: 181, 233, 149;
  --rgb-cactus: 127, 188, 91;
  --rgb-sand: 220, 193, 162;
  --rgb-black: 51, 51, 51;
  --rgb-grey: 76, 76, 76;
  --rgb-mediumGrey: 140, 140, 140;
  --rgb-lightGrey: 217, 217, 217;
  --rgb-white: 255, 255, 255;
  --rgb-successDark: 55, 179, 116;
  --rgb-successLight: 227, 250, 231;
  --rgb-warnDark: 234, 195, 72;
  --rgb-warnLight: 254, 248, 227;
  --rgb-errorDark: 217, 59, 59;
  --rgb-errorLight: 253, 241, 241;
}
```