### PR TITLE
build(stats): add script to check component usage in a consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,10 +40,12 @@
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.2",
         "chromatic": "^6",
+        "cli-table": "^0.3.11",
         "conventional-changelog-conventionalcommits": "^4.6.1",
         "copy-webpack-plugin": "^9.0.1",
         "core-js": "^3.15.2",
         "css-loader": "^6.2.0",
+        "glob": "^7.2.0",
         "html-webpack-plugin": "^5.3.1",
         "husky": "^7.0.2",
         "jest": "^27.2.4",
@@ -14381,6 +14383,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/cli-table/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/cli-table3": {
@@ -49535,6 +49558,23 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
     },
     "cli-table3": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "release": "semantic-release",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes"
+    "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes",
+    "stats:components": "node ./scripts/component-adoption.mjs"
   },
   "peerDependencies": {
     "react": "^16",
@@ -52,10 +53,12 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "chromatic": "^6",
+    "cli-table": "^0.3.11",
     "conventional-changelog-conventionalcommits": "^4.6.1",
     "copy-webpack-plugin": "^9.0.1",
     "core-js": "^3.15.2",
     "css-loader": "^6.2.0",
+    "glob": "^7.2.0",
     "html-webpack-plugin": "^5.3.1",
     "husky": "^7.0.2",
     "jest": "^27.2.4",

--- a/scripts/component-adoption.mjs
+++ b/scripts/component-adoption.mjs
@@ -1,0 +1,106 @@
+/**
+ * Reads relevant files from <TARGET_DIR>, counts up NDS component imports,
+ * and prints the results in the console.
+ */
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import glob from "glob";
+import Table from "cli-table";
+import toAst from "./util/toAst.mjs";
+import getComponentNames from "./util/getComponentNames.mjs";
+
+if (!process.argv[2]) {
+  throw new Error(
+    "Missing target path. Example: `npm run stats:components <TARGET_DIR>`"
+  );
+}
+
+const PACKAGE_NAME = "@narmi/design_system";
+const TARGET_DIR = process.argv[2];
+const ignore = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/static/**",
+  "**/test/**",
+  "**/spec/**",
+  "**/__tests__/**",
+  "**/__mocks__/**",
+];
+
+/**
+ * Formats and prints import stats
+ * @param {Object} componentCounts map of component names to import counts
+ * @param {Array} unusedComponents list of component names that are not imported in consumer
+ */
+const printResults = (componentCounts, unusedComponents) => {
+  const ansi = { bold: "\x1b[1m", reset: "\x1b[0m" };
+  const totalImports = Object.values(componentCounts).reduce(
+    (acc, curr) => acc + curr
+  );
+  const countTable = new Table({
+    head: ["#", "Component Name"],
+    style: { "padding-left": 1, "padding-right": 1, compact: true },
+  });
+  Object.entries(componentCounts).forEach(([k, v]) => {
+    countTable.push([v, k]);
+  });
+
+  console.log(`\n${ansi.bold}Component usage in ${TARGET_DIR}:${ansi.reset}`);
+  console.log(countTable.toString());
+  console.log(`TOTAL NDS IMPORTS: ${totalImports}`);
+
+  console.log(
+    `\n${ansi.bold}${unusedComponents.length} components are NOT used in ${TARGET_DIR}:${ansi.reset}`
+  );
+  console.log(`${unusedComponents.join(", ")}\n`);
+};
+
+/**
+ * @param {String} fileContent
+ * @returns {Array} list of NDS components being imported in the file
+ */
+const _toImportedComponentsList = (fileContent) =>
+  toAst(fileContent)
+    .program.body.filter((o) => o.type === "ImportDeclaration") // only import statements
+    .filter((o) => o.source.value.includes(PACKAGE_NAME)) // only NDS imports
+    .flatMap((o) => o.specifiers.map((s) => s.imported.name)); // return a flat array of component names in NDS imports
+
+glob(`${resolve(TARGET_DIR)}/**/*.+(js|jsx)`, { ignore }, (error, files) => {
+  if (error) {
+    throw new Error(error);
+  }
+
+  // initialize a totals object so that unused components are included
+  // in our importCountMap as "0"
+  const totals = getComponentNames().reduce((acc, curr) => {
+    acc[curr] = 0;
+    return acc;
+  }, {});
+
+  // @returns { ComponentName: <importCount>, ... }
+  const importCountMap = files
+    .map((path) => readFileSync(path).toString()) // map filepaths to file content strings
+    .filter((fileContent) => fileContent.includes(PACKAGE_NAME)) // only include files with an NDS import
+    .flatMap(_toImportedComponentsList) // return an array of every NDS component import instance
+    .reduce((acc, curr) => {
+      // tally imports into our totals obj and return the resulting count map
+      acc[curr] = acc[curr] + 1;
+      return acc;
+    }, totals);
+
+  // sorted object of adopted components and their counts
+  const adoptedComponentCounts = Object.entries(importCountMap)
+    .filter(([key, value]) => value >= 1)
+    .sort(([aKey, aValue], [bKey, bValue]) => bValue - aValue)
+    .reduce((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
+
+  // list of component names that are not used
+  const unadoptedComponentNames = Object.entries(importCountMap)
+    .filter(([key, value]) => value === 0)
+    .flatMap(([key]) => key);
+
+  printResults(adoptedComponentCounts, unadoptedComponentNames);
+});

--- a/scripts/util/getComponentNames.mjs
+++ b/scripts/util/getComponentNames.mjs
@@ -1,0 +1,24 @@
+/**
+ * helper that returns a list of components currently exported by NDS
+ */
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import toAst from "./toAst.mjs";
+
+const PATH_SRC = resolve(process.cwd(), "src");
+
+/**
+ * Reads index.js file from source to find all component names
+ * @returns {Array} list of all component names from NDS distribution
+ */
+const getComponentNames = () => {
+  const ast = toAst(readFileSync(resolve(PATH_SRC, "index.js")).toString());
+  const result = ast.program.body
+    .filter((o) => o.type === "ExportNamedDeclaration") // take only the final export statement
+    .flatMap((o) => o.specifiers) // convert to list of individual export specifiers
+    .map((specifier) => specifier.exported.name); // take the names components are exported as
+
+  return result;
+};
+
+export default getComponentNames;

--- a/scripts/util/toAst.mjs
+++ b/scripts/util/toAst.mjs
@@ -1,0 +1,14 @@
+import { parse } from "@babel/parser";
+
+const options = {
+  sourceType: "module",
+  plugins: ["jsx", "classProperties"],
+};
+
+/**
+ * @param {String} fileContent
+ * @returns AST of file
+ */
+const toAst = (fileContent) => parse(fileContent, options);
+
+export default toAst;


### PR DESCRIPTION
Adds a script that counts all NDS component imports in a given local directory.

The script converts files to AST using `@babel/parser` to ensure the es6 style destructured imports are counted correctly.

To help make sense of the AST traversal, see [this ASTExplorer example](https://astexplorer.net/#/gist/fa4070479b60f4302e0618bb8c6c26c1/ccef1f865b2064b696de3b3dbeadb670a009e55e)

<img width="461" alt="Screen Shot 2022-01-07 at 6 41 36 PM" src="https://user-images.githubusercontent.com/231252/148620944-446e6ba8-08e2-4d4e-892d-4d36a522e2c1.png">