### PR TITLE
fix(LoadingShim): add z-index to absolutely positioend shim

### DIFF
--- a/src/LoadingShim/index.scss
+++ b/src/LoadingShim/index.scss
@@ -8,6 +8,7 @@
   bottom: 0;
   left: 0;
   background-color: var(--bgColor-scrimLight);
+  z-index: 2;
 
   /* ensure enough room for the dots animation when there's no content */
   min-height: 200px;


### PR DESCRIPTION
Prevents loading shim from appearing under content in `banking`