### PR TITLE
feat(LoadingSkeleton): add component

### DIFF
--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Used to mask a limited block of loadable content. When `isLoading` is set to true,
+ * the content area will be be replaced by a shadowed, skeletal imitation of the
+ * pending content.
+ */
+
+ const ParagraphSkeleton = ({ lines=3, showTitle=true}) => (
+  <div className="nds-paragraph-skeleton">
+    {showTitle && <div className="nds-line-block header" />}
+    {[...Array(lines)].map((_, i) => <div className="nds-line-block" key={i} />)}
+  </div>
+);
+ParagraphSkeleton.propTypes = {
+  lines: PropTypes.number,
+  showTitle: PropTypes.bool,
+}
+
+ const LoadingSkeleton = ({ children, isLoading=false, displayText="paragraph" }) => {
+  return isLoading ?
+    (
+      <div className="nds-loading-skeleton">
+        {displayText === "paragraph" && <ParagraphSkeleton />}
+      </div>
+    ) :
+    (
+      <>
+        {children}
+      </>
+    )
+}
+LoadingSkeleton.propTypes = {
+  children: PropTypes.node,
+  isLoading: PropTypes.bool,
+  displayText: PropTypes.oneOf(["paragraph"]),
+}
+
+export default LoadingSkeleton;

