### PR TITLE
feat(typography): add heading0 font size token with helper class

### DIFF
--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -35,7 +35,7 @@
 /**
 * font size helpers
 */
-@each $size in (xs, s, m, l, heading1, heading2, heading3) {
+@each $size in (xs, s, m, l, heading0, heading1, heading2, heading3) {
   .fontSize--#{$size} {
     font-size: var(--font-size-#{$size}) !important;
   }

--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -101,6 +101,7 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `fontSize--s`        | Sets font size to `var(--font-size-s)`              |
 | `fontSize--m`        | Sets font size to `var(--font-size-m)`              |
 | `fontSize--l`        | Sets font size to `var(--font-size-l)`              |
+| `fontSize--heading0` | Sets font size to `var(--font-size-heading0)`       |
 | `fontSize--heading1` | Sets font size to `var(--font-size-heading1)`       |
 | `fontSize--heading2` | Sets font size to `var(--font-size-heading2)`       |
 | `fontSize--heading3` | Sets font size to `var(--font-size-heading3)`       |

--- a/tokens/src/font/size.json
+++ b/tokens/src/font/size.json
@@ -5,6 +5,7 @@
       "s": { "value": "14px" },
       "m": { "value": "16px" },
       "l": { "value": "20px" },
+      "heading0": { "value": "40px" },
       "heading1": { "value": "32px" },
       "heading2": { "value": "28px" },
       "heading3": { "value": "24px" },


### PR DESCRIPTION
fix #508

Adds a design token for the concept of "h0", which is the topmost heading font size in our type scale (`40px`).

<img width="937" alt="Screen Shot 2022-01-24 at 5 08 24 PM" src="https://user-images.githubusercontent.com/231252/150873753-075746ce-7a9f-4f54-9b7c-dda0f7360690.png">
<img width="589" alt="Screen Shot 2022-01-24 at 5 08 35 PM" src="https://user-images.githubusercontent.com/231252/150873758-ff7be4df-d901-4a01-ac10-bc107d080eb2.png">

