### PR TITLE
feat(Tabs): add Tabs component

### DIFF
--- a/src/Tabs/TabsList.js
+++ b/src/Tabs/TabsList.js
@@ -1,0 +1,56 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import TabsContext from "./context";
+
+const noop = () => {};
+
+const TabsList = ({ children }) => {
+  const { tabIds, setTabIds, changeTabs, selectedIndex, hasPanels } =
+    useContext(TabsContext);
+  const childArray = React.Children.toArray(children);
+
+  // populate tabIds state variable in root component
+  // with tabId props from `Tabs.Tab` children passed into `Tabs.List`
+  if (tabIds.length !== childArray.length) {
+    setTabIds(childArray.map((t) => t.props.tabId));
+  }
+
+  const handleKeyDown = ({ key }) => {
+    let newIndex;
+    switch (key) {
+      case "ArrowLeft":
+        newIndex = selectedIndex - 1;
+        if (newIndex >= 0) {
+          changeTabs(tabIds[newIndex]);
+        }
+        break;
+      case "ArrowRight":
+        newIndex = selectedIndex + 1;
+        if (newIndex <= tabIds.length - 1) {
+          changeTabs(tabIds[newIndex]);
+        }
+        break;
+    }
+  };
+
+  return (
+    <ul
+      role={hasPanels ? "tablist" : undefined}
+      className="list--reset nds-tabs-tabsList"
+      onKeyDown={hasPanels ? handleKeyDown : noop}
+      tabIndex={hasPanels ? "0" : undefined}
+      data-testid="nds-tablist"
+    >
+      {children}
+    </ul>
+  );
+};
+
+TabsList.propTypes = {
+  /** Children must be of type `Tabs.Tab` */
+  children: PropTypes.node.isRequired,
+};
+
+TabsList.displayName = "Tabs.List";
+
+export default TabsList;

--- a/src/Tabs/TabsPanel.js
+++ b/src/Tabs/TabsPanel.js
@@ -1,0 +1,37 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import TabsContext from "./context";
+
+const TabsPanel = ({ children, tabId }) => {
+  const { selectedIndex, tabIds, hasPanels, setHasPanels } =
+    useContext(TabsContext);
+  const selectedId = tabIds[selectedIndex];
+
+  if (!hasPanels) {
+    setHasPanels(true);
+  }
+
+  return (
+    <div
+      className="nds-tabs-panel"
+      tabIndex="0"
+      role="tabpanel"
+      id={`${tabId}-tabpanel`}
+      aria-labelledby={`${tabId}-tab`}
+      hidden={tabId !== selectedId ? true : undefined}
+    >
+      {children}
+    </div>
+  );
+};
+
+TabsPanel.propTypes = {
+  /** The content of the tab panel (any node type) */
+  children: PropTypes.node.isRequired,
+  /** String ID used to link the `Tabs.Panel` to a `Tabs.Tab` */
+  tabId: PropTypes.string.isRequired,
+};
+
+TabsPanel.displayName = "Tabs.Panel";
+
+export default TabsPanel;

--- a/src/Tabs/TabsTab.js
+++ b/src/Tabs/TabsTab.js
@@ -1,0 +1,50 @@
+import React, { useContext } from "react";
+import PropTypes from "prop-types";
+import TabsContext from "./context";
+import cc from "classcat";
+
+const TabsTab = ({ label, tabId }) => {
+  const { selectedIndex, tabIds, hasPanels, changeTabs } =
+    useContext(TabsContext);
+  const isSelected = tabId === tabIds[selectedIndex];
+
+  return (
+    <li
+      className={cc([
+        "nds-tabs-tabItem",
+        {
+          "nds-tabs-tabItem--selected": isSelected,
+        },
+      ])}
+    >
+      <button
+        className={cc([
+          "resetButton",
+          "nds-tabs-button",
+          {
+            "nds-tabs-button--selected": isSelected,
+          },
+        ])}
+        role={hasPanels ? "tab" : undefined}
+        aria-selected={isSelected.toString()}
+        aria-controls={hasPanels ? `${tabId}-tabpanel` : undefined}
+        id={`${tabId}-tab`}
+        tabIndex={hasPanels ? "-1" : "0"}
+        onClick={() => changeTabs(tabId)}
+      >
+        {label}
+      </button>
+    </li>
+  );
+};
+
+TabsTab.propTypes = {
+  /** Label of the tab button */
+  label: PropTypes.string.isRequired,
+  /** String ID used to link the `Tabs.Tab` to a `Tabs.Panel` */
+  tabId: PropTypes.string.isRequired,
+};
+
+TabsTab.displayName = "Tabs.Tab";
+
+export default TabsTab;

