### PR TITLE
Feat/support as props

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,7 @@ import { NdsStyles } from "./decorators";
 import { Layout } from "./Layouts";
 
 export const parameters = {
+  viewMode: "docs",
   previewTabs: {
     "storybook/docs/panel": { index: -1 },
   },

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import AsElement from "../util/AsElement";
 
 /**
  * builds style object for `Row`
@@ -23,10 +24,14 @@ const _getRowStyle = (alignItems, gapSize) => {
  * Items of `Row` will grow to fit remaining space by default.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
  */
-const Row = ({ alignItems = "top", gapSize = "l", children }) => (
-  <div className="nds-row" style={_getRowStyle(alignItems, gapSize)}>
+const Row = ({ alignItems = "top", gapSize = "l", as = "div", children }) => (
+  <AsElement
+    elementType={as}
+    className="nds-row"
+    style={_getRowStyle(alignItems, gapSize)}
+  >
     {children}
-  </div>
+  </AsElement>
 );
 
 Row.propTypes = {
@@ -36,17 +41,23 @@ Row.propTypes = {
    * Set `gapSize="none"` to remove gaps between all row items.
    */
   gapSize: PropTypes.oneOf(["xxs", "xs", "s", "m", "l", "xl", "none"]),
+  /** Controls vertical alignment of items within the row */
   alignItems: PropTypes.oneOf(["top", "center"]),
+  /** The html element to render as the root node of `Row` */
+  as: PropTypes.oneOf(["div", "ul"]),
 };
 
 /**
  * Child component of `Row`.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
  */
-const RowItem = ({ shrink = false, children }) => (
-  <div className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}>
+const RowItem = ({ shrink = false, as = "div", children }) => (
+  <AsElement
+    elementType={as}
+    className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}
+  >
     {children}
-  </div>
+  </AsElement>
 );
 
 RowItem.propTypes = {
@@ -55,6 +66,8 @@ RowItem.propTypes = {
    * Otherwise, the item will expand to fill remaining space in the row.
    */
   shrink: PropTypes.bool,
+  /** The html element to render as the root node of `Row` */
+  as: PropTypes.oneOf(["div", "li"]),
 };
 
 Row.Item = RowItem;

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -138,6 +138,27 @@ SectionHeaderExample.parameters = {
   },
 };
 
+export const AsProp = () => (
+  <div className="nds-typography">
+    <Row as="ul">
+      <Row.Item as="li">
+        Row item as a <code>li</code> inside a <code>ul</code> Row
+      </Row.Item>
+      <Row.Item as="li">
+        Row item as a <code>li</code> inside a <code>ul</code> Row
+      </Row.Item>
+    </Row>
+  </div>
+);
+AsProp.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `as` prop is used to control the html element type that renders of the root nodes of `Row` and `Row.Item`",
+    },
+  },
+};
+
 export default {
   title: "Components/Row",
   component: Row,

--- a/src/util/AsElement.js
+++ b/src/util/AsElement.js
@@ -6,9 +6,12 @@ import PropTypes from "prop-types";
  * only the elements we want to support in `as` props.
  */
 export const VALID_ELEMENTS = [
+  "span",
+  "div",
   "ul",
   "ol",
   "li",
+  "p",
   "nav",
   "article",
   "section",
@@ -18,6 +21,8 @@ export const VALID_ELEMENTS = [
   "h4",
   "h5",
   "h6",
+  "button",
+  "a",
 ];
 
 /**
@@ -26,25 +31,15 @@ export const VALID_ELEMENTS = [
  *
  * `<Row as="ul"><Row.Item as="li" /></Row>
  *
- * @usage <AsElement elementName="ul">
+ * @usage <AsElement elementName="ul" otherProp="this gets passed through">
  */
-const AsElement = ({
-  elementName = "div",
-  fallbackElement = "div",
-  children,
-  ...rest
-}) => {
-  let Element;
-
-  // fall back to a safe element if an empty element name is given
-  if ([undefined, ""].any((name) => name === elementName)) {
-    Element = fallbackElement;
-  }
+const AsElement = ({ elementType = "div", children, ...rest }) => {
+  let Element = "div"; // always fall back to div if something is wrong
 
   // extra layer of validation; only set the element name to
   // the given `elementName` if it is in our valid elements list
-  if (VALID_ELEMENTS.some((name) => name === elementName)) {
-    Element = elementName;
+  if (VALID_ELEMENTS.includes(elementType)) {
+    Element = elementType;
   }
 
   return <Element {...rest}>{children}</Element>;
@@ -52,9 +47,7 @@ const AsElement = ({
 
 AsElement.propTypes = {
   /** element to render  */
-  elementName: PropTypes.oneOf(VALID_ELEMENTS).isRequired,
-  /** fallback element, in case `elementName` can not be rendered */
-  fallbackElement: PropTypes.oneOf(VALID_ELEMENTS),
+  elementType: PropTypes.oneOf(VALID_ELEMENTS).isRequired,
 };
 
 export default AsElement;

--- a/src/util/asElement.test.js
+++ b/src/util/asElement.test.js
@@ -3,6 +3,17 @@ import { render } from "@testing-library/react";
 import AsElement from "./AsElement";
 
 describe("AsElement", () => {
-  it("renders the ", () => {});
-  it("falls back to fallbackElement when bad elementName is given", () => {});
+  it("renders the given element", () => {
+    const elementType = "p";
+    render(<AsElement elementType={elementType} />);
+    expect(document.querySelector(elementType)).toBeInTheDocument();
+  });
+  it("passes through any additional props", () => {
+    const elementType = "p";
+    const testClass = "color--azul";
+    const { container } = render(
+      <AsElement elementType={elementType} className={testClass} />
+    );
+    expect(document.querySelector(elementType)).toHaveClass(testClass);
+  });
 });


### PR DESCRIPTION
Sometimes we want to offer some control over the HTML element type of the root node a component renders. For example, `Button` would be a bit more useful if we could switch between `button` and `a` elements.

This PR adds support for `as` props that control element type rendering, and adds `as` props to `Row` and `RowItem`, which will be used for the pagination component.

<img width="515" alt="Screen Shot 2021-11-22 at 2 52 35 PM" src="https://user-images.githubusercontent.com/231252/142926835-838348e1-d680-471d-9a31-36251735680a.png">
<img width="733" alt="Screen Shot 2021-11-22 at 2 52 57 PM" src="https://user-images.githubusercontent.com/231252/142926838-edeb03a0-f32e-4a55-88fa-fffdfd014c24.png">

## Reviewing

I recommend starting with the test file for `AsElement` to get an idea of what's going on here


