### PR TITLE
feat(Pagination): add  component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10379,7 +10379,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "resolved": "",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -10394,7 +10394,7 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "resolved": "",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -10404,7 +10404,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -10413,7 +10413,7 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
@@ -10425,13 +10425,13 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -1,0 +1,230 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+import Row from "../Row";
+import { tSUnknownKeyword } from "@babel/types";
+
+const noop = () => {};
+const MAX_VISIBLE_PAGES = 5;
+
+/**
+ * Business logic for pagination; given a total number of pages
+ * and the selected page, returns attributes used to render pagination
+ *
+ * @param {Number} totalPages
+ * @param {Number} selectedPage
+ * @returns {Object} attributes used to render pagination
+ */
+export const _getAttributes = (
+  totalPages,
+  selectedPage = 1,
+  segmentSize = MAX_VISIBLE_PAGES
+) => {
+  // create a list of page segments
+  // each segment is an array of page numbers.
+  const pageSegments = [...new Array(totalPages)]
+    .map((p, i) => i + 1) // [1,2,3,4,5,6,7, ...]
+    .reduce((segments, page, i) => {
+      const segmentIndex = Math.floor(i / segmentSize);
+      if (!segments[segmentIndex]) {
+        segments[segmentIndex] = [];
+      }
+      segments[segmentIndex].push(page);
+      return segments;
+    }, []); // [[1,2,3,4,5], [6,7,8,9,10], ...]
+
+  // show the segment that has the selected page
+  const visiblePages = pageSegments.filter((segment) =>
+    segment.includes(selectedPage)
+  )[0];
+  const selectedIndex = visiblePages.indexOf(selectedPage);
+
+  // show prev/next arrows unless we are in the first or last segment
+  const showPrev = !visiblePages.includes(1);
+  const showNext = !visiblePages.includes(totalPages);
+
+  // only populate first/last pages when they are outside the visible segment
+  const firstPage = !visiblePages.includes(1) && 1;
+  const lastPage = !visiblePages.includes(totalPages) && totalPages;
+
+  return {
+    visiblePages,
+    selectedIndex,
+    firstPage,
+    lastPage,
+    showPrev,
+    showNext,
+  };
+};
+
+/**
+ * Component that allows users to navigate between pages of information.
+ * Your application is responsible for setting the total number of pages and
+ * responding to the `onPageChange` callback.
+ *
+ * The component will handle which page numbers to render, next and previous arrows,
+ * and conditionally rendering first and last pages.
+ *
+ * If your pagination setup expectes a fully controlled component, you may set `defaultSelectedPage` on every `onPageChange` call.
+ */
+const Pagination = ({
+  onPageChange = noop,
+  totalPages = 1,
+  defaultSelectedPage = 1,
+}) => {
+  // no jokers allowed 🤡
+  // - default to first page if default selected page is out of bounds
+  // - enforce minimum of 1 pages
+  if (defaultSelectedPage > totalPages || defaultSelectedPage < 1) {
+    defaultSelectedPage = 1;
+  }
+  if (totalPages < 1) {
+    totalPages = 1;
+  }
+
+  const [selectedPage, setSelectedPage] = useState(defaultSelectedPage);
+  const {
+    visiblePages,
+    selectedIndex,
+    showPrev,
+    showNext,
+    firstPage,
+    lastPage,
+  } = _getAttributes(totalPages, selectedPage);
+
+  const handlePageClick = ({ target }) => {
+    const page = parseInt(target.dataset.page, 10);
+    setSelectedPage(page);
+    onPageChange(page);
+  };
+
+  const handlePrevClick = () => {
+    const newSelectedPage = selectedPage - 1;
+    setSelectedPage(newSelectedPage);
+    onPageChange(newSelectedPage);
+  };
+
+  const handleNextClick = () => {
+    const newSelectedPage = selectedPage + 1;
+    setSelectedPage(newSelectedPage);
+    onPageChange(newSelectedPage);
+  };
+
+  return (
+    <div className="nds-typography nds-pagination">
+      <nav aria-label="pagination">
+        <Row gapSize="xs" alignItems="center">
+          <Row.Item shrink>
+            <span
+              role="button"
+              aria-disabled={!showPrev}
+              aria-label="Previous page"
+              onClick={handlePrevClick}
+              className={cc([
+                "nds-pagination-page",
+                {
+                  "nds-pagination-page--disabled": !showPrev,
+                },
+              ])}
+            >
+              <i role="image" className="narmi-icon-chevron-left"></i>
+            </span>
+          </Row.Item>
+
+          {firstPage && (
+            <Row.Item shrink>
+              <span
+                role="button"
+                aria-label="First page"
+                onClick={handlePageClick}
+                data-page={firstPage}
+                className="nds-pagination-page"
+              >
+                {firstPage.toString()}
+              </span>
+            </Row.Item>
+          )}
+          {firstPage && (
+            <Row.Item shrink>
+              <div className="nds-pagination-ellipsis">&hellip;</div>
+            </Row.Item>
+          )}
+
+          {visiblePages.map((page, i) => (
+            <Row.Item key={page} shrink>
+              <span
+                role="button"
+                className={cc([
+                  "nds-pagination-page",
+                  {
+                    "nds-pagination-page--selected": i === selectedIndex,
+                  },
+                ])}
+                data-page={page}
+                onClick={handlePageClick}
+                aria-label={`Page ${page}`}
+                aria-current={i === selectedIndex && "page"}
+              >
+                {page.toString()}
+              </span>
+            </Row.Item>
+          ))}
+
+          {lastPage && (
+            <Row.Item shrink>
+              <div className="nds-pagination-ellipsis">&hellip;</div>
+            </Row.Item>
+          )}
+          {lastPage && (
+            <Row.Item shrink>
+              <span
+                role="button"
+                aria-label="Last page"
+                onClick={handlePageClick}
+                data-page={lastPage}
+                className="nds-pagination-page"
+              >
+                {lastPage.toString()}
+              </span>
+            </Row.Item>
+          )}
+
+          <Row.Item shrink>
+            <span
+              role="button"
+              aria-disabled={!showNext}
+              aria-label="Next page"
+              onClick={handleNextClick}
+              className={cc([
+                "nds-pagination-page",
+                {
+                  "nds-pagination-page--disabled": !showNext,
+                },
+              ])}
+            >
+              <i role="image" className="narmi-icon-chevron-right"></i>
+            </span>
+          </Row.Item>
+        </Row>
+      </nav>
+    </div>
+  );
+};
+
+Pagination.propTypes = {
+  /** Total number of pages */
+  totalPages: PropTypes.number.isRequired,
+  /**
+   * Default selected page by page number.
+   */
+  defaultSelectedPage: PropTypes.number,
+  /**
+   * Callback invoked when user selects a new page via page numbers or
+   * previous/next arrows.
+   *
+   * Invoked with selected page number as the argument.
+   */
+  onPageChange: PropTypes.func,
+};
+
+export default Pagination;

