### PR TITLE
fix(typography): use correct vars from design tokens; fix heading color

### DIFF
--- a/src/base-styles/typography.scss
+++ b/src/base-styles/typography.scss
@@ -1,5 +1,5 @@
 .nds-typography {
-  font-family: var(--nds-font-family);
+  font-family: var(--font-family-default);
   text-rendering: geometricPrecision;
   line-height: var(--font-lineHeight-default);
 
@@ -7,8 +7,8 @@
   h2,
   h3,
   h4 {
-    font-family: var(--nds-header-font);
-    color: var(--nds-black);
+    font-family: var(--font-family-heading);
+    color: var(--font-color-heading);
     font-weight: var(--font-weight-bold);
 
     &::first-letter {
@@ -32,14 +32,14 @@
     font-size: var(--font-size-heading3);
 
     &.nds-sans {
-      font-family: var(--nds-font-family);
+      font-family: var(--font-family-body);
     }
   }
   h4 {
     font-size: var(--font-size-l);
 
     &.nds-sans {
-      font-family: var(--nds-font-family);
+      font-family: var(--font-family-body);
     }
   }
   h5 {


### PR DESCRIPTION
fixes #489 

Uses correct vars from design tokens; fixes bug with heading color

### Before

<img width="993" alt="Screen Shot 2021-12-14 at 4 30 12 PM" src="https://user-images.githubusercontent.com/231252/146082559-e3205c3c-0826-40a4-b606-59bea6b163fd.png">

### After

<img width="719" alt="Screen Shot 2021-12-14 at 4 30 24 PM" src="https://user-images.githubusercontent.com/231252/146082577-b3950158-809d-467e-a708-06dd26719845.png">

