### PR TITLE
build(scripts): add class adoption script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "conventional-changelog-conventionalcommits": "^4.6.1",
         "copy-webpack-plugin": "^9.0.1",
         "core-js": "^3.15.2",
+        "css": "^3.0.0",
         "css-loader": "^6.2.0",
         "glob": "^7.2.0",
         "html-webpack-plugin": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes",
-    "stats:components": "node ./scripts/component-adoption.mjs"
+    "stats:components": "node ./scripts/component-adoption.mjs",
+    "stats:classes": "node ./scripts/class-adoption.mjs"
   },
   "peerDependencies": {
     "react": "^16",
@@ -58,6 +59,7 @@
     "conventional-changelog-conventionalcommits": "^4.6.1",
     "copy-webpack-plugin": "^9.0.1",
     "core-js": "^3.15.2",
+    "css": "^3.0.0",
     "css-loader": "^6.2.0",
     "glob": "^7.2.0",
     "html-webpack-plugin": "^5.3.1",

--- a/scripts/class-adoption.mjs
+++ b/scripts/class-adoption.mjs
@@ -1,0 +1,86 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import glob from "glob";
+import Table from "cli-table";
+import getHelperClassNames from "./util/getHelperClassNames.mjs";
+import ignore from "./util/ignore-patterns.mjs";
+
+if (!process.argv[2]) {
+  throw new Error(
+    "Missing target path. Example: `npm run stats:classes <TARGET_DIR>`"
+  );
+}
+
+const TARGET_DIR = process.argv[2];
+const CLASSES = getHelperClassNames();
+
+/**
+ * Prints a table of total casses found in target project and a count for each class
+ * @param {Object} countMap className keys to occurance count values
+ */
+const printResults = (countMap) => {
+  const ansi = { bold: "\x1b[1m", reset: "\x1b[0m" };
+  const totalClasses = Object.values(countMap).reduce(
+    (acc, curr) => acc + curr
+  );
+  const classTable = new Table({
+    head: ["#", "Class Name"],
+    style: { "padding-left": 1, "padding-right": 1, compact: true },
+  });
+  Object.entries(countMap).forEach(([k, v]) => {
+    classTable.push([v, k]);
+  });
+  console.log(
+    `\n${ansi.bold}Helper class usage in ${TARGET_DIR}:${ansi.reset}`
+  );
+  console.log(classTable.toString());
+  console.log(`TOTAL CLASSES USED: ${totalClasses}\n`);
+};
+
+/**
+ * @param {String} content file content
+ * @param {String} className class name to match
+ * @returns {Number} number of matches for the given file and class
+ */
+const getNumMatches = (content, className) => {
+  // this pattern matches:
+  // - single classes `className="foo"` / `className='foo'`
+  // - multiple classes `className="foo bar"`
+  // - classcat conditionals `className={cc({ foo: condition })}`
+  const rx = new RegExp(`${className}[\s'":]+`, "g");
+  return (content.match(rx) || []).length;
+};
+
+glob(`${resolve(TARGET_DIR)}/**/*.+(js|jsx)`, { ignore }, (error, files) => {
+  if (error) {
+    throw new Error(error);
+  }
+
+  // initialize an object with a count of 0 for every helper class
+  const totals = CLASSES.reduce((acc, curr) => {
+    acc[curr] = 0;
+    return acc;
+  }, {});
+
+  const classCountMap = files
+    .map((path) => readFileSync(path).toString())
+    .reduce((acc, curr) => {
+      // check each file for matches on every available helper class
+      // if matches exist, increment totals key by occurrance count
+      CLASSES.forEach((className) => {
+        acc[className] = acc[className] + getNumMatches(curr, className);
+      });
+      return acc;
+    }, totals);
+
+  // don't report on classes that are not found
+  const filteredCountMap = Object.entries(classCountMap).reduce(
+    (acc, [k, v]) => {
+      if (v > 0) acc[k] = v;
+      return acc;
+    },
+    {}
+  );
+
+  printResults(filteredCountMap);
+});

--- a/scripts/class-adoption.mjs
+++ b/scripts/class-adoption.mjs
@@ -43,11 +43,8 @@ const printResults = (countMap) => {
  * @returns {Number} number of matches for the given file and class
  */
 const getNumMatches = (content, className) => {
-  // this pattern matches:
-  // - single classes `className="foo"` / `className='foo'`
-  // - multiple classes `className="foo bar"`
-  // - classcat conditionals `className={cc({ foo: condition })}`
-  const rx = new RegExp(`${className}[\s'":]+`, "g");
+  // look for any exact match for class name
+  const rx = new RegExp(`${className}`, "g");
   return (content.match(rx) || []).length;
 };
 

--- a/scripts/component-adoption.mjs
+++ b/scripts/component-adoption.mjs
@@ -8,6 +8,7 @@ import glob from "glob";
 import Table from "cli-table";
 import toAst from "./util/toAst.mjs";
 import getComponentNames from "./util/getComponentNames.mjs";
+import ignore from "./util/ignore-patterns.mjs";
 
 if (!process.argv[2]) {
   throw new Error(
@@ -17,15 +18,6 @@ if (!process.argv[2]) {
 
 const PACKAGE_NAME = "@narmi/design_system";
 const TARGET_DIR = process.argv[2];
-const ignore = [
-  "**/node_modules/**",
-  "**/dist/**",
-  "**/static/**",
-  "**/test/**",
-  "**/spec/**",
-  "**/__tests__/**",
-  "**/__mocks__/**",
-];
 
 /**
  * Formats and prints import stats

--- a/scripts/util/getHelperClassNames.mjs
+++ b/scripts/util/getHelperClassNames.mjs
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import glob from "glob";
+import sass from "sass";
+import { parse } from "css";
+
+/**
+ * @returns {Array} full list of helper class strings from NDS
+ */
+const getHelperClassNames = () => {
+  // join all scss files in `helper-classes` insto a single scss string
+  const sassString = glob
+    .sync(`${resolve(process.cwd(), "src/helper-classes")}/*.scss`)
+    .map((file) => readFileSync(file).toString())
+    .join("\n");
+
+  // convert sass to CSS
+  const compiledCSS = sass.compileString(sassString).css;
+
+  // parse CSS into AST and get a list of all classNames and return result
+  return parse(compiledCSS)
+    .stylesheet.rules.filter((rule) => rule.type === "rule") // no comments
+    .flatMap((rule) => rule.selectors) // take only the selector from each rule
+    .map((selector) => selector.replace(".", "")); // return classes as they'red used in DOM attributes
+};
+
+export default getHelperClassNames;

--- a/scripts/util/ignore-patterns.mjs
+++ b/scripts/util/ignore-patterns.mjs
@@ -1,0 +1,12 @@
+// ignore patterns for `glob` searches used by scripts
+const ignore = [
+  "**/node_modules/**",
+  "**/dist/**",
+  "**/static/**",
+  "**/test/**",
+  "**/spec/**",
+  "**/__tests__/**",
+  "**/__mocks__/**",
+];
+
+export default ignore;

--- a/src/helper-classes/background.scss
+++ b/src/helper-classes/background.scss
@@ -1,7 +1,8 @@
 /**
 * Standard background colors
 */
-@each $bgColor in (blueGrey, cloudGrey, neutralGrey, smokeGrey, snowGrey, white)
+@each $bgColor
+  in (blueGrey, cloudGrey, neutralGrey, smokeGrey, snowGrey, "white")
 {
   .bgColor--#{$bgColor} {
     background-color: var(--bgColor-#{$bgColor});

--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -13,7 +13,7 @@
 /**
 * brand/base text colors
 */
-@each $color in (moss, pine, cove, azul, pistachio, cactus, sand, white) {
+@each $color in (moss, pine, cove, azul, pistachio, cactus, sand, "white") {
   .fontColor--#{$color} {
     color: var(--color-#{$color}) !important;
   }


### PR DESCRIPTION
Adds command `npm run stats:classes <target>` to find all usage of NDS helper classes in a given local dir.

<img width="387" alt="Screen Shot 2022-01-10 at 4 28 12 PM" src="https://user-images.githubusercontent.com/231252/148969542-e24e8b69-8ce9-40e9-b198-6529ef722dc7.png">

#### How it works
1. the script reads `src/helper-classes` and compiles sass files into CSS
2. the CSS is parsed to get all the class names
3. every valid file in the target directory is searched for all the class names and results are tallied