### PR TITLE
fix(Card): don't render space inside icon element

### DIFF
--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
  */
 const Card = (props) => {
   const icon = props.icon ? (
-    <span className={`narmi-icon-${props.icon}`}>&nbsp;</span>
+    <span className={`narmi-icon-${props.icon}`}></span>
   ) : (
     ""
   );
@@ -18,12 +18,15 @@ const Card = (props) => {
       {...props}
     >
       <div className="nds-card-heading">
-        <div style={{ justifyContent: "start", display: "flex"}}>
-          <h4 className="nds-sans nds-card-title">
-            {props.title}&nbsp;
-          </h4>
+        <div style={{ justifyContent: "start", display: "flex" }}>
+          <h4 className="nds-sans nds-card-title">{props.title}&nbsp;</h4>
           {icon && (
-            <div className="nds-sans nds-card-title" style={{ fontSize: props.iconSize }}>{icon}</div>
+            <div
+              className="nds-sans nds-card-title"
+              style={{ fontSize: props.iconSize }}
+            >
+              {icon}
+            </div>
           )}
         </div>
         {props.button ? props.button : ""}


### PR DESCRIPTION
Related to https://github.com/narmi/banking/pull/13461

Removing this space should allow for the header text to render on a single line, which is a quick cheap fix, especially since I'm not sure the space serves a purpose.

