### PR TITLE
fix: sub-header style should display text color as --nds-black

### DIFF
--- a/src/base-styles/typography.scss
+++ b/src/base-styles/typography.scss
@@ -51,6 +51,7 @@
     font-weight: var(--font-weight-bold);
     font-size: var(--font-size-xs);
     text-transform: uppercase;
+    color: var(--nds-black);
   }
 
   p {


### PR DESCRIPTION
This style class has relatively little usage currently so the change should be pretty safe. 