### PR TITLE
build(semantic-release): update release rules

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -11,6 +11,19 @@ const config = {
       "@semantic-release/commit-analyzer",
       {
         preset: "conventionalcommits",
+        releaseRules: [
+          // commits triggering a major version release
+          { breaking: true, release: "major" },
+
+          // commits triggering a minor version release
+          { type: "feat", release: "minor" },
+
+          // commits triggering a patch version release
+          { type: "fix", release: "patch" },
+          { type: "style", release: "patch" },
+          { type: "perf", release: "patch" },
+          { revert: true, release: "patch" },
+        ],
       },
     ],
     [


### PR DESCRIPTION
fixes #520 

This change instructs `semantic-release` to make a patch version release on `style` type commits. The rest of the rules are the defaults, but I am explicitly adding to make it more clear what commit type does what.