### PR TITLE
fix(Input): keep label margin consistent when focused, to avoid undesired shift on focus

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -21,7 +21,7 @@
 
       label {
         color: RGB(var(--nds-primary-color));
-        margin-bottom: -4px;
+        margin-bottom: -3px;
       }
     }
   }


### PR DESCRIPTION
for https://github.com/narmi/banking/issues/12696

The value I altered https://github.com/narmi/design_system/commit/93a69f408a479af8beb2b65f75de220ebe26d89a we actually define in two places, one of when the input is focused and one when it's not. 