### PR TITLE
style(helper-classes): add axis based spacing helper classes

### DIFF
--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -50,6 +50,8 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `margin--<side>`           | Adds margin of default space to given _side_ of element          |
 | `margin--<side>--none`     | Removes margin from given _side_ of element                      |
 | `margin--<side>--<amount>` | Adds a margin of a given _amount_ to the given _side_ of element |
+| `margin--<axis>--none`     | Removes margin from given _axis_ of element                      |
+| `margin--<axis>--<amount>` | Adds a margin to x or y _axis_ of element for given amount       |
 
 ### Padding
 
@@ -65,6 +67,8 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `padding--<side>`           | Adds padding of default space to given _side_ of element          |
 | `padding--<side>--none`     | Removes padding from given _side_ of element                      |
 | `padding--<side>--<amount>` | Adds a padding of a given _amount_ to the given _side_ of element |
+| `padding--<axis>--none`     | Removes padding from given _axis_ of element                      |
+| `padding--<axis>--<amount>` | Adds a padding to x or y _axis_ of element for given amount       |
 
 ## Font
 

--- a/src/helper-classes/spacing.scss
+++ b/src/helper-classes/spacing.scss
@@ -1,6 +1,8 @@
 /**
 * padding and margin helpers
 */
+$sizes: xxs, xs, s, m, l, xl;
+
 @each $property in (padding, margin) {
   // all sides spacing (`<margin|padding>--all`)
   .#{$property}--all {
@@ -10,6 +12,16 @@
   // negate all sides spacing (`<margin|padding>--none`)
   .#{$property}--none {
     #{$property}: 0;
+  }
+
+  // negate spacing on an axis (`<margin|padding>--<axis>--none`)
+  .#{$property}--x--none {
+    #{$property}-left: 0;
+    #{$property}-right: 0;
+  }
+  .#{$property}--y--none {
+    #{$property}-top: 0;
+    #{$property}-bottom: 0;
   }
 
   @each $direction in (top, right, bottom, left) {
@@ -23,7 +35,7 @@
       #{$property}-#{direction}: 0;
     }
 
-    @each $size in (xxs, xs, s, m, l, xl) {
+    @each $size in ($sizes) {
       // spacing by direction and size (`<margin|padding>--top--xl`)
       .#{$property}--#{$direction}--#{$size} {
         #{$property}-#{$direction}: var(--space-#{$size});
@@ -33,6 +45,18 @@
       .#{$property}--all--#{$size} {
         #{$property}: var(--space-#{$size});
       }
+    }
+  }
+
+  // spacing amount by axis (`<margin|padding>--<axis>--<amount>`)
+  @each $size in ($sizes) {
+    .#{$property}--x--#{$size} {
+      #{$property}-left: var(--space-#{$size});
+      #{$property}-right: var(--space-#{$size});
+    }
+    .#{$property}--y--#{$size} {
+      #{$property}-top: var(--space-#{$size});
+      #{$property}-bottom: var(--space-#{$size});
     }
   }
 }


### PR DESCRIPTION
fixes #440 

Adds spacing helpers based on element axis. For example:

```
margin--y--none
padding--x--s
```
<img width="706" alt="Screen Shot 2022-01-19 at 4 25 46 PM" src="https://user-images.githubusercontent.com/231252/150216418-d46eecaf-c879-42b1-ac8f-0a186d0192a8.png">
<img width="711" alt="Screen Shot 2022-01-19 at 4 25 52 PM" src="https://user-images.githubusercontent.com/231252/150216421-54e61e51-7ff1-45b5-a128-c47a62201a67.png">


