### PR TITLE
build(browserslist): add browserslist config and postcss-preset-env

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,11 @@
+# Browsers officially supported by Narmi Design System
+
+last 2 major versions
+> 5% in US
+
+not IE > 0
+not Opera > 0
+not op_mob > 0
+not op_mini all
+not kaios > 0
+not dead

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Refer to the [**Changelog**](https://github.com/narmi/design_system/blob/master/CHANGELOG.md) for details.
 
 ### Browser Support
-Please check the following chart to see the minimum browser versions supported by `@narmi/design_system`:
+See [`.browserslistrc`](https://github.com/narmi/design_system/blob/master/.editorconfig) for officially supported browsers or
+run `npx browserslist` in this project locally to see a full list of targeted browsers.
 
-- https://caniuse.com/?search=focus-within
+This project does not support any version of Internet Explorer.
+
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3087,6 +3087,12 @@
         }
       }
     },
+    "@csstools/convert-colors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-2.0.0.tgz",
+      "integrity": "sha512-P7BVvddsP2Wl5v3drJ3ArzpdfXMqoZ/oHOV/yFiGFb3JQr9Z9UXZ9tnHAKJsO89lfprR1F9ExW3Yij21EjEBIA==",
+      "dev": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.3",
       "resolved": "",
@@ -14116,6 +14122,21 @@
         }
       }
     },
+    "css-blank-pseudo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-2.0.0.tgz",
+      "integrity": "sha512-n7fxEOyuvAVPLPb9kL4XTIK/gnp2fKQ7KFQ+9lj60W9pDn/jTr5LjS/kHHm+rES/YJ3m0S6+uJgYSuAJg9zOyA==",
+      "dev": true
+    },
+    "css-has-pseudo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-2.0.0.tgz",
+      "integrity": "sha512-URYSGI0ggED1W1/xOAH0Zn1bf+YL6tYh1PQzAPlWddEAyyO37mPqMbwCzSjTTNmeCR8BMNXSFLaT5xb6MERdAA==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6"
+      }
+    },
     "css-loader": {
       "version": "6.2.0",
       "resolved": "",
@@ -14143,6 +14164,12 @@
         }
       }
     },
+    "css-prefers-color-scheme": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-5.0.0.tgz",
+      "integrity": "sha512-XpzVrdwbppHm+Nnrzcb/hQb8eq1aKv4U8Oh59LsLfTsbIZZ6Fvn9razb66ihH2aTJ0VhO9n9sVm8piyKXJAZMA==",
+      "dev": true
+    },
     "css-select": {
       "version": "4.1.3",
       "resolved": "",
@@ -14166,6 +14193,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
+    "cssdb": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-5.0.0.tgz",
+      "integrity": "sha512-Q7982SynYCtcLUBCPgUPFy2TZmDiFyimpdln8K2v4w2c07W4rXL7q5F1ksVAqOAQfxKyyUGCKSsioezKT5bU1Q==",
       "dev": true
     },
     "cssesc": {
@@ -16025,6 +16058,12 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
+    "fraction.js": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+      "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "",
@@ -17601,6 +17640,12 @@
       "version": "1.0.0",
       "resolved": "",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
       "dev": true
     },
     "is-weakref": {
@@ -25858,6 +25903,93 @@
         "source-map-js": "^0.6.2"
       }
     },
+    "postcss-attribute-case-insensitive": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
+      "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.2"
+      }
+    },
+    "postcss-color-functional-notation": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.0.1.tgz",
+      "integrity": "sha512-qxD/7Q2rdmqJLSYxlJFJM9gVdyVLTBVrOUc+B6+KbOe4t2G2KnoI3HdimdK4PerGLqAqKnEVGgal7YKImm0g+w==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "6.0.1"
+      }
+    },
+    "postcss-color-hex-alpha": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.0.tgz",
+      "integrity": "sha512-Z0xiE0j+hbefUj0LWOMkzmTIS7k+dqJKzLwoKww0KJhju/sWXr+84Yk7rmvFoML/4LjGpJgefZvDwExrsWfHZw==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "^6.0.0"
+      }
+    },
+    "postcss-color-rebeccapurple": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.0.tgz",
+      "integrity": "sha512-+Ogw3SA0ESjjO87S8Dn+aAEHK6hFAWAVbTVnyXnmbV6Xh0TKi0vXpzhlKG/yrxujxtlgQcMQNQjg75uWWv28xA==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "^6"
+      }
+    },
+    "postcss-custom-media": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
+      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+      "dev": true
+    },
+    "postcss-custom-properties": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.0.0.tgz",
+      "integrity": "sha512-eAyX3rMjZKxdne6tWKjkWbNWfw6bbv4xTsrjNJ7C3uGDODrzbQXR+ueshRkw7Lhlhc3qyTmYH/sFfD0AbhgdSQ==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "^6"
+      }
+    },
+    "postcss-custom-selectors": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
+      "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "postcss-dir-pseudo-class": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.0.tgz",
+      "integrity": "sha512-TC4eB5ZnLRSV1PLsAPualEjxFysU9IVEBx8h+Md2qzo8iWdNqwWCckx5fTWfe6dJxUpB0TWEpWEFhZ/YHvjSCA==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "6.0.6"
+      }
+    },
+    "postcss-double-position-gradients": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.0.1.tgz",
+      "integrity": "sha512-L18N4Y1gpKQPEnZ6JOxO3H5gswZzTNR+ZqruZG7cOtOF/GR6J1YBRKn5hdTn3Vs4Y9XuDqaBD8vIXFIEft9Jqw==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "6.0.1"
+      }
+    },
+    "postcss-env-function": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.2.tgz",
+      "integrity": "sha512-VXKv0Vskq7olS3Q2zj38G4au4PkW+YWBRgng2Czx0pP9PyqU6uzjS6uVU1VkJN8i0OTPM7g82YFUdiz/7pEvpg==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "6.0.1"
+      }
+    },
     "postcss-flexbugs-fixes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
