### PR TITLE
style(reset): add reset and base CSS

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -1,6 +1,5 @@
 .nds-button,
 .nds-button.resetButton {
-  box-sizing: border-box;
   display: inline-flex;
   position: relative;
   cursor: pointer;
@@ -33,6 +32,8 @@
   background-color: var(--theme-primary);
 
   &:hover {
+    color: var(--color-white);
+    text-decoration: none;
     filter: opacity(80%);
   }
 }
@@ -73,8 +74,10 @@
   font-weight: var(--font-weight-semibold);
   border-radius: 0;
   justify-content: start;
+  min-height: unset;
 
   &:hover {
+    color: var(--theme-primary);
     text-decoration: underline;
   }
 }

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -5,7 +5,6 @@
   border-radius: 4px;
 
   padding: 20px;
-  box-sizing: border-box;
   background-color: RGB(var(--nds-white));
   border: 1px solid RGB(var(--nds-lightest-grey));
 

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -1,5 +1,4 @@
 .nds-shim--dark {
-  box-sizing: border-box;
   position: fixed;
   top: 0;
   right: 0;

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -6,7 +6,6 @@
   font-size: 16px;
 
   .nds-input-box {
-    box-sizing: border-box;
     border: 1px solid RGB(var(--nds-lightest-grey));
     background: RGB(var(--nds-white));
     position: relative;

--- a/src/Row/index.scss
+++ b/src/Row/index.scss
@@ -1,5 +1,4 @@
 .nds-row {
-  box-sizing: border-box;
   display: flex;
   flex-wrap: nowrap;
   flex-direction: row;
@@ -9,7 +8,6 @@
 
 // Row items grow to fit remaining space in row by default
 .nds-row-item {
-  box-sizing: border-box;
   flex-basis: 0;
   flex-grow: 1;
   width: auto;

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -141,7 +141,7 @@ SectionHeaderExample.parameters = {
 
 export const JustifyingContent = () => (
   <div className="nds-typography">
-    <Row justifyContent="end">
+    <Row justifyContent="end" alignItems="center">
       <Row.Item shrink>
         <Button type="plain">Cancel</Button>
       </Row.Item>

--- a/src/base-styles/defaults.scss
+++ b/src/base-styles/defaults.scss
@@ -1,0 +1,50 @@
+/**
+* NDS standard styles for base elements
+*
+* Any redundant rules here can be assumed to exist
+* in order to override `semantic-ui` in consumers that use it.
+*/
+
+body {
+  text-rendering: geometricPrecision;
+  font-family: var(--font-family-default);
+  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-default);
+  line-height: var(--font-lineHeight-default);
+  color: var(--font-color-primary);
+  max-width: unset;
+  background-color: var(--color-white);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  padding: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: var(--font-lineHeight-bigText);
+}
+
+h1 {
+  min-height: unset;
+}
+
+p {
+  line-height: var(--font-lineHeight-default);
+}
+
+a {
+  color: var(--theme-link);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--theme-link);
+  }
+}
+
+b,
+strong {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/base-styles/reset.scss
+++ b/src/base-styles/reset.scss
@@ -1,0 +1,192 @@
+/**
+* reset.css
+* Custom normailze/reset
+*
+* - Normalizes styling across browsers
+* - Sets sensible defaults for base elements
+* - Repeats some key rules from `semantic-ui` that allow us to remove it from consumers
+*/
+
+// border-box on all elements
+html {
+  box-sizing: border-box;
+}
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+// Avoid font size changing when device orientation changes
+html {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+// Allow percentage-based heights in children
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+// Media defaults
+img,
+picture,
+audio,
+video,
+canvas,
+svg {
+  display: inline-block;
+  border-style: none;
+  max-width: 100%;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+
+// Inherit all font properties in forms from parent context
+input,
+button,
+optgroup,
+textarea,
+select {
+  font: inherit;
+  margin: 0;
+}
+
+// Avoid text overflows
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+// Override UA font family and sizing for code
+pre,
+code {
+  font-family: Monaco, Consolas, monospace;
+  font-size: 1em;
+}
+
+// Normalize summary/details across browsers
+details {
+  display: block;
+}
+summary {
+  display: list-item;
+}
+
+// Normalize horizontal rule
+hr {
+  box-sizing: content-box;
+  height: 0;
+  overflow: visible;
+}
+
+// normalize block flow elements
+article,
+aside,
+footer,
+header,
+nav,
+section,
+figcaption,
+figure,
+main,
+menu {
+  display: block;
+}
+
+// Normalize inline-block flow elements
+canvas,
+progress {
+  display: inline-block;
+}
+
+// Normalize progress element across browsers
+progress {
+  vertical-align: baseline;
+}
+
+// Scrollable textareas by default in all browsers
+textarea {
+  overflow: auto;
+}
+
+// Override UA styling that sets all caps on select and button
+button,
+select {
+  text-transform: none;
+  text-rendering: geometricPrecision;
+}
+
+// Replicates input reset behavior from `semantic-ui`
+input[type="email"],
+input[type="password"],
+input[type="search"],
+input[type="text"] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+// iOS/Safari fix to enable styling clickable elements
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+// Firefox button reset
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+// Normalize checkbox/radio elements
+[type="checkbox"],
+[type="radio"] {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+}
+
+// Improve rendering of webkit number input arrows
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+// Normalize search inputs
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+// Improve webkit file upload input rendering
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}

--- a/src/base-styles/typography.scss
+++ b/src/base-styles/typography.scss
@@ -1,8 +1,4 @@
 .nds-typography {
-  font-family: var(--font-family-default);
-  text-rendering: geometricPrecision;
-  line-height: var(--font-lineHeight-default);
-
   h1,
   h2,
   h3,

--- a/src/index.scss
+++ b/src/index.scss
@@ -32,6 +32,8 @@ $desktop-big: 1440px;
 @import "icons/icons.css";
 
 // base styles
+@import "base-styles/reset";
+@import "base-styles/defaults";
 @import "base-styles/typography";
 @import "base-styles/grid";
 


### PR DESCRIPTION
fixes #494 

### What changed
- Adds `reset.css` with common styles to reset/normalize elements across browsers
- Adds `defaults.css` to set NDS default styles on some base elements
- Makes some minor style fixes to bugs exposed by adding base styling

### Why do we need this?
Setting foundational styles helps make NDS styling more portable and predictable across different browsers and consumers. The styles in `default.css` are also essential to overriding [underqualified selectors from semantic ui in banking](https://gist.github.com/akdetrick/72ee0385f10a5b4e14a1326e2a416acc)

---

Tested changes with `1.27.0-beta.0` in banking.

**This is not a high risk change**
`semantic-ui` still comes last in load order in `banking`, so it will override any selectors of the same specificity from NDS. The scarier, higher risk change is adjusting the load order in banking which will be handled by this ticket:
- https://github.com/narmi/banking/issues/13781