### PR TITLE
fix(Button): fix background of primary button when rendering as button

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -24,7 +24,8 @@
   }
 }
 
-.nds-button--primary {
+.nds-button--primary,
+.nds-button--primary.resetButton {
   color: var(--color-white);
   background-color: var(--theme-primary);
 


### PR DESCRIPTION
Adds a selector to primary button selector list that allows background to override `resetButton `class