### PR TITLE
style(Button): fix hover states; add 'label' and 'as' props

### DIFF
--- a/.storybook/Layouts.jsx
+++ b/.storybook/Layouts.jsx
@@ -20,8 +20,8 @@ export const Layout = () => (
   <>
     <Title />
     <Description />
-    <Primary />
     <ImportCopy />
+    <Primary />
     <ArgsTable story={PRIMARY_STORY} />
     <Stories />
   </>
@@ -34,8 +34,8 @@ export const Layout = () => (
 export const DialogLayout = () => (
   <>
     <Title />
-    <Description />
     <ImportCopy />
+    <Description />
     <ArgsTable story={PRIMARY_STORY} />
     <Stories />
   </>

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,31 +1,70 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import AsElement from "../util/AsElement";
 
-const Button = ({ disabled, type, children, className, ...props }) => (
-  <a
-    {...props}
-    className={cc([
-      "nds-typography",
-      "nds-button",
-      `nds-button--${type}`,
-      {
-        "nds-button--disabled": disabled,
-      },
-      className,
-    ])}
-  >
-    <div className="nds-button-content">{children}</div>
-  </a>
-);
+/**
+ * Narmi style action buttons.
+ *
+ * Button renders as an `a` element by default, but can render as a `button` element
+ * via the `as` prop.
+ *
+ * This component supports rest props; any additional props on button will be
+ * passed through to the root node of `Button`.
+ */
+const Button = ({
+  disabled = false,
+  type = "primary",
+  children,
+  label,
+  className,
+  onClick = () => {},
+  as = "a",
+  ...otherProps
+}) => {
+  let buttonLabel = label;
+  if (!buttonLabel) {
+    buttonLabel = children;
+  }
+
+  // set disabled attribute if this is a `button` element
+  if (as === "button" && disabled) {
+    otherProps.disabled = true;
+  }
+
+  return (
+    <AsElement
+      role="button"
+      elementType={as}
+      onClick={onClick}
+      {...otherProps}
+      className={cc([
+        "nds-typography",
+        "nds-button",
+        `nds-button--${type}`,
+        {
+          resetButton: as === "button",
+          "nds-button--disabled": disabled,
+        },
+        className,
+      ])}
+    >
+      <div className="nds-button-content">{buttonLabel}</div>
+    </AsElement>
+  );
+};
 
 Button.propTypes = {
-  /** The children passed to `Button` are rendered as the button label */
-  children: PropTypes.node.isRequired,
+  /** The html element to render as the root node of `Button` */
+  as: PropTypes.oneOf(["a", "button"]),
+  /** Renders the button label */
+  label: PropTypes.string,
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
   /** type of button to render */
   type: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
+  /** Click callback, with event object passed as argument */
+  onClick: PropTypes.func,
   /**
    * ️**⚠️ DEPRECATED**
    *
@@ -34,11 +73,13 @@ Button.propTypes = {
    * Please use the `type` prop to determine the button style instead.
    */
   className: PropTypes.string,
-};
-
-Button.defaultProps = {
-  disabled: false,
-  type: "primary",
+  /**
+   * **⚠️ DEPRECATED**
+   *
+   * Passing children to render the button label will be removed
+   * in a future release. Use the `label` prop instead.
+   */
+  children: PropTypes.node,
 };
 
 export default Button;

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -1,4 +1,5 @@
-.nds-button {
+.nds-button,
+.nds-button.resetButton {
   box-sizing: border-box;
   display: inline-flex;
   position: relative;
@@ -9,65 +10,49 @@
   text-align: center;
   justify-content: center;
   align-items: center;
-  padding: 0 32px;
   min-height: 40px;
+  border-radius: 20px;
 
   /* mobile buttons have slightly taller padding for ease of tapping */
   @media (max-width: $mobile_size) {
     min-height: 48px;
   }
 
-  &::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border-radius: 24px;
-  }
-
   .nds-button-content {
-    position: relative;
-    height: 100%;
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    white-space: nowrap;
-  }
-
-  &:hover::before {
-    filter: brightness(80%);
+    margin: var(--space-xs) 32px;
+    max-width: 240px;
   }
 }
 
 .nds-button--primary {
   color: var(--color-white);
-  &::before {
-    /* TODO: replace with `--theme` var when banking theming is ready */
-    background-color: RGB(var(--nds-primary-color));
+  background-color: var(--theme-primary);
+
+  &:hover {
+    filter: opacity(80%);
   }
 }
 
-.nds-button--secondary {
-  /* TODO: replace with `--theme` var when banking theming is ready */
-  color: RGB(var(--nds-primary-color));
-  &::before {
-    /* TODO: replace with `--theme` var when banking theming is ready */
-    border: var(--border-size-s) solid RGB(var(--nds-primary-color));
+.nds-button--secondary,
+.nds-button--secondary.resetButton {
+  color: var(--theme-primary);
+  background-color: var(--color-white);
+  border: var(--border-size-s) solid var(--theme-primary);
+
+  &:hover {
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
   }
 }
 
-.nds-button--menu {
+.nds-button--menu,
+.nds-button--menu.resetButton {
   text-align: left;
-  color: RGB(var(--nds-black));
-  padding: 10px 0;
+  color: var(--font-color-primary);
   display: block;
   font-size: var(--font-size-l);
 
-  &::before {
-    display: none;
+  .nds-button-content {
+    margin: 10px 0;
   }
 
   @media (min-width: $desktop-small) {
@@ -78,26 +63,34 @@
   }
 }
 
-.nds-button--plain {
-  color: RGB(var(--nds-primary-color));
+.nds-button--plain,
+.nds-button--plain.resetButton {
+  color: var(--theme-primary);
   font-weight: var(--font-weight-semibold);
-  padding: var(--space-s);
+
+  .nds-button-content {
+    margin: var(--space-s);
+  }
 
   &:hover {
     text-decoration: underline;
-    color: RGB(var(--nds-primary-color));
-  }
-
-  &::before {
-    display: none;
   }
 }
 
 .nds-button--disabled {
   pointer-events: none;
   color: var(--color-white);
-  &::before {
+
+  &.nds-button--menu,
+  &.nds-button--plain {
+    color: var(--font-color-hint);
+  }
+  &.nds-button--primary {
     background-color: var(--color-lightGrey);
+  }
+  &.nds-button--secondary {
+    color: var(--color-lightGrey);
+    border-color: var(--color-lightGrey);
   }
 }
 

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -5,10 +5,13 @@ const Template = (args) => <Button {...args} />;
 
 export const Overview = Template.bind({});
 Overview.args = {
-  children: "Submit",
+  label: "Submit",
 };
 
 export default {
   title: "Components/Button",
   component: Button,
+  argTypes: {
+    onClick: { action: "clicked" },
+  },
 };


### PR DESCRIPTION
fixes: #414 

Addresses feedback from design and cleans some things up.

- enables rendering Button as a `button` element via `as` prop
- refactors button layout to accommodate both `button` and `a` elements
- sets a max width for button content; allows content to wrap within button
- add explicit props for `label`, `onClick`, and `as`