### PR TITLE
style(Tooltip): positioning engine change; styling updates

### DIFF
--- a/jest-testing-library-setup.js
+++ b/jest-testing-library-setup.js
@@ -1,2 +1,0 @@
-// extend jest's `expect` matchers
-import "@testing-library/jest-dom";

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "jsx", "vue"],
   moduleDirectories: ["node_modules", "src"],
   testEnvironment: "jest-environment-jsdom",
-  setupFilesAfterEnv: ["./jest-testing-library-setup.js"],
+  setupFilesAfterEnv: ["./setupTests.js"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5172,7 +5172,8 @@
     "@popperjs/core": {
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
+      "dev": true
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -10516,14 +10517,6 @@
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"
-      }
-    },
-    "@tippyjs/react": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
-      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
-      "requires": {
-        "tippy.js": "^6.3.1"
       }
     },
     "@tootallnate/once": {
@@ -26737,6 +26730,14 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "react-laag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-laag/-/react-laag-2.0.3.tgz",
+      "integrity": "sha512-f3LYHu6kOU+Ii63/ZkzLDobGLf2Q4EYjIA/TUHmaQmBv5use09ClPy5tEgXazkTnp/PC1Sivb+wr0+q8mv9ITQ==",
+      "requires": {
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -29468,19 +29469,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
       "dev": true
-    },
-    "tippy.js": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.3.tgz",
-      "integrity": "sha512-Y3bLm4p33a8TJ49idtxfe6YYxcrmGKkOosry5clshy+wue622nhOxpf+KDfOQmif8etqsoIYFfVyVyXKQDqWVw==",
-      "requires": {
-        "@popperjs/core": "^2.9.0"
-      }
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
   "author": "@fkotsian, @reshav-abraham",
   "license": "SEE LICENSE IN LICENSE.md",
   "dependencies": {
-    "@tippyjs/react": "^4.2.6",
     "classcat": "^5.0.3",
     "flatpickr": "^4.6.9",
     "moment": "^2.29.1",
-    "raf-schd": "^4.0.3"
+    "raf-schd": "^4.0.3",
+    "react-laag": "^2.0.3"
   },
   "repository": {
     "type": "git",

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,9 @@
+// extend jest's `expect` matchers
+import "@testing-library/jest-dom";
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+window.ResizeObserver = MockResizeObserver;

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -1,17 +1,14 @@
 .nds-tooltip {
-  border-radius: 8px;
-  background-color: #333;
-  color: #fff;
-  font-size: 16px;
-  font-family: var(--nds-font-family);
-  box-shadow: 0px 6px 12px 0px rgba(0, 0, 0, 0.2);
+  border-radius: var(--border-radius-default);
+  padding: var(--space-s) var(--space-m);
+  font-size: var(--font-size-s);
+  background-color: var(--color-black);
+  color: var(--color-white);
+  text-align: center;
+  z-index: 999;
 
-  .tippy-content {
-    text-align: center;
-    padding: 16px;
-  }
-
-  .tippy-arrow {
-    background-color: #333;
+  // The arrow SVG path
+  path {
+    fill: var(--color-black);
   }
 }

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -46,6 +46,7 @@ export default {
         style={{
           height: "200px",
           display: "flex",
+          flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
         }}

--- a/src/index.scss
+++ b/src/index.scss
@@ -25,9 +25,6 @@ $desktop-big: 1440px;
   --subdued-5-opacity: var(--alpha-5);
 }
 
-// vendor styles
-@import "~tippy.js/dist/tippy.css";
-
 // webfont
 @import "fonts/fonts.css";
 


### PR DESCRIPTION
fixes #333 

- 🛠 replaces `tippyjs` positioning engine with `react-laag` headless popover hooks
- 🗜 reduces bundle size by 40kb
- 🧑‍🎨 address design feeback (adjust padding and font size)

This paves the way for building other popovers based components, like the generic `Popover`, `Menu`, `Listbox`, and `Combobox`