### PR TITLE
docs: fix section order of dialog story

### DIFF
--- a/.storybook/Layouts.jsx
+++ b/.storybook/Layouts.jsx
@@ -51,8 +51,8 @@ export const DialogLayout = () => {
   return (
     <>
       <Title />
-      {isComponent && <ImportCopy />}
       <Description />
+      {isComponent && <ImportCopy />}
       <ArgsTable story={PRIMARY_STORY} />
       <Stories />
     </>


### PR DESCRIPTION
This PR makes the import statement appear _under_ the description in the `Dialog` story, making it consistent with other stories