### PR TITLE
fix(Pagination): use recommended markup for a11y

### DIFF
--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -113,8 +113,8 @@ const Pagination = ({
   return (
     <div className="nds-typography nds-pagination">
       <nav aria-label="pagination">
-        <Row gapSize="xs" alignItems="center">
-          <Row.Item shrink>
+        <Row gapSize="xs" alignItems="center" as="ul">
+          <Row.Item as="li" shrink>
             <span
               role="button"
               aria-disabled={!showPrev}
@@ -132,7 +132,7 @@ const Pagination = ({
           </Row.Item>
 
           {firstPage && (
-            <Row.Item shrink>
+            <Row.Item as="li" shrink>
               <span
                 role="button"
                 aria-label="First page"
@@ -145,13 +145,13 @@ const Pagination = ({
             </Row.Item>
           )}
           {firstPage && (
-            <Row.Item shrink>
+            <Row.Item as="li" shrink>
               <div className="nds-pagination-ellipsis">&hellip;</div>
             </Row.Item>
           )}
 
           {visiblePages.map((page, i) => (
-            <Row.Item key={page} shrink>
+            <Row.Item as="li" key={page} shrink>
               <span
                 role="button"
                 className={cc([
@@ -171,12 +171,12 @@ const Pagination = ({
           ))}
 
           {lastPage && (
-            <Row.Item shrink>
+            <Row.Item as="li" shrink>
               <div className="nds-pagination-ellipsis">&hellip;</div>
             </Row.Item>
           )}
           {lastPage && (
-            <Row.Item shrink>
+            <Row.Item as="li" shrink>
               <span
                 role="button"
                 aria-label="Last page"
@@ -189,7 +189,7 @@ const Pagination = ({
             </Row.Item>
           )}
 
-          <Row.Item shrink>
+          <Row.Item as="li" shrink>
             <span
               role="button"
               aria-disabled={!showNext}


### PR DESCRIPTION
fixes #405 

Use recommended elements for accessible pagination via `as` props on `Row` and `Row.Item`.
<img width="540" alt="Screen Shot 2021-11-29 at 7 22 28 PM" src="https://user-images.githubusercontent.com/231252/143963258-3d4da291-e275-4ad8-82fd-08d5b72c7e97.png">

