### PR TITLE
feat(Popover): add generic Popover component

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,0 +1,131 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { useLayer } from "react-laag";
+
+/**
+ * Generic Popover component. Renders a floating element that can contain any content,
+ * positioned relatively to its triggering element.
+ *
+ * This Popover only appears on "click" (focus + activate or mouse click) interactions.
+ * The Escape key and clicking outside of the Popover will dismiss it.
+ * For a hover-based informative popover, use `Tooltip`.
+ *
+ * The popover will position itself based on the `side` prop, but will
+ * automatically reposition to avoid collisions with viewport edges.
+ */
+const Popover = ({
+  side = "bottom",
+  content,
+  children,
+  wrapperDisplay = "inline-flex",
+  offset = 2,
+  disableAutoPlacement = false,
+  matchTriggerWidth = false,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const closePopover = () => {
+    setIsOpen(false);
+  };
+
+  const togglePopover = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleKeyDown = ({ key }) => {
+    switch (key) {
+      case "Escape":
+        setIsOpen(false);
+        break;
+      case "Enter":
+        setIsOpen(true);
+        break;
+    }
+  };
+
+  const { renderLayer, triggerProps, triggerBounds, layerProps } = useLayer({
+    isOpen,
+    onOutsideClick: closePopover,
+    onDisappear: closePopover,
+    auto: !disableAutoPlacement,
+    placement: `${side}-center`,
+    preferX: "left",
+    preferY: "bottom",
+    container: document.body,
+    triggerOffset: offset,
+  });
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  let layerStyle = layerProps.style;
+  if (triggerBounds && matchTriggerWidth) {
+    layerStyle = {
+      width: triggerBounds.width,
+      ...layerProps.style,
+    };
+  }
+
+  return (
+    <>
+      <div
+        {...triggerProps}
+        style={{ display: wrapperDisplay }}
+        onClick={togglePopover}
+        onKeyDown={handleKeyDown}
+        tabIndex="0"
+        data-testid="nds-popover-trigger"
+        aria-haspopup="true"
+        aria-expanded={isOpen.toString()}
+      >
+        {children}
+      </div>
+      {renderLayer(
+        <>
+          {isOpen && (
+            <div
+              {...layerProps}
+              className="nds-typography nds-popover round--all bgColor--white"
+              style={layerStyle}
+            >
+              {content}
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+Popover.propTypes = {
+  /** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
+  children: PropTypes.node.isRequired,
+  /** Content of popover */
+  content: PropTypes.node.isRequired,
+  /** Sets prefferred side of the trigger the tooltip should appear */
+  side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
+  /** CSS `display` value for the element that wraps the Tooltip children */
+  wrapperDisplay: PropTypes.oneOf([
+    "inline-flex",
+    "inline-block",
+    "inline",
+    "block",
+    "flex",
+  ]),
+  /** Distance of Popover from trigger element in number of pixels */
+  offset: PropTypes.number,
+  /** When `true`, the Popover container will match the width of its triggering element */
+  matchTriggerWidth: PropTypes.bool,
+  /**
+   * By default, the Popover will automatically reposition itself to avoid viewport edges.
+   * Setting this prop to `true` will disable this behavior so that the Popover will
+   * always be placed on the given `side` prop.
+   */
+  disableAutoPlacement: PropTypes.bool,
+};
+
+export default Popover;

--- a/src/Popover/index.scss
+++ b/src/Popover/index.scss
@@ -1,0 +1,4 @@
+.nds-popover {
+  z-index: 999;
+  box-shadow: var(--elevation-middle);
+}

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+import Popover from "./";
+import Button from "../Button";
+import TextInput from "../TextInput";
+
+const Template = (args) => <Popover {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  content: <div className="padding--all--m">📦 Any content</div>,
+  children: <Button type="secondary">Click to show Popover</Button>,
+};
+Overview.argTypes = {
+  content: { control: false },
+};
+
+export default {
+  title: "Components/Popover",
+  component: Popover,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          height: "200px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/Popover/index.test.js
+++ b/src/Popover/index.test.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Popover from "./";
+
+const TRIGGER_TEXT = "Toggle Popover";
+const CONTENT_TEXT = "Popover content";
+
+const renderPopover = () => {
+  render(
+    <Popover content={<p>{CONTENT_TEXT}</p>}>
+      <button>{TRIGGER_TEXT}</button>
+    </Popover>
+  );
+};
+
+const getTrigger = () => screen.getByTestId("nds-popover-trigger");
+
+describe("Popover", () => {
+  it("renders children without errors", () => {
+    renderPopover();
+    const children = screen.queryByText(TRIGGER_TEXT, { selector: "button" });
+    expect(children).toBeTruthy();
+  });
+
+  it("shows popover on click", () => {
+    renderPopover();
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+  });
+
+  it("shows popover on focus + enter", () => {
+    renderPopover();
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+    fireEvent.focus(trigger);
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+  });
+
+  it("dismisses popover on outside click", () => {
+    renderPopover();
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+    fireEvent.click(document.body);
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("dismisses popover on escape key", () => {
+    renderPopover();
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+    fireEvent.click(trigger);
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const Dialog = require("./Dialog").default;
 const Row = require("./Row").default;
 const Pagination = require("./Pagination").default;
 const SeparatorList = require("./SeparatorList").default;
+const Popover = require("./Popover").default;
 const components = {
   Input,
   DateInput,
@@ -41,6 +42,7 @@ const components = {
   Row,
   Pagination,
   SeparatorList,
+  Popover,
 };
 
 let styleString = require("global").styles;
@@ -70,4 +72,5 @@ export {
   Row,
   Pagination,
   SeparatorList,
+  Popover,
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -52,6 +52,7 @@ $desktop-big: 1440px;
 @import "Row/";
 @import "Pagination/";
 @import "SeparatorList/";
+@import "Popover/";
 
 // Helper classes
 @import "helper-classes/spacing";


### PR DESCRIPTION
fixes #368 

Adds a generic popover that can accept any arbitrary content.

<img width="333" alt="Screen Shot 2021-11-29 at 3 37 15 PM" src="https://user-images.githubusercontent.com/231252/143939429-0476b457-91db-47d4-81b0-9cb2c33f0909.png">
<img width="1044" alt="Screen Shot 2021-11-29 at 3 37 23 PM" src="https://user-images.githubusercontent.com/231252/143939433-4d8fbc38-3192-48f1-9c53-27928bc6030a.png">
