### PR TITLE
feat(Row): add `justifyContent` prop

### DIFF
--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -9,12 +9,13 @@ import AsElement from "../util/AsElement";
  * @param {String} gapSize
  * @returns {Object} style object for `Row`
  */
-const _getRowStyle = (alignItems, gapSize) => {
+const _getRowStyle = (alignItems, justifyContent, gapSize) => {
   let result = {};
   if (gapSize) {
     result.gap = gapSize === "none" ? "0" : `var(--space-${gapSize})`;
   }
   result.alignItems = alignItems === "top" ? "flex-start" : alignItems;
+  result.justifyContent = `flex-${justifyContent}`;
   return result;
 };
 
@@ -24,11 +25,17 @@ const _getRowStyle = (alignItems, gapSize) => {
  * Items of `Row` will grow to fit remaining space by default.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
  */
-const Row = ({ alignItems = "top", gapSize = "l", as = "div", children }) => (
+const Row = ({
+  alignItems = "top",
+  justifyContent = "start",
+  gapSize = "l",
+  as = "div",
+  children,
+}) => (
   <AsElement
     elementType={as}
     className="nds-row"
-    style={_getRowStyle(alignItems, gapSize)}
+    style={_getRowStyle(alignItems, justifyContent, gapSize)}
   >
     {children}
   </AsElement>
@@ -43,6 +50,8 @@ Row.propTypes = {
   gapSize: PropTypes.oneOf(["xxs", "xs", "s", "m", "l", "xl", "none"]),
   /** Controls vertical alignment of items within the row */
   alignItems: PropTypes.oneOf(["top", "center"]),
+  /** Controls horizontal flex justification */
+  justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "ul"]),
 };

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Button from "../Button";
 import Row from "./";
 
 const Template = (args) => (
@@ -134,6 +135,27 @@ SectionHeaderExample.parameters = {
     description: {
       story:
         "The first `Row.Item` fills the space while the last two shrink to the width of the links. The `alignItems` prop is used to vertically center the row item content.",
+    },
+  },
+};
+
+export const JustifyingContent = () => (
+  <div className="nds-typography">
+    <Row justifyContent="end">
+      <Row.Item shrink>
+        <Button type="plain">Cancel</Button>
+      </Row.Item>
+      <Row.Item shrink>
+        <Button>Continue</Button>
+      </Row.Item>
+    </Row>
+  </div>
+);
+JustifyingContent.parameters = {
+  docs: {
+    description: {
+      story:
+        "If a Row contains only shrink items, they will be justified to `flex-start` by default. To right-align them, set the `justifyContent` prop to `end`.",
     },
   },
 };

--- a/src/Row/index.test.js
+++ b/src/Row/index.test.js
@@ -6,12 +6,18 @@ describe("Row", () => {
   it("has correct default styles for alignment and gap size", () => {
     const { container } = render(<Row />);
     expect(container.firstChild).toHaveStyle("align-items: flex-start");
+    expect(container.firstChild).toHaveStyle("justify-content: flex-start");
     expect(container.firstChild).toHaveStyle("gap: var(--space-l)");
   });
 
   it("has correct override styles for center alignment", () => {
     const { container } = render(<Row alignItems="center" />);
     expect(container.firstChild).toHaveStyle("align-items: center");
+  });
+
+  it("has correct override styles for 'end' justificiation", () => {
+    const { container } = render(<Row justifyContent="end" />);
+    expect(container.firstChild).toHaveStyle("justify-content: flex-end");
   });
 
   it("has correct override styles for gap shirt size values", () => {


### PR DESCRIPTION
fixes #506 

Feature, story, and tests for a `justifyContent` prop on `Row`. This will make it easier to lay out content in `Dialog` footers.

<img width="727" alt="Screen Shot 2022-01-06 at 5 29 26 PM" src="https://user-images.githubusercontent.com/231252/148461576-793657c9-3cd7-4a4d-919d-4ce294dc85b7.png">

