### PR TITLE
fix(RadioButtons): properly set line height on label, and unchecked colour on checkbox

### DIFF
--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -8,7 +8,7 @@
     margin-bottom: 12px;
     cursor: pointer;
     font-size: 16px;
-    line-height: 22px;
+    line-height: 1.25;
     font-family: var(--nds-font-family);
     font-weight: 400;
 
@@ -41,7 +41,7 @@
       height: 20px;
       width: 20px;
       background-color: transparent;
-      border: 1px solid RGB(var(--nds-medium-grey));
+      border: 1px solid RGB(var(--nds-lightest-grey));
       border-radius: 50%;
 
       &:after {


### PR DESCRIPTION
for https://github.com/narmi/banking/issues/12696

> On radio buttons, text needs to be centered to button. It’s currently not

symptom occurs because the incorrect line height results in some padding beneath the checkbox 