### PR TITLE
style(Button): fix type="plain" styles; update dropdown stories

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -68,9 +68,11 @@
 .nds-button--plain.resetButton {
   color: var(--theme-primary);
   font-weight: var(--font-weight-semibold);
+  border-radius: 0;
+  justify-content: start;
 
   .nds-button-content {
-    margin: var(--space-s);
+    margin: 0;
   }
 
   &:hover {
@@ -102,8 +104,8 @@
 .nds-plain-button {
   cursor: pointer;
   color: RGB(var(--nds-primary-color));
-  font-weight: 600;
-  font-size: 16px;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-default);
 
   &:hover {
     text-decoration: underline;

--- a/src/Dropdown/index.stories.js
+++ b/src/Dropdown/index.stories.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import Dropdown from "./";
 import Modal from "../Modal";
-import PlainButton from "../PlainButton";
 import TextInput from "../TextInput";
 import Button from "../Button";
 
@@ -20,14 +19,13 @@ export const BasicExample = () => {
       <Dropdown triggerLabel={"Accounts"} closeDropDown={modalOpen}>
         <div>Member 1</div>
         <div>Member 2</div>
-        <PlainButton
+        <Button
+          type="plain"
           onClick={() => {
             setModalOpen(true);
           }}
-          style={{ color: "rgb(var(--nds-primary-color))" }}
-        >
-          Link a new payee!
-        </PlainButton>
+          label="Link a new payee"
+        />
       </Dropdown>
       <Modal
         open={modalOpen}
@@ -48,22 +46,21 @@ export const NewMemberDropDown = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const actions = (
     <div className="nds-typography">
-      <PlainButton
-        onClick={() => {
-          setModalOpen(false);
-        }}
-        style={{ paddingRight: "16px", color: "rgb(var(--nds-primary-color))" }}
-        type="plain"
-      >
-        Cancel
-      </PlainButton>
+      <div className="padding--right--m">
+        <Button
+          onClick={() => {
+            setModalOpen(false);
+          }}
+          type="plain"
+          label="Cancel"
+        />
+      </div>
       <Button
         onClick={() => {
           setModalOpen(false);
         }}
-      >
-        Add member
-      </Button>
+        label="Add member"
+      />
     </div>
   );
   return (
@@ -76,14 +73,13 @@ export const NewMemberDropDown = () => {
         {["Rowena Wick", "Daya Zakim"].map((option, i) => (
           <div key={i}>{option}</div>
         ))}
-        <PlainButton
+        <Button
           onClick={() => {
             setModalOpen(true);
           }}
-          style={{ color: "rgb(var(--nds-primary-color))" }}
-        >
-          Add a new member
-        </PlainButton>
+          type="plain"
+          label="Add a new member"
+        />
       </Dropdown>
       <Modal
         open={modalOpen}


### PR DESCRIPTION
fixes #390 

- Update `Dropdown` stories to use `Button type="plain"` instead of `PlainButton`
- Fixes some lingering style issues with `Button type="plain"`

### Before
<img src="https://user-images.githubusercontent.com/1795659/142453045-d0e8d45a-541a-48f6-934c-062eba8c32e4.png" width="444" />

### After
<img width="444" alt="Screen Shot 2021-12-07 at 5 27 32 PM" src="https://user-images.githubusercontent.com/231252/145115751-22317841-4c9d-40f6-a634-c2151b97a60c.png">