--- a/src/Tabs/context.js
+++ b/src/Tabs/context.js
@@ -1,0 +1,21 @@
+import { createContext } from "react";
+
+const TabsContext = createContext({
+  // list of tabIds set by TabsList
+  tabIds: [],
+  setTabIds: () => {},
+
+  // index of tab in source order that is selected
+  selectedIndex: 0,
+  setSelectedIndex: () => {},
+
+  // only set if there is a TabsPanel present inside Tabs.
+  // used to determine when to add aria labelling attributes
+  hasPanels: false,
+  setHasPanels: () => {},
+
+  // allows any consumer of this context to change tabs by id
+  changeTabs: () => {},
+});
+
+export default TabsContext;

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import TabsContext from "./context";
+import TabsList from "./TabsList";
+import TabsTab from "./TabsTab";
+import TabsPanel from "./TabsPanel";
+
+const noop = () => {};
+
+/**
+ * Component that handles tabs and tab panels based on WAI-ARIA [best practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel)
+ * for the "tabs" design pattern.
+ *
+ * The `Tabs` component mananges its own state, changing the visible tab panel based
+ * on user events. Use the `onTabChange` callback to add any custom behaviors.
+ */
+const Tabs = ({ children, defaultSelectedIndex = 0, onTabChange = noop }) => {
+  const [tabIds, setTabIds] = useState([]);
+  const [hasPanels, setHasPanels] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(defaultSelectedIndex);
+
+  const changeTabs = (tabId) => {
+    onTabChange(tabId);
+    setSelectedIndex(tabIds.indexOf(tabId));
+  };
+
+  return (
+    <TabsContext.Provider
+      value={{
+        tabIds,
+        setTabIds,
+        selectedIndex,
+        setSelectedIndex,
+        hasPanels,
+        setHasPanels,
+        changeTabs,
+      }}
+    >
+      <div className="nds-tabs">{children}</div>
+    </TabsContext.Provider>
+  );
+};
+
+Tabs.propTypes = {
+  /**
+   * Direct children of `Tabs` should be one of:
+   * `Tabs.List` or `Tabs.Panel`
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * Sets default tab selection by index in source order
+   */
+  defaultSelectedIndex: PropTypes.number,
+  /** Callback invoked with `tabId` of the tab as the argument */
+  onTabChange: PropTypes.func,
+};
+
+Tabs.List = TabsList;
+Tabs.Tab = TabsTab;
+Tabs.Panel = TabsPanel;
+
+export default Tabs;

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -1,0 +1,32 @@
+.nds-tabs-tabsList {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-end;
+  border-bottom: var(--border-size-s) solid var(--border-color-light);
+}
+
+.nds-tabs-tabItem {
+  border-bottom: 3px solid transparent;
+  &:not(:last-child) {
+    margin-right: var(--space-xl);
+  }
+  &--selected {
+    border-color: var(--theme-primary);
+  }
+}
+
+.nds-tabs-button {
+  padding: var(--space-xs) 0 !important;
+  color: var(--font-color-primary) !important;
+  font-size: var(--font-size-default);
+  font-family: var(--font-family-default);
+
+  &--selected,
+  &:hover {
+    color: var(--theme-primary) !important;
+  }
+
+  &--selected {
+    font-weight: var(--font-weight-semibold);
+  }
+}

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -1,0 +1,54 @@
+import React from "react";
+import Tabs from "./";
+
+const Template = (args) => (
+  <Tabs {...args}>
+    <Tabs.List>
+      <Tabs.Tab label="Apples" tabId="apple" />
+      <Tabs.Tab label="Oranges" tabId="orange" />
+      <Tabs.Tab label="Pineapples" tabId="pineapple" />
+    </Tabs.List>
+    <Tabs.Panel tabId="apple">
+      <div className="padding--all--s">🍎🍎🍎</div>
+    </Tabs.Panel>
+    <Tabs.Panel tabId="orange">
+      <div className="padding--all--s">🍊🍊🍊</div>
+    </Tabs.Panel>
+    <Tabs.Panel tabId="pineapple">
+      <div className="padding--all--s">🍍🍍🍍</div>
+    </Tabs.Panel>
+  </Tabs>
+);
+
+export const Overview = Template.bind({});
+Overview.argTypes = {
+  onTabChange: { action: "tab change" },
+};
+
+export const DefaultSelectedTab = Template.bind({});
+DefaultSelectedTab.args = {
+  defaultSelectedIndex: 1,
+};
+
+export const WithoutPanels = () => (
+  <Tabs>
+    <Tabs.List>
+      <Tabs.Tab label="Apples" tabId="apple" />
+      <Tabs.Tab label="Oranges" tabId="orange" />
+      <Tabs.Tab label="Pineapples" tabId="pineapple" />
+    </Tabs.List>
+  </Tabs>
+);
+WithoutPanels.parameters = {
+  docs: {
+    description: {
+      story:
+        "You can decouple tabs from conent by omitting the panel components. Use the `onTabChange` callback to respond to user events.",
+    },
+  },
+};
+
+export default {
+  title: "Components/Tabs",
+  component: Tabs,
+};

