### PR TITLE
style(helper-classes): add child alignment helper classes

### DIFF
--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -70,6 +70,21 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `padding--<axis>--none`     | Removes padding from given _axis_ of element                      |
 | `padding--<axis>--<amount>` | Adds a padding to x or y _axis_ of element for given amount       |
 
+## Position
+
+### Child alignment
+
+These helpers will horizontally and vertical align the direct child of an element.
+To vertically and horizontally center a child in a container for example, use `alignChild--center--center`.
+
+Valid horizontal alignments are (`left`, `center`, `right`)
+
+Valid vertical alignments are (`top`, `center`, `bottom`).
+
+| Class                                      | Description                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `alignChild--<X alignment>--<Y alignment>` | Aligns direct child of element with flexbox `justify-content` and `align-items` properties |
+
 ## Font
 
 ### Color

--- a/src/helper-classes/position.scss
+++ b/src/helper-classes/position.scss
@@ -1,0 +1,27 @@
+/**
+* Child Alignment
+* `alignChild--<horizontal alignment>--<vertical alignment>`
+*/
+$xAlign: (
+  left: flex-start,
+  center: center,
+  right: flex-end,
+);
+$yAlign: (
+  top: flex-start,
+  center: center,
+  bottom: flex-end,
+);
+
+[class^="alignChild--"] {
+  display: flex;
+}
+
+@each $xAlignment, $xValue in $xAlign {
+  @each $yAlignment, $yValue in $yAlign {
+    .alignChild--#{$xAlignment}--#{$yAlignment} {
+      justify-content: #{$xValue};
+      align-items: #{$yValue};
+    }
+  }
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -58,6 +58,7 @@ $desktop-big: 1440px;
 @import "Tabs/";
 
 // Helper classes
+@import "helper-classes/position";
 @import "helper-classes/spacing";
 @import "helper-classes/font";
 @import "helper-classes/background";


### PR DESCRIPTION
fixes #441 

Adds `alignChild` helper classes.

`alignChild--<xAlign>--<yAlign>` (follows the same x,y order of `background-position` and other CSS rules)

### Examples

Right align something:
```jsx
<div className="alignChild--center--right">
  <a href="#">Link aligned right and vertically centered within the parent without floats!</a>
</div>
```

Vertically and horizontally center an emoji in a 60px² box:
```jsx
<div style={{ width: '60px', height: '60px' }} className="alignChild--center--center">
  <span>😎</span>
</div>
```

Place the emoji in the bottom left of a 60px² box:
```jsx
<div style={{ width: '60px', height: '60px' }} className="alignChild--left--bottom">
  <span>😎</span>
</div>
```