--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -12,7 +12,7 @@ const LoadingSkeleton = ({
   isLoading=false,
   content="paragraph",
   lines=3,
-  title=false,
+  showTitle=false,
   size="medium",
 }) => {
   return isLoading ?
@@ -20,7 +20,7 @@ const LoadingSkeleton = ({
       <div className="nds-loading-skeleton">
         {content === "paragraph" &&
           <>
-            {title && <div className="nds-line-block header" />}
+            {showTitle && <div className="nds-line-block header" />}
             {[...Array(lines)].map((_, i) => <div className="nds-line-block" key={i} />)}
           </>
         }
@@ -49,7 +49,7 @@ LoadingSkeleton.propTypes = {
    * Only applies if `content` prop is set to `paragraph`.
    * When `true`, a skeletal title row will be shown above the first line.
    */
-  title: PropTypes.bool,
+  showTitle: PropTypes.bool,
   /**
    * Only applies if `content` prop is set to `headerText`.
    * The size of the skeletal header text.

--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -7,22 +7,24 @@ import PropTypes from "prop-types";
  * pending content.
  */
 
- const ParagraphSkeleton = ({ lines=3, showTitle=true}) => (
-  <div className="nds-paragraph-skeleton">
-    {showTitle && <div className="nds-line-block header" />}
-    {[...Array(lines)].map((_, i) => <div className="nds-line-block" key={i} />)}
-  </div>
-);
-ParagraphSkeleton.propTypes = {
-  lines: PropTypes.number,
-  showTitle: PropTypes.bool,
-}
-
- const LoadingSkeleton = ({ children, isLoading=false, displayText="paragraph" }) => {
+const LoadingSkeleton = ({
+  children,
+  isLoading=false,
+  content="paragraph",
+  lines=3,
+  size="medium",
+  title=false
+}) => {
   return isLoading ?
     (
       <div className="nds-loading-skeleton">
-        {displayText === "paragraph" && <ParagraphSkeleton />}
+        {content === "paragraph" &&
+          <>
+            {title && <div className="nds-line-block header" />}
+            {[...Array(lines)].map((_, i) => <div className="nds-line-block" key={i} />)}
+          </>
+        }
+        {content === "displayText" && <div className={`nds-line-block ${size}`} />}
       </div>
     ) :
     (
@@ -30,11 +32,14 @@ ParagraphSkeleton.propTypes = {
         {children}
       </>
     )
-}
+  }
 LoadingSkeleton.propTypes = {
   children: PropTypes.node,
   isLoading: PropTypes.bool,
-  displayText: PropTypes.oneOf(["paragraph"]),
+  content: PropTypes.oneOf(["paragraph", "displayText"]),
+  lines: PropTypes.number,
+  size: PropTypes.oneOf(["small", "medium", "large"]),
+  title: PropTypes.bool,
 }
 
 export default LoadingSkeleton;

--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -12,8 +12,8 @@ const LoadingSkeleton = ({
   isLoading=false,
   content="paragraph",
   lines=3,
+  title=false,
   size="medium",
-  title=false
 }) => {
   return isLoading ?
     (
@@ -24,7 +24,7 @@ const LoadingSkeleton = ({
             {[...Array(lines)].map((_, i) => <div className="nds-line-block" key={i} />)}
           </>
         }
-        {content === "displayText" && <div className={`nds-line-block ${size}`} />}
+        {content === "headerText" && <div className={`nds-line-block ${size}`} />}
       </div>
     ) :
     (
@@ -34,12 +34,27 @@ const LoadingSkeleton = ({
     )
   }
 LoadingSkeleton.propTypes = {
+  /** Loadable content area - will render normally unless `isLoading` is true. */
   children: PropTypes.node,
+  /** When `true`, the child content is replaced by the skeleton imitation. */
   isLoading: PropTypes.bool,
-  content: PropTypes.oneOf(["paragraph", "displayText"]),
+  /** The mask type that best represents the content. */
+  content: PropTypes.oneOf(["paragraph", "headerText"]),
+  /**
+   * Only applies if `content` prop is set to `paragraph`.
+   * The number of lines to be shown by the skeleton.
+   */
   lines: PropTypes.number,
-  size: PropTypes.oneOf(["small", "medium", "large"]),
+  /**
+   * Only applies if `content` prop is set to `paragraph`.
+   * When `true`, a skeletal title row will be shown above the first line.
+   */
   title: PropTypes.bool,
+  /**
+   * Only applies if `content` prop is set to `headerText`.
+   * The size of the skeletal header text.
+   */
+  size: PropTypes.oneOf(["small", "medium", "large"]),
 }
 
 export default LoadingSkeleton;

--- a/src/LoadingSkeleton/index.scss
+++ b/src/LoadingSkeleton/index.scss
@@ -21,6 +21,5 @@
     &.large {
       height: 40px;
     }
-
   }
 }

--- a/src/LoadingSkeleton/index.scss
+++ b/src/LoadingSkeleton/index.scss
@@ -1,0 +1,22 @@
+.nds-loading-skeleton {
+  padding: 8px;
+
+  .nds-line-block {
+    border-radius: 8px;
+    background-color: RGB(var(--nds-smoke-grey));
+    margin: 0 20px 20px 20px;
+    height: 22px;
+
+    &:first-of-type {
+      margin-top: 20px;
+    }
+
+    &.header {
+      width: 40%;
+    }
+  }
+
+  // .nds-paragraph-skeleton {
+  //   min-height: 300px;
+  // }
+}

--- a/src/LoadingSkeleton/index.scss
+++ b/src/LoadingSkeleton/index.scss
@@ -6,17 +6,21 @@
     background-color: RGB(var(--nds-smoke-grey));
     margin: 0 20px 20px 20px;
     height: 22px;
-
     &:first-of-type {
       margin-top: 20px;
     }
-
     &.header {
       width: 40%;
     }
-  }
+    &.small {
+      height: 22px;
+    }
+    &.medium {
+      height: 28px;
+    }
+    &.large {
+      height: 40px;
+    }
 
-  // .nds-paragraph-skeleton {
-  //   min-height: 300px;
-  // }
+  }
 }

--- a/src/LoadingSkeleton/index.stories.js
+++ b/src/LoadingSkeleton/index.stories.js
@@ -1,0 +1,34 @@
+import React from "react";
+import LoadingSkeleton from ".";
+
+const Template = (args) => <LoadingSkeleton {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  isLoading: false,
+  displayText: "paragraph",
+  children: (
+    <div className="nds-typography" style={{ outline: "1px dashed hotpink" }}>
+      <h2>This area has a LoadingSkeleton wrapper</h2>
+      <p>
+        Toggle the <code>isLoading</code> prop below to see the mask appear.
+      </p>
+      <p>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+        odit aut fugit, sed quia consequuntur magni dolores eos qui ratione
+        voluptatem sequi nesciunt
+      </p>
+    </div>
+  ),
+};
+
+export default {
+  title: "Components/LoadingSkeleton",
+  component: LoadingSkeleton,
+  argTypes: {
+    children: { control: false },
+  },
+};

--- a/src/LoadingSkeleton/index.stories.js
+++ b/src/LoadingSkeleton/index.stories.js
@@ -6,7 +6,7 @@ const Template = (args) => <LoadingSkeleton {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   isLoading: false,
-  title: true,
+  showTitle: true,
   content: "paragraph",
   children: (
     <div className="nds-typography" style={{ padding: "20px", outline: "1px dashed hotpink" }}>

--- a/src/LoadingSkeleton/index.stories.js
+++ b/src/LoadingSkeleton/index.stories.js
@@ -6,9 +6,10 @@ const Template = (args) => <LoadingSkeleton {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   isLoading: false,
-  displayText: "paragraph",
+  title: true,
+  content: "paragraph",
   children: (
-    <div className="nds-typography" style={{ outline: "1px dashed hotpink" }}>
+    <div className="nds-typography" style={{ padding: "20px", outline: "1px dashed hotpink" }}>
       <h2>This area has a LoadingSkeleton wrapper</h2>
       <p>
         Toggle the <code>isLoading</code> prop below to see the mask appear.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const RadioButtons = require("./RadioButtons").default;
 const CheckBox = require("./CheckBox").default;
 const Tooltip = require("./Tooltip").default;
 const LoadingShim = require("./LoadingShim").default;
+const LoadingSkeleton = require("./LoadingSkeleton").default;
 const Dialog = require("./Dialog").default;
 const Row = require("./Row").default;
 const Pagination = require("./Pagination").default;
@@ -40,6 +41,7 @@ const components = {
   Card,
   Tooltip,
   LoadingShim,
+  LoadingSkeleton,
   Dialog,
   Row,
   Pagination,
@@ -72,6 +74,7 @@ export {
   Dropdown,
   Tooltip,
   LoadingShim,
+  LoadingSkeleton,
   Dialog,
   Row,
   Pagination,

--- a/src/index.scss
+++ b/src/index.scss
@@ -42,6 +42,7 @@ $desktop-big: 1440px;
 @import "Button/";
 @import "Card/";
 @import "LoadingShim/";
+@import "LoadingSkeleton/";
 @import "Dialog/";
 @import "Modal/";
 @import "NavBar/";


### PR DESCRIPTION
close https://github.com/narmi/design_system/issues/512

Should fit the bill as per the design spec, but not sure I love shoving both the title mask and the paragraph mask into one component. My issue is that are prop combinations that have no effect: for example, `lines` and `title` only apply if `content` is set to `paragraph`, and `size` only applies if `content` is set to `displayText`, so maybe it makes sense to have two LoadingShadow components? 

Or I suppose, we could remove the `content` prop altogether, and allow the consumer to set the number of lines, the size of the lines, and whether there is a title row regardless of how certain combinations aren't strictly compatible with the Narmi style guide. 

Then again maybe I'm overthinking it, and this is fine, as long as the props are well documented. 



