### PR TITLE
build(node version): explicitly use node version ^16 in ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,15 @@ jobs:
   Build-design_system:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - name: Check out repository code
         uses: actions/checkout@v2
-      - run: npm install
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
+      - run: |
+          npm ci
+          npm run build

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -12,10 +12,18 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
       - name: Build static storybook
         run: |
           npm ci -loglevel=warn
           ./node_modules/.bin/build-storybook
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.7
         with:

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -8,6 +8,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
       - name: Jest
         run: |
           echo "The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/publish_storybook.yaml
+++ b/.github/workflows/publish_storybook.yaml
@@ -12,6 +12,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
       - name: Publish to Chromatic
         env:
          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
- makes all actions explicitly use node version ^16
- fixes commands for "build check" job (install with `npm ci`, run the actual build command)

A lot of this is redundant right now; in a future ticket we may be able to pass `dist` and `node_modules` from the initial build check to other actions as artifacts. (#473)