### PR TITLE
docs: add intro page and sort sidebar sections

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,6 +21,11 @@ export const parameters = {
       color: /(background|color)$/i,
     },
   },
+  options: {
+    storySort: {
+      order: ["Introduction", "Design Tokens", "Style", "Components"],
+    },
+  },
 };
 
 export const decorators = [NdsStyles];

--- a/.storybook/story-styles.css
+++ b/.storybook/story-styles.css
@@ -35,6 +35,9 @@ code {
 .sbdocs-h1 {
   padding-bottom: 1em !important;
 }
+#welcome-to-narmi-design-system {
+  padding-bottom: 0 !important; /* hacky override for welcome page h1 */
+}
 
 .docblock-source {
   margin: 24px 0;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Narmi Design System (NDS)
 
-⚡ Build your own experiences with the [Narmi platform](https://www.narmi.com/developers/developer-portal)!
+⚡ Build your own experiences on the [Narmi platform](https://www.narmi.com/developers/developer-portal)!
 
 This design system provides low level utilities and UI components for building
 custom experiences in combination with the [Narmi API](https://www.narmi.com/developers/developer-portal#api).

--- a/src/index.stories.mdx
+++ b/src/index.stories.mdx
@@ -1,0 +1,37 @@
+import { Meta } from "@storybook/addon-docs";
+import { LinkTo } from "@storybook/addon-links/react";
+
+<Meta title="Introduction/Welcome" />
+
+[![npm](https://img.shields.io/npm/v/@narmi/design_system.svg?style=flat&color=blue)](http://www.npmjs.com/package/@narmi/design_system)
+
+# Welcome to Narmi Design System
+
+⚡ Build your own experiences on the [Narmi platform](https://www.narmi.com/developers/developer-portal)!
+
+This framework provides low level utilities and UI components for building
+custom experiences in combination with the [Narmi API](https://www.narmi.com/developers/developer-portal#api).
+
+<hr style={{ borderWidth: "0", margin: "2rem 0" }} />
+
+## Design Tokens
+
+This framework uses Design Tokens to store standard values for spacing, colors, typography, and more.
+These values are available as CSS custom properties provided by the `@narmi/design_system` stylesheet.
+
+## Style
+
+The Narmi Design System stylesheet also provides a set of global CSS classes that can be used for
+typesetting, displaying icons, and adjusting other style properties. All CSS classes provided by this
+framework apply standard values defined by Design Tokens.
+
+## Components
+
+UI Components are currently offered as React (Web) components. Direct control over styling
+is limited by design, but [theming is supported](?path=/docs/design-tokens-color--theme).
+
+## More Resources
+
+- [Full Design Guidelines of Narmi Design System](https://zeroheight.com/8ac87d4ba/p/446c38-narmi-design-system-nds)
+- [View on Github](https://github.com/narmi/design_system)
+- [NPM](https://www.npmjs.com/package/@narmi/design_system)


### PR DESCRIPTION
fixes #267 

- adds basic introduction screen to storybook
- sorts sidebar links correctly

<img width="941" alt="Screen Shot 2021-12-01 at 11 47 18 AM" src="https://user-images.githubusercontent.com/231252/144276757-fcc5d84e-b666-4a8e-ab9b-dfaac2a0c378.png">