--- a/src/Pagination/index.scss
+++ b/src/Pagination/index.scss
@@ -1,0 +1,53 @@
+.nds-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--theme-primary);
+
+  ul {
+    list-style-type: none;
+  }
+  ul,
+  li {
+    text-indent: 0;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.nds-pagination-page,
+.nds-pagination-ellipsis {
+  user-select: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 28px;
+  width: 28px;
+  border-radius: 50%;
+}
+
+.nds-pagination-page {
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--bgColor-smokeGrey);
+  }
+
+  &--selected {
+    background-color: var(--theme-primary) !important;
+    color: var(--color-white);
+  }
+
+  &--disabled {
+    pointer-events: none;
+    cursor: none;
+    color: var(--font-color-hint);
+    background-color: transparent !important;
+  }
+}
+
+.nds-pagination-ellipsis {
+  transform: translateY(-5px);
+  color: var(--fontColor-tertiary);
+  font-weight: var(--fontWeight-semibold);
+}

--- a/src/Pagination/index.stories.js
+++ b/src/Pagination/index.stories.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Pagination from "./";
+
+const Template = (args) => <Pagination {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  totalPages: 40,
+  defaultSelectedPage: 3,
+};
+
+export default {
+  title: "Components/Pagination",
+  component: Pagination,
+};

