### PR TITLE
🗜 refactor(moment): remove momentjs from project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22435,11 +22435,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "dependencies": {
     "classcat": "^5.0.3",
     "flatpickr": "^4.6.9",
-    "moment": "^2.29.1",
     "raf-schd": "^4.0.3",
     "react-laag": "^2.0.3"
   },

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 import Input from "../Input";
 import { english } from "flatpickr/dist/l10n/default";
 import flatpickr from "flatpickr";
-import moment from "moment";
 import "flatpickr/dist/themes/airbnb.css";
+
+const noop = () => {};
 
 /**
  * Single day picker.
@@ -17,6 +18,7 @@ const DateInput = ({
   altInput,
   altFormat,
   defaultDate,
+  onChange: onChangeProp = noop,
   ...props
 }) => {
   const input = useRef();
@@ -35,8 +37,15 @@ const DateInput = ({
     altFormat,
     disable: disableDates,
     defaultDate,
-    onChange: (flatpickrVal) =>
-      props.onChange(moment(flatpickrVal[0]).format("YYYY-MM-DD")),
+    onChange: (flatpickrVal) => {
+      const selectedDate = new Date(flatpickrVal);
+      // 🇨🇦 Our neighbors to the north have adopted ISO 8601.
+      // localizing to en-CA produces the expected result of YYYY-MM-DD
+      const formattedDate = new Intl.DateTimeFormat("en-CA").format(
+        selectedDate
+      );
+      onChangeProp(formattedDate);
+    },
   };
 
   useEffect(() => {


### PR DESCRIPTION
fixes #308 

### 🎉 Reduces NDS dist size by nearly half

`dist/index.js` before: `692kb`
`dist/index.js` after: `376kb`

I thought we might find some small wins by excluding translations in flatpickr, but removing `moment` lead to a far bigger win.

This PR removes `moment` and uses native date formatting via `Intl`, [supported in all of our target browsers](https://caniuse.com/?search=datetimeformat).

The `onChange` callback will be invoked with the exact same argument, a string in `YYYY-MM-DD` format