@@ -25885,6 +26017,55 @@
         }
       }
     },
+    "postcss-focus-visible": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.1.tgz",
+      "integrity": "sha512-UddLlBmJ78Nu7OrKME70EKxCPBdxTx7pKIyD3GDNRM8Tnq19zmscT9QzsvR8gygz0i0nNUjMtSz4N3AEWZ5R/Q==",
+      "dev": true
+    },
+    "postcss-focus-within": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.1.tgz",
+      "integrity": "sha512-50v1AZVlFSVzLTNdBQG521Aa54VABf/X1RkhR8Fm/9dDQby0W0XdwOnuo8Juvf0ZZXbKkxyTkyyQD0QaNVZVGg==",
+      "dev": true
+    },
+    "postcss-font-variant": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "dev": true
+    },
+    "postcss-gap-properties": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.0.tgz",
+      "integrity": "sha512-QJOkz1epC/iCuOdhQPm3n9T+F25+P+MYJEEcs5xz/Q+020mc9c6ZRGJkzPJd8FS9hFmT9eEKFEx9PEDl+lH5og==",
+      "dev": true
+    },
+    "postcss-image-set-function": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.2.tgz",
+      "integrity": "sha512-NbTOc3xOq/YjIJS8/UVnhI16NxRuCiEWjem0eYt87sKvjdpk00niQ9oVo3eSR+kmMKWIO979x3j5i1GYJNxe1A==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "6.0.1"
+      }
+    },
+    "postcss-initial": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+      "dev": true
+    },
+    "postcss-lab-function": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.0.1.tgz",
+      "integrity": "sha512-8F2keZUlUiX/tznbCZ5y3Bmx6pnc19kvL4oq+x+uoK0ZYQjUWmHDdVHBG6iMq2T0Fteu+AgGAo94UcIsL4ay2w==",
+      "dev": true,
+      "requires": {
+        "@csstools/convert-colors": "2.0.0",
+        "postcss-values-parser": "6.0.1"
+      }
+    },
     "postcss-loader": {
       "version": "6.1.1",
       "resolved": "",
@@ -25906,6 +26087,18 @@
           }
         }
       }
+    },
+    "postcss-logical": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.0.tgz",
+      "integrity": "sha512-fWEWMn/xf6F9SMzAD7OS0GTm8Qh1BlBmEbVT/YZGYhwipQEwOpO7YOOu+qnzLksDg9JjLRj5tLmeN8OW8+ogIA==",
+      "dev": true
+    },
+    "postcss-media-minmax": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+      "dev": true
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
@@ -25942,6 +26135,155 @@
         "icss-utils": "^5.0.0"
       }
     },
