### PR TITLE
feat(helper-classes): add color helpers for font and backgrounds

### DIFF
--- a/src/helper-classes/background.scss
+++ b/src/helper-classes/background.scss
@@ -1,0 +1,41 @@
+/**
+* Standard background colors
+*/
+@each $bgColor in (blueGrey, cloudGrey, neutralGrey, smokeGrey, snowGrey, white)
+{
+  .bgColor--#{$bgColor} {
+    background-color: var(--bgColor-#{$bgColor});
+  }
+}
+
+/**
+* brand/base background colors
+*/
+@each $color in (moss, pine, cove, azul, pistachio, cactus, sand) {
+  .bgColor--#{$color} {
+    background-color: var(--color-#{$color});
+  }
+}
+
+/**
+* system background colors
+*/
+.bgColor--success {
+  background-color: var(--color-successLight);
+}
+.bgColor--warn {
+  background-color: var(--color-warnLight);
+}
+.bgColor--error {
+  background-color: var(--color-errorLight);
+}
+
+/**
+* Overlay scrims
+*/
+.scrim--light {
+  background-color: var(--bgColor-scrimLight);
+}
+.scrim--dark {
+  background-color: var(--bgColor-scrimLight);
+}

--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -11,6 +11,28 @@
 }
 
 /**
+* brand/base text colors
+*/
+@each $color in (moss, pine, cove, azul, pistachio, cactus, sand, white) {
+  .fontColor--#{$color} {
+    color: var(--color-#{$color});
+  }
+}
+
+/**
+* helpers for setting font color to a standard "system" color
+*/
+.fontColor--success {
+  color: var(--color-successDark);
+}
+.fontColor--warn {
+  color: var(--color-warnDark);
+}
+.fontColor--error {
+  color: var(--color-errorDark);
+}
+
+/**
 * font size helpers
 */
 @each $size in (xs, s, m, l, heading1, heading2, heading3) {
@@ -31,7 +53,7 @@
   }
 }
 .fontFamily--default {
-  font-size: var(--font-family-default) !important;
+  font-family: var(--font-family-default) !important;
 }
 
 /**

--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from "@storybook/addon-docs";
+import { Meta, Story, Preview } from "@storybook/addon-docs";
 
 <Meta title="Style/Helper Classes" />
 
@@ -11,6 +11,28 @@ All helper classes follow a common signature:
 ```css
 .<cssProperty > --<variant>(--<optional variant>);
 ```
+
+#### Example
+
+Each helper class does one, and only one styling task. You can mix and match classes
+to compose styles without needing to write additional CSS. This can be useful for tweaking spacing, font properties, or colors.
+
+<Preview>
+  <Story name="Using Helper Classes">
+    <div className="fontFamily--default padding--all--m bgColor--smokeGrey">
+      <p>
+        Message in a "smokeGrey" padded box with some{" "}
+        <span className="fontWeight--bold fontColor--error">
+          bold error text
+        </span>
+        .
+      </p>
+      <p className="fontSize--xs fontColor--azul margin--bottom--xl">
+        extra small azul text with extra large bottom margin
+      </p>
+    </div>
+  </Story>
+</Preview>
 
 ## Spacing
 
@@ -54,6 +76,17 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `fontColor--primary`   | Sets text color to `var(--font-color-primary)`           |
 | `fontColor--secondary` | Sets text color to `var(--font-color-secondary)`         |
 | `fontColor--hint`      | Sets text color to `var(--font-color-hint)`              |
+| `fontColor--moss`      | Sets text color to `var(--color-moss)`                   |
+| `fontColor--pine`      | Sets text color to `var(--color-pine)`                   |
+| `fontColor--cove`      | Sets text color to `var(--color-cove)`                   |
+| `fontColor--azul`      | Sets text color to `var(--color-azul)`                   |
+| `fontColor--pistachio` | Sets text color to `var(--color-pistachio)`              |
+| `fontColor--cactus`    | Sets text color to `var(--color-cactus)`                 |
+| `fontColor--sand`      | Sets text color to `var(--color-sand)`                   |
+| `fontColor--white`     | Sets text color to `var(--color-white)`                  |
+| `fontColor--success`   | Sets text color to `var(--color-successDark)`            |
+| `fontColor--warn`      | Sets text color to `var(--color-warnDark)`               |
+| `fontColor--error`     | Sets text color to `var(--color-errorDark)`              |
 | `fontColor--default`   | Sets text color to `var(--font-color-default)` (primary) |
 
 ### Size
@@ -85,3 +118,38 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `fontWeight--semibold` | Sets font weight to `var(--font-weight-semibold)`             |
 | `fontWeight--bold`     | Sets font weight to `var(--font-weight-bold)`                 |
 | `fontWeight--default`  | Sets font weight to `var(--font-weight-default)` (normal/400) |
+
+## Color
+
+### Background colors
+
+These classes set the `background-color` property for an element. For a themable background color,
+you must write your own CSS selector that uses `var(--theme-<color>)` .
+
+| Class                  | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `bgColor--blueGrey`    | Sets background color to `var(--bgColor-blueGrey)`    |
+| `bgColor--cloudGrey`   | Sets background color to `var(--bgColor-cloudGrey)`   |
+| `bgColor--neutralGrey` | Sets background color to `var(--bgColor-neutralGrey)` |
+| `bgColor--smokeGrey`   | Sets background color to `var(--bgColor-smokeGrey)`   |
+| `bgColor--snowGrey`    | Sets background color to `var(--bgColor-snowGrey)`    |
+| `bgColor--white`       | Sets background color to `var(--bgColor-white)`       |
+| `bgColor--success`     | Sets background color to `var(--color-successLight)`  |
+| `bgColor--warn`        | Sets background color to `var(--color-warnLight)`     |
+| `bgColor--error`       | Sets background color to `var(--color-errorLight)`    |
+| `bgColor--moss`        | Sets background color to `var(--color-moss)`          |
+| `bgColor--pine`        | Sets background color to `var(--color-pine)`          |
+| `bgColor--cove`        | Sets background color to `var(--color-cove)`          |
+| `bgColor--azul`        | Sets background color to `var(--color-azul)`          |
+| `bgColor--pistachio`   | Sets background color to `var(--color-pistachio)`     |
+| `bgColor--cactus`      | Sets background color to `var(--color-cactus)`        |
+| `bgColor--sand`        | Sets background color to `var(--color-sand)`          |
+
+### Transparent overlay backgrounds
+
+Useful for loading states, modals, and other designs that require a transparent overlay.
+
+| Class          | Description                         |
+| -------------- | ----------------------------------- |
+| `scrim--light` | Sets a light transparent background |
+| `scrim--dark`  | Sets a dark transparent background  |

--- a/src/helper-classes/spacing.scss
+++ b/src/helper-classes/spacing.scss
@@ -31,7 +31,7 @@
 
       // spacing by size for all sides (`<margin|padding>--all--xxs`)
       .#{$property}--all--#{$size} {
-        margin: var(--space-#{$size});
+        #{$property}: var(--space-#{$size});
       }
     }
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -56,5 +56,6 @@ $desktop-big: 1440px;
 // Helper classes
 @import "helper-classes/spacing";
 @import "helper-classes/font";
+@import "helper-classes/background";
 @import "helper-classes/forms";
 @import "helper-classes/scroll";


### PR DESCRIPTION
fixes #397 

- Adds color helper classes for setting font color and background color
- Adds a "how to use helper classes" example story
- fixes two bugs I missed with font and spacing helpers

<img width="922" alt="Screen Shot 2021-11-19 at 7 15 23 PM" src="https://user-images.githubusercontent.com/231252/142706470-acaf85cf-096d-4c21-a101-9a617cccaeb6.png">
<img width="639" alt="Screen Shot 2021-11-19 at 7 15 34 PM" src="https://user-images.githubusercontent.com/231252/142706471-282d2d97-b72f-4542-b2ba-e59e334a9d21.png">
<img width="634" alt="Screen Shot 2021-11-19 at 7 15 45 PM" src="https://user-images.githubusercontent.com/231252/142706472-cda8010a-8a32-430c-b95a-f7a26bf0a506.png">
<img width="601" alt="Screen Shot 2021-11-19 at 7 15 50 PM" src="https://user-images.githubusercontent.com/231252/142706473-d441ea1b-fc68-4a3b-bd0b-9601cd273678.png">