--- a/src/Tabs/index.test.js
+++ b/src/Tabs/index.test.js
@@ -1,0 +1,196 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Tabs from "./";
+
+const TAB_NAMES = ["Tab One", "Tab Two", "Tab Three"];
+const TAB_IDS = ["uno", "dos", "tres"];
+const PANEL_CONTENTS = ["Panel One", "Panel Two", "Panel Three"];
+
+/**
+ * @returns {Object} panel elements returned by `screen`
+ */
+const getPanels = () => ({
+  firstPanel: screen.getByText(PANEL_CONTENTS[0]),
+  secondPanel: screen.getByText(PANEL_CONTENTS[1]),
+  thirdPanel: screen.getByText(PANEL_CONTENTS[2]),
+});
+
+/**
+ * @returns {Object} tab button elements returned by `screen`
+ */
+const getTabs = () => ({
+  firstTab: screen.getByText(TAB_NAMES[0]),
+  secondTab: screen.getByText(TAB_NAMES[1]),
+  thirdTab: screen.getByText(TAB_NAMES[2]),
+});
+
+const renderTabsWithPanels = (args) =>
+  render(
+    <Tabs {...args}>
+      <Tabs.List>
+        <Tabs.Tab label={TAB_NAMES[0]} tabId={TAB_IDS[0]} />
+        <Tabs.Tab label={TAB_NAMES[1]} tabId={TAB_IDS[1]} />
+        <Tabs.Tab label={TAB_NAMES[2]} tabId={TAB_IDS[2]} />
+      </Tabs.List>
+      <Tabs.Panel tabId={TAB_IDS[0]}>{PANEL_CONTENTS[0]}</Tabs.Panel>
+      <Tabs.Panel tabId={TAB_IDS[1]}>{PANEL_CONTENTS[1]}</Tabs.Panel>
+      <Tabs.Panel tabId={TAB_IDS[2]}>{PANEL_CONTENTS[2]}</Tabs.Panel>
+    </Tabs>
+  );
+
+const renderTabsWithoutPanels = (args) =>
+  render(
+    <Tabs {...args}>
+      <Tabs.List>
+        <Tabs.Tab label={TAB_NAMES[0]} tabId={TAB_IDS[0]} />
+        <Tabs.Tab label={TAB_NAMES[1]} tabId={TAB_IDS[1]} />
+        <Tabs.Tab label={TAB_NAMES[2]} tabId={TAB_IDS[2]} />
+      </Tabs.List>
+    </Tabs>
+  );
+
+describe("Tabs", () => {
+  it("renders tabs with tablist only without errors", () => {
+    renderTabsWithoutPanels();
+    TAB_NAMES.forEach((tabText) => {
+      expect(screen.getByText(tabText)).toBeInTheDocument();
+    });
+  });
+
+  it("renders tabs with tablist AND tabpanels without errors", () => {
+    renderTabsWithPanels();
+    TAB_NAMES.forEach((tabText) => {
+      expect(screen.getByText(tabText)).toBeInTheDocument();
+    });
+    PANEL_CONTENTS.forEach((panelText) => {
+      expect(screen.getByText(panelText)).toBeInTheDocument();
+    });
+  });
+
+  it("defaults to first tab when no defaultSelectedId is specified", () => {
+    renderTabsWithPanels();
+    const { firstTab } = getTabs();
+    const { firstPanel, secondPanel, thirdPanel } = getPanels();
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+    expect(firstPanel).not.toHaveAttribute("hidden");
+
+    // make sure other panels are hidden
+    [secondPanel, thirdPanel].forEach((panel) => {
+      expect(panel).toHaveAttribute("hidden");
+    });
+  });
+
+  it("correctly sets default selected tab and its panel", () => {
+    renderTabsWithPanels({ defaultSelectedIndex: 1 });
+    const { firstTab, secondTab, thirdTab } = getTabs();
+    const { firstPanel, secondPanel, thirdPanel } = getPanels();
+
+    expect(secondTab).toHaveAttribute("aria-selected", "true");
+    [firstTab, thirdTab].forEach((tab) => {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    });
+
+    expect(secondPanel).not.toHaveAttribute("hidden");
+    [firstPanel, thirdPanel].forEach((panel) => {
+      expect(panel).toHaveAttribute("hidden");
+    });
+  });
+
+  it("changes tab selection and tabpanel with click", () => {
+    const handleTabChange = jest.fn();
+    renderTabsWithPanels({ onTabChange: handleTabChange });
+    const { firstTab, secondTab, thirdTab } = getTabs();
+    const { firstPanel, secondPanel, thirdPanel } = getPanels();
+
+    expect(handleTabChange).not.toHaveBeenCalled();
+    fireEvent.click(secondTab);
+    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[1]);
+
+    expect(secondTab).toHaveAttribute("aria-selected", "true");
+    [firstTab, thirdTab].forEach((tab) => {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    });
+
+    expect(secondPanel).not.toHaveAttribute("hidden");
+    [firstPanel, thirdPanel].forEach((panel) => {
+      expect(panel).toHaveAttribute("hidden");
+    });
+  });
+
+  it("changes selected tab and active tabpanel with arrow key", () => {
+    const handleTabChange = jest.fn();
+    renderTabsWithPanels({ onTabChange: handleTabChange });
+    const { firstTab, secondTab, thirdTab } = getTabs();
+    const { firstPanel, secondPanel, thirdPanel } = getPanels();
+
+    // arrow to second tab
+    expect(handleTabChange).not.toHaveBeenCalled();
+    fireEvent.keyDown(firstTab, { key: "ArrowRight" });
+    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[1]);
+
+    expect(secondTab).toHaveAttribute("aria-selected", "true");
+    [firstTab, thirdTab].forEach((tab) => {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    });
+
+    expect(secondPanel).not.toHaveAttribute("hidden");
+    [firstPanel, thirdPanel].forEach((panel) => {
+      expect(panel).toHaveAttribute("hidden");
+    });
+
+    // arrow back to first tab
+    fireEvent.keyDown(secondTab, { key: "ArrowLeft" });
+    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[0]);
+
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+    [secondTab, thirdTab].forEach((tab) => {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    });
+
+    expect(firstTab).not.toHaveAttribute("hidden");
+    [secondPanel, thirdPanel].forEach((panel) => {
+      expect(panel).toHaveAttribute("hidden");
+    });
+  });
+
+  it("does NOT change selected tab with arrow key when panels are NOT present", () => {
+    const handleTabChange = jest.fn();
+    renderTabsWithoutPanels({ onTabChange: handleTabChange });
+    const { firstTab, secondTab, thirdTab } = getTabs();
+
+    expect(handleTabChange).not.toHaveBeenCalled();
+    fireEvent.keyDown(firstTab, { key: "ArrowRight" });
+    expect(handleTabChange).not.toHaveBeenCalled();
+
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+    [secondTab, thirdTab].forEach((tab) => {
+      expect(tab).toHaveAttribute("aria-selected", "false");
+    });
+  });
+
+  it("applies tabs design pattern aria attributes when panels are present", () => {
+    renderTabsWithPanels();
+    const { firstTab, secondTab, thirdTab } = getTabs();
+    const tabList = screen.getByTestId("nds-tablist");
+
+    expect(tabList).toHaveAttribute("role", "tablist");
+    expect(tabList).toHaveAttribute("tabIndex", "0");
+
+    expect(firstTab).toHaveAttribute("role", "tab");
+    expect(firstTab).toHaveAttribute("aria-controls");
+  });
+
+  it("does NOT apply tabs design pattern aria attributes when panels are NOT present", () => {
+    renderTabsWithoutPanels();
+    const { firstTab, secondTab, thirdTab } = getTabs();
+    const tabList = screen.getByTestId("nds-tablist");
+
+    expect(tabList).not.toHaveAttribute("role", "tablist");
+    expect(tabList).not.toHaveAttribute("tabIndex", "0");
+
+    [firstTab, secondTab, thirdTab].forEach((tab) => {
+      expect(tab).not.toHaveAttribute("role", "tab");
+      expect(tab).not.toHaveAttribute("aria-controls");
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const Pagination = require("./Pagination").default;
 const SeparatorList = require("./SeparatorList").default;
 const Popover = require("./Popover").default;
 const Toggle = require("./Toggle").default;
+const Tabs = require("./Tabs").default;
 const components = {
   Input,
   DateInput,
@@ -45,6 +46,7 @@ const components = {
   SeparatorList,
   Popover,
   Toggle,
+  Tabs,
 };
 
 let styleString = require("global").styles;
@@ -76,4 +78,5 @@ export {
   SeparatorList,
   Popover,
   Toggle,
+  Tabs,
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -54,6 +54,7 @@ $desktop-big: 1440px;
 @import "SeparatorList/";
 @import "Popover/";
 @import "Toggle/";
+@import "Tabs/";
 
 // Helper classes
 @import "helper-classes/spacing";


### PR DESCRIPTION
fixes: #372 

Adds `Tabs` component, stories, and tests

## usage

```jsx
  <Tabs {...args}>
    <Tabs.List>
      <Tabs.Tab label="Tab One" tabId="apple" />
      <Tabs.Tab label="Tab Two" tabId="orange" />
      <Tabs.Tab label="Tab Three" tabId="pineapple" />
    </Tabs.List>
    <Tabs.Panel tabId="apple">
      <div className="padding--all--s">🍎🍎🍎</div>
    </Tabs.Panel>
    <Tabs.Panel tabId="orange">
      <div className="padding--all--s">🍊🍊🍊</div>
    </Tabs.Panel>
    <Tabs.Panel tabId="pineapple">
      <div className="padding--all--s">🍍🍍🍍</div>
    </Tabs.Panel>
  </Tabs>
```

## docs

<img width="835" alt="Screen Shot 2021-12-03 at 5 42 18 PM" src="https://user-images.githubusercontent.com/231252/144682353-255d288c-41ce-415d-b979-fb9edb076c8e.png">
<img width="840" alt="Screen Shot 2021-12-03 at 5 42 24 PM" src="https://user-images.githubusercontent.com/231252/144682356-a9df9fa7-7983-49ad-9fd0-157bef0b4062.png">


