### PR TITLE
Docs/410 suppress useless props controls

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,9 +12,11 @@ export const parameters = {
   docs: {
     page: () => <Layout />,
   },
+  argTypes: {
+    children: { control: false }, // never show a control for `children` prop
+  },
   controls: {
     sort: "requiredFirst",
-    //exclude: ["children"],
     matchers: {
       color: /(background|color)$/i,
     },

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -51,6 +51,9 @@ Overview.args = {
   onUserDismiss: () => {},
   width: "500px",
 };
+Overview.argTypes = {
+  footer: { control: false }, // hide control for `footer` prop
+};
 
 export const UsingWithState = InteractiveTemplate.bind({});
 UsingWithState.args = {


### PR DESCRIPTION
Some component props accept a `PropType.node`, where any arbitrary JSX is expected. The controls storybook generates for these are really awful and take up a lot of room. This PR disables controls for those props.

- globally disables controls for `children` prop
- disables `Dialog` `footer` prop controls

### Before
<img width="789" alt="Screen Shot 2021-11-29 at 3 52 34 PM" src="https://user-images.githubusercontent.com/231252/143941598-98acbe27-8418-44e6-a5b3-fd9c544af00e.png">

### After
<img width="1064" alt="Screen Shot 2021-11-29 at 3 51 47 PM" src="https://user-images.githubusercontent.com/231252/143941610-dc7df851-509d-4e85-b027-e4084283ed31.png">

