### PR TITLE
feat(Tooltip): add  prop to control styling behavior of trigger wrapper

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -7,8 +7,17 @@ import Tippy from "@tippyjs/react";
  *
  * The tooltip will position itself based on the `side` prop, but will
  * automatically reposition to avoid collisions with viewport edges.
+ *
+ * The `children` of this component will be wapped with a focusable `div`.
+ * By default, this `div` shrink wraps content via `inline-flex`, but this styling
+ * can be controlled via the `wrapperDisplay` prop.
  */
-const Tooltip = ({ side = "top", text, children }) => (
+const Tooltip = ({
+  side = "top",
+  text,
+  children,
+  wrapperDisplay = "inline-flex",
+}) => (
   <Tippy
     content={text}
     placement={side}
@@ -16,7 +25,7 @@ const Tooltip = ({ side = "top", text, children }) => (
     maxWidth={320}
     delay={[300, 100]}
   >
-    <div tabIndex="0" style={{ display: "inline-flex" }}>
+    <div tabIndex="0" style={{ display: wrapperDisplay }}>
       {children}
     </div>
   </Tippy>
@@ -29,6 +38,14 @@ Tooltip.propTypes = {
   text: PropTypes.string.isRequired,
   /** Sets prefferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
+  /** CSS `display` value for the element that wraps the Tooltip children */
+  wrapperDisplay: PropTypes.oneOf([
+    "inline-flex",
+    "inline-block",
+    "inline",
+    "block",
+    "flex",
+  ]),
 };
 
 export default Tooltip;


### PR DESCRIPTION
Adds prop to `Tooltip` that allows callers to change the default `display` value of the trigger wrapper.

<img width="582" alt="Screen Shot 2021-11-04 at 11 48 42 AM" src="https://user-images.githubusercontent.com/231252/140369873-58fd6a6c-164a-4e11-9925-fe324a845f95.png">