+    "postcss-nesting": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.0.2.tgz",
+      "integrity": "sha512-FdecapAKIe+kp6uLNW7icw1g1B2HRhAAfsNv/TPzopeM08gpUbnBpqKSVqxrCqLDwzQG854ZJn5I0BiJ35WvmA==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "6.0.6"
+      }
+    },
+    "postcss-overflow-shorthand": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.0.tgz",
+      "integrity": "sha512-4fTapLT68wUoIr4m3Z0sKn1NbXX0lJYvj4aDA2++KpNx8wMSVf55UuLPz0nSjXa7dV1p0xQHlJ0iFJRNrSY2mw==",
+      "dev": true
+    },
+    "postcss-page-break": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "dev": true
+    },
+    "postcss-place": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.1.tgz",
+      "integrity": "sha512-X+vHHzqZjI4JbSoj3uYpL6rGRUHE1O9F8g+jBFn5U94U0t6GjJuL/xSN7tU6Pnm9tpfXioHfxwt9E8+JrCB9OQ==",
+      "dev": true,
+      "requires": {
+        "postcss-values-parser": "6.0.1"
+      }
+    },
+    "postcss-preset-env": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.0.1.tgz",
+      "integrity": "sha512-oB7IJGwLBEwnao823mS2b9hqbp5Brm0EZKWRVROayjGwyPQVjY9gZpPZk/ItFakdx7GAPgv3ya+9R3KrUqCwYA==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^10.4.0",
+        "browserslist": "^4.17.5",
+        "caniuse-lite": "^1.0.30001272",
+        "css-blank-pseudo": "^2.0.0",
+        "css-has-pseudo": "^2.0.0",
+        "css-prefers-color-scheme": "^5.0.0",
+        "cssdb": "^5.0.0",
+        "postcss": "^8.3",
+        "postcss-attribute-case-insensitive": "^5.0.0",
+        "postcss-color-functional-notation": "^4.0.1",
+        "postcss-color-hex-alpha": "^8.0.0",
+        "postcss-color-rebeccapurple": "^7.0.0",
+        "postcss-custom-media": "^8.0.0",
+        "postcss-custom-properties": "^12.0.0",
+        "postcss-custom-selectors": "^6.0.0",
+        "postcss-dir-pseudo-class": "^6.0.0",
+        "postcss-double-position-gradients": "^3.0.1",
+        "postcss-env-function": "^4.0.2",
+        "postcss-focus-visible": "^6.0.1",
+        "postcss-focus-within": "^5.0.1",
+        "postcss-font-variant": "^5.0.0",
+        "postcss-gap-properties": "^3.0.0",
+        "postcss-image-set-function": "^4.0.2",
+        "postcss-initial": "^4.0.1",
+        "postcss-lab-function": "^4.0.1",
+        "postcss-logical": "^5.0.0",
+        "postcss-media-minmax": "^5.0.0",
+        "postcss-nesting": "^10.0.2",
+        "postcss-overflow-shorthand": "^3.0.0",
+        "postcss-page-break": "^3.0.4",
+        "postcss-place": "^7.0.1",
+        "postcss-pseudo-class-any-link": "^7.0.0",
+        "postcss-replace-overflow-wrap": "^4.0.0",
+        "postcss-selector-not": "^5.0.0"
+      },
+      "dependencies": {
+        "autoprefixer": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
+          "integrity": "sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^4.17.5",
+            "caniuse-lite": "^1.0.30001272",
+            "fraction.js": "^4.1.1",
+            "normalize-range": "^0.1.2",
+            "picocolors": "^1.0.0",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "browserslist": {
+          "version": "4.18.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+          "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001280",
+            "electron-to-chromium": "^1.3.896",
+            "escalade": "^3.1.1",
+            "node-releases": "^2.0.1",
+            "picocolors": "^1.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001285",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
+          "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.4.12",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.12.tgz",
+          "integrity": "sha512-zjfhG9Us/hIy8AlQ5OzfbR/C4aBv1Dg/ak4GX35CELYlJ4tDAtoEcQivXvyBdqdNQ+R6PhlgQqV8UNPJmhkJog==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+          "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+          "dev": true
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
+        }
+      }
+    },
+    "postcss-pseudo-class-any-link": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.0.0.tgz",
+      "integrity": "sha512-Q4KjHlyBo91nvW+wTDZHGYcjtlSSkYwxweMuq1g8+dx1S8qAnedItvHLnbdAAdqJCZP1is5dLqiI8TvfJ+cjVQ==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6"
+      }
+    },
+    "postcss-replace-overflow-wrap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+      "dev": true
+    },
+    "postcss-selector-not": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz",
+      "integrity": "sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "postcss-selector-parser": {
       "version": "6.0.6",
       "resolved": "",
@@ -25957,6 +26299,25 @@
       "resolved": "",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
+    },
+    "postcss-values-parser": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.1.tgz",
+      "integrity": "sha512-hH3HREaFAEsVOzUgYiwvFggUqUvoIZoXD2OjhzY2CEM7uVDaQTKP5bmqbchCBoVvywsqiGVYhwC8p2wMUzpW+Q==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -26386,6 +26747,12 @@
       "version": "4.0.1",
       "resolved": "",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=",
       "dev": true
     },
     "raf-schd": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node-sass": "^6.0.1",
     "polished": "^4.1.1",
     "postcss-loader": "^6.1.1",
+    "postcss-preset-env": "^7.0.1",
     "prettier": "^2.3.1",
     "pretty-quick": "^3.1.0",
     "prop-types": "^15.7.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["postcss-preset-env"],
+};


### PR DESCRIPTION
fixes #436 

- Adds `browserslist` config ([docs](https://github.com/browserslist/browserslist))
- Updates README with new browser support info
- Adds `postcss-preset-env`, which makes our `postcss-loader` automatically polyfill CSS based on browser support listed in our `.browserslistrc`

### output from `npx browserslist`

```
and_chr 92
and_ff 90
and_qq 10.4
and_uc 12.12
android 92
baidu 7.12
chrome 92
chrome 91
edge 92
edge 91
firefox 91
firefox 90
ios_saf 14.5-14.7
ios_saf 14.0-14.4
ios_saf 13.4-13.7
ios_saf 13.3
ios_saf 13.2
ios_saf 13.0-13.1
safari 14.1
safari 14
safari 13.1
safari 13
samsung 14.0
samsung 13.0
```