### PR TITLE
feat(Button): add "kind" prop; deprecate "type" prop

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -14,7 +14,8 @@ import AsElement from "../util/AsElement";
  */
 const Button = ({
   disabled = false,
-  type = "primary",
+  type,
+  kind = "primary",
   children,
   label,
   className,
@@ -30,6 +31,12 @@ const Button = ({
     buttonLabel = children;
   }
 
+  // support legacy `type` prop
+  let variant = kind;
+  if (!kind) {
+    variant = type;
+  }
+
   return (
     <AsElement
       role={isButtonElement ? undefined : "button"}
@@ -39,7 +46,7 @@ const Button = ({
       className={cc([
         "nds-typography",
         "nds-button",
-        `nds-button--${type}`,
+        `nds-button--${variant}`,
         {
           resetButton: as === "button",
           "nds-button--disabled": disabled,
@@ -61,8 +68,15 @@ Button.propTypes = {
   label: PropTypes.string,
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
-  /** type of button to render */
+  /**
+   * ️**⚠️ DEPRECATED**
+   *
+   * Support for the `type` prop will be removed in a future release.
+   * Please use the `kind` prop to set the kind of button.
+   */
   type: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
+  /** kind of button to render */
+  kind: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
   /**

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -14,5 +14,7 @@ export default {
   argTypes: {
     onClick: { action: "clicked" },
     children: { control: false },
+    className: { control: false },
+    type: { control: false },
   },
 };

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -45,19 +45,19 @@ describe("Button", () => {
   });
 
   it("has expected classes for secondary button", () => {
-    render(<Button label={LABEL} type="secondary" />);
+    render(<Button label={LABEL} kind="secondary" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--secondary");
   });
 
   it("has expected classes for menu button", () => {
-    render(<Button label={LABEL} type="menu" />);
+    render(<Button label={LABEL} kind="menu" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--menu");
   });
 
   it("has expected classes for plain button", () => {
-    render(<Button label={LABEL} type="plain" />);
+    render(<Button label={LABEL} kind="plain" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--plain");
   });


### PR DESCRIPTION
fixes #462 

Button style variant controlled by `kind` prop instead of `type`. This is not a breaking change; `type` will be removed in a future major version ( issue #464 )