### PR TITLE
feat(formatters): add formatDate utility function

### DIFF
--- a/src/formatters/formatDate.js
+++ b/src/formatters/formatDate.js
@@ -1,0 +1,31 @@
+/**
+ * Wrapper for `Intl.DateTimeFormat` with options configured for Narmi applications.
+ *
+ * @example
+ * import { formatDate } from '@narmi/design_system';
+ *
+ * formatDate(new Date('July 4, 2022'), 'short'); // '7/4/2022'
+ * formatDate(new Date('7/4/2022'), 'long');      // 'July 4, 2022'
+ *
+ * @param {Date} date native date object
+ * @param {String} style formatting style (`short` or `long`)
+ * @returns {String} date string formatted for display
+ */
+const formatDate = (date, style = "short") => {
+  let formatterOpts = {
+    dateStyle: style,
+  };
+
+  const validStyles = ["short", "long"];
+  if (!validStyles.includes(style)) {
+    throw new Error(
+      `formatDate: invalid style argument. Must be one of: ${JSON.stringify(
+        validStyles
+      )}`
+    );
+  }
+
+  return new Intl.DateTimeFormat("en-US", formatterOpts).format(date);
+};
+
+export default formatDate;

--- a/src/formatters/formatDate.test.js
+++ b/src/formatters/formatDate.test.js
@@ -1,0 +1,46 @@
+import formatDate from "./formatDate";
+
+const MOCK_DATES = {
+  july4: new Date("July 4, 2022"),
+  wallaceShawnBirthday: new Date("November 12, 2022"),
+};
+
+describe("formatDate", () => {
+  it("formats with 'short' style by default", () => {
+    const actual = formatDate(MOCK_DATES.wallaceShawnBirthday);
+    const expected = "11/12/22";
+    expect(actual).toEqual(expected);
+  });
+
+  describe("short", () => {
+    const style = "short";
+
+    it("no leading zeroes on month or day", () => {
+      const actual = formatDate(MOCK_DATES.july4, style);
+      const expected = "7/4/22";
+      expect(actual).toEqual(expected);
+    });
+
+    it("all digits for MM DD dates", () => {
+      const actual = formatDate(MOCK_DATES.wallaceShawnBirthday, style);
+      const expected = "11/12/22";
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe("long", () => {
+    const style = "long";
+
+    it("no leading zero on day", () => {
+      const actual = formatDate(MOCK_DATES.july4, style);
+      const expected = "July 4, 2022";
+      expect(actual).toEqual(expected);
+    });
+
+    it("both digits for DD day", () => {
+      const actual = formatDate(MOCK_DATES.wallaceShawnBirthday, style);
+      const expected = "November 12, 2022";
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/formatters/formatNumber.js
+++ b/src/formatters/formatNumber.js
@@ -1,7 +1,9 @@
 /**
- * Thin wrapper for `Intl.NumberFormat` with options configured for Narmi applications.
+ * Wrapper for `Intl.NumberFormat` with options configured for Narmi applications.
  *
  * @example
+ * import { formatNumber } from '@narmi/design_system';
+ *
  * formatNumber(1234.56, 'currency'); // '$1,234.56'
  * formatNumber(34.4, 'currency');    // '$34.40'
  * formatNumber(-12, 'currency');     // '-$12'
@@ -10,7 +12,7 @@
  *
  * @param {String|Number} input string or number to format into a number string
  * @param {String} style format style (`currency` or `percent`)
- * @returns {String} formatted string
+ * @returns {String} number string formatted for display
  */
 const formatNumber = (input, style = "currency") => {
   let number = parseFloat(input, 10);

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ Object.values(components).forEach((component) => {
 });
 
 const formatNumber = require("./formatters/formatNumber").default;
+const formatDate = require("./formatters/formatDate").default;
 
 export {
   Input,
@@ -85,4 +86,5 @@ export {
   Toggle,
   Tabs,
   formatNumber,
+  formatDate,
 };


### PR DESCRIPTION
fixes https://github.com/narmi/banking/issues/15021

Adds `formatDate` function

<img width="787" alt="Screen Shot 2022-01-26 at 11 13 10 AM" src="https://user-images.githubusercontent.com/231252/151201521-a76ff401-b954-485a-957e-e71bf9bdc8dc.png">

