### PR TITLE
fix(Dialog): address design feedback

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -80,14 +80,17 @@ const Dialog = ({
             <span className="narmi-icon-x"></span>
           </button>
         </div>
-        <div ref={contentRef} className="nds-dialog-content nds-typography">
+        <div
+          ref={contentRef}
+          className="nds-dialog-content nds-typography padding--top--xs"
+        >
           {children}
         </div>
         {footer && (
           <div
             className={cc([
               "nds-dialog-footer",
-              { "nds-dialog-footer--bordered": isContentOverflowing },
+              { "nds-dialog-footer--overflowing": isContentOverflowing },
             ])}
           >
             {footer}

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -35,7 +35,7 @@
 .nds-dialog-header {
   margin: 0 var(--space-xl);
   padding-top: var(--space-xl);
-  padding-bottom: var(--space-xs);
+  padding-bottom: var(--space-xxs);
 
   h4 {
     margin: 0;
@@ -53,6 +53,7 @@
 .nds-dialog-closeButton {
   position: absolute;
   font-size: var(--font-size-l) !important;
+  color: var(--font-color-primary);
   right: var(--space-m);
   top: var(--space-m);
 }
@@ -75,8 +76,7 @@
   padding-top: var(--space-default);
 }
 
-.nds-dialog-footer--bordered {
-  border-top: var(--border-size-s) solid var(--border-color-light);
+.nds-dialog-footer--overflowing {
   position: relative;
 
   &::before {
@@ -84,7 +84,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    top: -21px; /* stack on top of footer border */
+    top: -20px; /* stack on top of footer border */
     height: 20px;
     background-image: linear-gradient(
       to top,

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -42,7 +42,7 @@ export const Overview = BaseTemplate.bind({});
 Overview.args = {
   isOpen: false,
   title: "Dialog title",
-  children: <p>Dialog content</p>,
+  children: <div>Dialog content</div>,
   footer: (
     <div style={{ textAlign: "right" }}>
       <Button>Accept</Button>
@@ -59,7 +59,7 @@ Overview.argTypes = {
 export const UsingWithState = InteractiveTemplate.bind({});
 UsingWithState.args = {
   title: "Dialog controlled by external state",
-  children: <p>Dialog content</p>,
+  children: <div>Dialog content</div>,
 };
 UsingWithState.parameters = {
   docs: {


### PR DESCRIPTION
fixes #417 

Updates `Dialog` styling to address design feedback

<img width="523" alt="Screen Shot 2022-01-24 at 3 43 52 PM" src="https://user-images.githubusercontent.com/231252/150861696-02b6d964-302d-4990-a7ce-0a276adbbe02.png">

