### PR TITLE
docs(Tabs): make Overview story the first story

### DIFF
--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -21,6 +21,9 @@ const Template = (args) => (
 );
 
 export const Overview = Template.bind({});
+Overview.args = {
+  onTabChange: () => {},
+};
 
 export const DefaultSelectedTab = Template.bind({});
 DefaultSelectedTab.args = {


### PR DESCRIPTION
Because the `Overview` story in Tabs didn't have an args passed, storybook set the second story as the primary story. This PR fixes that by adding args to `Overview`.