### PR TITLE
Breaking/464 button props

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -16,7 +16,6 @@ const Button = ({
   disabled = false,
   type = "primary",
   label,
-  className,
   onClick = () => {},
   as = "button",
   ...otherProps
@@ -37,7 +36,6 @@ const Button = ({
           resetButton: as === "button",
           "nds-button--disabled": disabled,
         },
-        className,
       ])}
       disabled={isButtonElement && disabled ? true : undefined}
       data-testid="nds-button"
@@ -58,14 +56,6 @@ Button.propTypes = {
   type: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
-  /**
-   * ️**⚠️ DEPRECATED**
-   *
-   * Support for passing custom `className` strings will be removed in
-   * a future release.
-   * Please use the `type` prop to determine the button style instead.
-   */
-  className: PropTypes.string,
 };
 
 export default Button;

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -15,7 +15,6 @@ import AsElement from "../util/AsElement";
 const Button = ({
   disabled = false,
   type = "primary",
-  children,
   label,
   className,
   onClick = () => {},
@@ -23,12 +22,6 @@ const Button = ({
   ...otherProps
 }) => {
   const isButtonElement = as === "button";
-
-  // support legacy method of passing label as children
-  let buttonLabel = label;
-  if (!buttonLabel) {
-    buttonLabel = children;
-  }
 
   return (
     <AsElement
@@ -49,16 +42,16 @@ const Button = ({
       disabled={isButtonElement && disabled ? true : undefined}
       data-testid="nds-button"
     >
-      <div className="nds-button-content">{buttonLabel}</div>
+      <div className="nds-button-content">{label}</div>
     </AsElement>
   );
 };
 
 Button.propTypes = {
+  /** Renders the button label */
+  label: PropTypes.string.isRequired,
   /** The html element to render as the root node of `Button` */
   as: PropTypes.oneOf(["a", "button"]),
-  /** Renders the button label */
-  label: PropTypes.string,
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
   /** type of button to render */
@@ -73,13 +66,6 @@ Button.propTypes = {
    * Please use the `type` prop to determine the button style instead.
    */
   className: PropTypes.string,
-  /**
-   * **⚠️ DEPRECATED**
-   *
-   * Passing children to render the button label will be removed
-   * in a future release. Use the `label` prop instead.
-   */
-  children: PropTypes.node,
 };
 
 export default Button;

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -15,12 +15,19 @@ import AsElement from "../util/AsElement";
 const Button = ({
   disabled = false,
   kind = "primary",
+  children,
   label,
   onClick = () => {},
   as = "button",
   ...otherProps
 }) => {
   const isButtonElement = as === "button";
+
+  // support legacy method of passing label as children
+  let buttonLabel = label;
+  if (!buttonLabel) {
+    buttonLabel = children;
+  }
 
   return (
     <AsElement
@@ -40,22 +47,29 @@ const Button = ({
       disabled={isButtonElement && disabled ? true : undefined}
       data-testid="nds-button"
     >
-      <div className="nds-button-content">{label}</div>
+      <div className="nds-button-content">{buttonLabel}</div>
     </AsElement>
   );
 };
 
 Button.propTypes = {
-  /** Renders the button label */
-  label: PropTypes.string.isRequired,
   /** The html element to render as the root node of `Button` */
   as: PropTypes.oneOf(["a", "button"]),
+  /** Renders the button label */
+  label: PropTypes.string,
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
   /** style of button to render */
   kind: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
+  /**
+   * **⚠️ DEPRECATED**
+   *
+   * Passing children to render the button label will be removed
+   * in a future release. Use the `label` prop instead.
+   */
+  children: PropTypes.node,
 };
 
 export default Button;

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -14,7 +14,7 @@ import AsElement from "../util/AsElement";
  */
 const Button = ({
   disabled = false,
-  type = "primary",
+  kind = "primary",
   label,
   onClick = () => {},
   as = "button",
@@ -31,7 +31,7 @@ const Button = ({
       className={cc([
         "nds-typography",
         "nds-button",
-        `nds-button--${type}`,
+        `nds-button--${kind}`,
         {
           resetButton: as === "button",
           "nds-button--disabled": disabled,
@@ -52,8 +52,8 @@ Button.propTypes = {
   as: PropTypes.oneOf(["a", "button"]),
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
-  /** type of button to render */
-  type: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
+  /** style of button to render */
+  kind: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
 };

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -19,7 +19,7 @@ const Button = ({
   label,
   className,
   onClick = () => {},
-  as = "a",
+  as = "button",
   ...otherProps
 }) => {
   const isButtonElement = as === "button";

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -11,15 +11,15 @@ describe("Button", () => {
     render(<Button label={LABEL} />);
     const button = getButton();
     expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute("role", "button");
+    expect(button).not.toHaveAttribute("role", "button"); // should be a button element
     expect(button).toHaveClass("nds-button--primary");
   });
 
   it("has expected classes for primary button as='button'", () => {
-    render(<Button as="button" label={LABEL} />);
+    render(<Button as="a" label={LABEL} />);
     const button = getButton();
     expect(button).toBeInTheDocument();
-    expect(button).not.toHaveAttribute("role", "button");
+    expect(button).toHaveAttribute("role", "button");
   });
 
   it("fires click callback as anchor", () => {
@@ -45,19 +45,19 @@ describe("Button", () => {
   });
 
   it("has expected classes for secondary button", () => {
-    render(<Button label={LABEL} type="secondary" />);
+    render(<Button label={LABEL} kind="secondary" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--secondary");
   });
 
   it("has expected classes for menu button", () => {
-    render(<Button label={LABEL} type="menu" />);
+    render(<Button label={LABEL} kind="menu" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--menu");
   });
 
   it("has expected classes for plain button", () => {
-    render(<Button label={LABEL} type="plain" />);
+    render(<Button label={LABEL} kind="plain" />);
     const button = getButton();
     expect(button).toHaveClass("nds-button--plain");
   });


### PR DESCRIPTION
fixes #464 

**Breaking change merging into `major/v2`**

Making the following changes in individual commits so that release notes display complete information on what breaking changes were made.

- Renders `Button` as a `button` element by default. Consumers may use `as="a"` to render as an anchor element
- ~Removes `children` support. Consumers must use `label` moving forward.~
- Removes `className` support. Consumers must rely on `kind` prop to choose button style from a limited set.
- Renames `type` prop to `kind`

_(Edit: reverted removal of `children` prop for this PR)_


<img width="1051" alt="Screen Shot 2022-01-24 at 6 37 39 PM" src="https://user-images.githubusercontent.com/231252/150883452-fe664c8f-20e8-44e3-a680-5380af0adb53.png">



