### PR TITLE
fix(Tabs): prevent state race condition with useEffect wrappers

### DIFF
--- a/src/Tabs/TabsList.js
+++ b/src/Tabs/TabsList.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useEffect, useContext } from "react";
 import PropTypes from "prop-types";
 import TabsContext from "./context";
 
@@ -11,9 +11,11 @@ const TabsList = ({ children }) => {
 
   // populate tabIds state variable in root component
   // with tabId props from `Tabs.Tab` children passed into `Tabs.List`
-  if (tabIds.length !== childArray.length) {
-    setTabIds(childArray.map((t) => t.props.tabId));
-  }
+  useEffect(() => {
+    if (tabIds.length !== childArray.length) {
+      setTabIds(childArray.map((t) => t.props.tabId));
+    }
+  }, [tabIds, setTabIds, childArray]);
 
   const handleKeyDown = ({ key }) => {
     let newIndex;

--- a/src/Tabs/TabsPanel.js
+++ b/src/Tabs/TabsPanel.js
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useEffect, useContext } from "react";
 import PropTypes from "prop-types";
 import TabsContext from "./context";
 
@@ -7,9 +7,11 @@ const TabsPanel = ({ children, tabId }) => {
     useContext(TabsContext);
   const selectedId = tabIds[selectedIndex];
 
-  if (!hasPanels) {
-    setHasPanels(true);
-  }
+  useEffect(() => {
+    if (!hasPanels) {
+      setHasPanels(true);
+    }
+  }, [hasPanels, setHasPanels]);
 
   return (
     <div


### PR DESCRIPTION
fixes #492 

For some reason, this didn't cause any issues in storybook, but in an example consumer, it threw errors.

This PR wraps the context functions that update state in the `Tabs` root component. Dependencies are injected into the `useState` so that the code is only executed when one of those dependencies changes. This prevents unnecessary state updates that were causing the error.