### PR TITLE
fix(Pagination): render empty fragment when totalPages is 1

### DIFF
--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -109,7 +109,7 @@ const Pagination = ({
     onPageChange(newSelectedPage);
   };
 
-  return (
+  const pagination = (
     <div className="nds-typography nds-pagination">
       <nav aria-label="pagination">
         <Row gapSize="xs" alignItems="center" as="ul">
@@ -208,10 +208,15 @@ const Pagination = ({
       </nav>
     </div>
   );
+
+  return totalPages > 1 ? pagination : <></>;
 };
 
 Pagination.propTypes = {
-  /** Total number of pages */
+  /**
+   * Total number of pages
+   * If the number of pages is 1, pagination will not render
+   */
   totalPages: PropTypes.number.isRequired,
   /**
    * Default selected page by page number.

--- a/src/Pagination/index.test.js
+++ b/src/Pagination/index.test.js
@@ -60,6 +60,11 @@ describe("Pagination", () => {
   });
 
   describe("Component render and interaction", () => {
+    it("does not render pagination when totalPages is 1", () => {
+      render(<Pagination totalPages={1} />);
+      expect(screen.queryByLabelText("pagination")).not.toBeInTheDocument();
+    });
+
     it("Clicking on page 3 changes selected page", () => {
       const handlePageChange = jest.fn();
       render(<Pagination totalPages={20} onPageChange={handlePageChange} />);


### PR DESCRIPTION
fixes #545 

Only render pagination component if `totalPages` is > 1