--- a/src/Pagination/index.test.js
+++ b/src/Pagination/index.test.js
@@ -1,0 +1,158 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Pagination, { _getAttributes } from "./";
+
+const CLASS_SELECTED = "nds-pagination-page--selected";
+
+describe("Pagination", () => {
+  describe("getAttributes", () => {
+    it("shows pages 1-5 for 5 total pages", () => {
+      const { visiblePages } = _getAttributes(5);
+      expect(visiblePages).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("shows pages 6-10 when 8 of 10 is selected", () => {
+      const { visiblePages } = _getAttributes(10, 8);
+      expect(visiblePages).toEqual([6, 7, 8, 9, 10]);
+    });
+
+    it("does NOT show previous arrow when rendering first 5 pages", () => {
+      const { showPrev } = _getAttributes(10);
+      expect(showPrev).toBeFalsy();
+    });
+
+    it("shows previous arrow when page 6 or above is selected", () => {
+      const { showPrev } = _getAttributes(10, 6);
+      expect(showPrev).toBeTruthy();
+    });
+
+    it("shows next arrow when total is higher than highest visible page", () => {
+      const { showNext } = _getAttributes(10, 1);
+      expect(showNext).toBeTruthy();
+    });
+
+    it("does NOT show next arrow when last page is visible", () => {
+      const { showNext } = _getAttributes(10, 9);
+      expect(showNext).toBeFalsy();
+    });
+
+    it("shows last page when 2 is selected of 20", () => {
+      const total = 20;
+      const { lastPage } = _getAttributes(total, 2);
+      expect(lastPage).toBe(total);
+    });
+
+    it("does NOT show last page when 18 is selected of 20", () => {
+      const total = 20;
+      const { lastPage } = _getAttributes(total, 18);
+      expect(lastPage).toBeFalsy();
+    });
+
+    it("shows first page when 8 is selected of 20", () => {
+      const { firstPage } = _getAttributes(20, 8);
+      expect(firstPage).toBe(1);
+    });
+
+    it("does NOT show first page when 4 is selected of 20", () => {
+      const { firstPage } = _getAttributes(20, 4);
+      expect(firstPage).toBeFalsy();
+    });
+  });
+
+  describe("Component render and interaction", () => {
+    it("Clicking on page 3 changes selected page", () => {
+      const handlePageChange = jest.fn();
+      render(<Pagination totalPages={20} onPageChange={handlePageChange} />);
+      const page3 = screen.getByLabelText("Page 3");
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(page3).not.toHaveClass(CLASS_SELECTED);
+
+      fireEvent.click(page3);
+
+      expect(handlePageChange).toHaveBeenCalledWith(3);
+      expect(page3).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Clicking on next arrow changes selected page", () => {
+      const handlePageChange = jest.fn();
+      render(<Pagination totalPages={20} onPageChange={handlePageChange} />);
+      const next = screen.getByLabelText("Next page");
+      const page2 = screen.getByLabelText("Page 2");
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(page2).not.toHaveClass(CLASS_SELECTED);
+
+      fireEvent.click(next);
+
+      expect(handlePageChange).toHaveBeenCalledWith(2);
+      expect(page2).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Clicking on previous arrow changes selected page", () => {
+      const handlePageChange = jest.fn();
+      render(
+        <Pagination
+          totalPages={20}
+          onPageChange={handlePageChange}
+          defaultSelectedPage={10}
+        />
+      );
+      const prev = screen.getByLabelText("Previous page");
+      const page9 = screen.getByLabelText("Page 9");
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(page9).not.toHaveClass(CLASS_SELECTED);
+
+      fireEvent.click(prev);
+
+      expect(handlePageChange).toHaveBeenCalledWith(9);
+      expect(page9).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Clicking on first page changes selected page", () => {
+      const handlePageChange = jest.fn();
+      render(
+        <Pagination
+          totalPages={20}
+          onPageChange={handlePageChange}
+          defaultSelectedPage={10}
+        />
+      );
+      const first = screen.getByLabelText("First page");
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.queryByLabelText("Page 1")).not.toBeInTheDocument();
+
+      fireEvent.click(first);
+
+      expect(handlePageChange).toHaveBeenCalledWith(1);
+      const page1 = screen.queryByLabelText("Page 1");
+      expect(page1).toBeInTheDocument();
+      expect(page1).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Clicking on last page changes selected page", () => {
+      const handlePageChange = jest.fn();
+      const total = 20;
+      render(
+        <Pagination
+          totalPages={total}
+          onPageChange={handlePageChange}
+          defaultSelectedPage={4}
+        />
+      );
+      const last = screen.getByLabelText("Last page");
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.queryByLabelText(`Page ${total}`)).not.toBeInTheDocument();
+
+      fireEvent.click(last);
+
+      expect(handlePageChange).toHaveBeenCalledWith(total);
+      const page20 = screen.queryByLabelText(`Page ${total}`);
+      expect(page20).toBeInTheDocument();
+      expect(page20).toHaveClass(CLASS_SELECTED);
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const Tooltip = require("./Tooltip").default;
 const LoadingShim = require("./LoadingShim").default;
 const Dialog = require("./Dialog").default;
 const Row = require("./Row").default;
+const Pagination = require("./Pagination").default;
 const components = {
   Input,
   DateInput,
@@ -37,6 +38,7 @@ const components = {
   LoadingShim,
   Dialog,
   Row,
+  Pagination,
 };
 
 let styleString = require("global").styles;
@@ -64,4 +66,5 @@ export {
   LoadingShim,
   Dialog,
   Row,
+  Pagination,
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -53,6 +53,7 @@ $desktop-big: 1440px;
 @import "Dropdown/";
 @import "Tooltip/";
 @import "Row/";
+@import "Pagination/";
 
 // Helper classes
 @import "helper-classes/spacing";


### PR DESCRIPTION
fixes #345 

Adds `Pagination` component, stories, and tests.

<img width="1053" alt="Screen Shot 2021-11-23 at 9 52 00 AM" src="https://user-images.githubusercontent.com/231252/143046853-335de923-2313-46a1-90e5-9b6689bdcb2b.png">

<img width="1033" alt="Screen Shot 2021-11-22 at 8 12 31 PM" src="https://user-images.githubusercontent.com/231252/143046704-3c9ebd38-734c-461d-ac95-0b9da497e336.png">

### As a drop-in replacement in azul

```jsx
// PageNavigation.jsx in azul
const PageNavigation = ({ pagination }) => (
  <Pagination
    totalPages={pagination.getNumPages()}
    defaultSelectedPage={pagination.page}
    onPageChange={pagination.navigatePage} // page number is passed as the arg
  />
);
```
