### PR TITLE
docs: add release notes to storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,10 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
+    {
+      name: "@storybook/addon-docs",
+      options: { transcludeMarkdown: true },
+    },
   ],
   webpackFinal: (config) => {
     config.resolve.alias = {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -22,7 +22,13 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: ["Introduction", "Design Tokens", "Style", "Components"],
+      order: [
+        "Introduction",
+        ["Welcome", "Release Notes"],
+        "Design Tokens",
+        "Style",
+        "Components",
+      ],
     },
   },
 };

--- a/src/ReleaseNotes.stories.mdx
+++ b/src/ReleaseNotes.stories.mdx
@@ -1,0 +1,6 @@
+import { Meta } from "@storybook/addon-docs";
+import Changelog from "../CHANGELOG.md";
+
+<Meta title="Introduction/Release Notes" />
+
+<Changelog />


### PR DESCRIPTION
fixes #480 

pulls release notes generated by semantic-release directly into storybook

<img width="1163" alt="Screen Shot 2021-12-10 at 5 41 15 PM" src="https://user-images.githubusercontent.com/231252/145650429-ff29656b-1597-4f5f-bdd5-17b12f4aebde.png">

