### PR TITLE
feat(TextInput): add search input styling

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -20,12 +20,22 @@ const Error = ({ error }) => {
   );
 };
 
-const Input = ({ id, label, icon, disabled, decoration, error, ...props }) => {
+const Input = ({
+  id,
+  label,
+  icon,
+  disabled,
+  decoration,
+  error,
+  search,
+  ...props
+}) => {
   const className = [
     "nds-input",
     disabled ? "disabled" : "",
     props.multiline ? "multiline" : "",
     error ? "error" : "",
+    search ? "search" : "",
   ].join(" ");
 
   return (

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -51,6 +51,10 @@
     }
   }
 
+  &.search .nds-input-box {
+    padding: 3px 0.8em;
+  }
+
   .nds-input-icon {
     display: flex;
     font-size: 1.25em;

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -9,6 +9,7 @@ const TextInput = (props) => {
   const {
     formatter,
     multiline,
+    search,
     defaultValue,
     onChange,
     onBlur,

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -65,6 +65,10 @@ export const AsColorInput = () => {
   );
 };
 
+export const Search = () => {
+  return <TextInput search />;
+};
+
 export default {
   title: "Components/TextInput",
   component: TextInput,


### PR DESCRIPTION
Part of https://github.com/narmi/banking/issues/12513

Nothing particularly interesting, but we apparently want to make search inputs on 40px in height total.

![image](https://user-images.githubusercontent.com/4285085/140396477-f9ed2fff-aef1-41ab-98a7-40885ddacfc3.png)
