### PR TITLE
feat(Tabs): add `hadBorder` prop to provide border control

### DIFF
--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
+import cc from "classcat";
 import TabsContext from "./context";
 import TabsList from "./TabsList";
 import TabsTab from "./TabsTab";
@@ -14,7 +15,12 @@ const noop = () => {};
  * The `Tabs` component mananges its own state, changing the visible tab panel based
  * on user events. Use the `onTabChange` callback to add any custom behaviors.
  */
-const Tabs = ({ children, defaultSelectedIndex = 0, onTabChange = noop }) => {
+const Tabs = ({
+  children,
+  defaultSelectedIndex = 0,
+  onTabChange = noop,
+  hasBorder = true,
+}) => {
   const [tabIds, setTabIds] = useState([]);
   const [hasPanels, setHasPanels] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(defaultSelectedIndex);
@@ -36,7 +42,9 @@ const Tabs = ({ children, defaultSelectedIndex = 0, onTabChange = noop }) => {
         changeTabs,
       }}
     >
-      <div className="nds-tabs">{children}</div>
+      <div className={cc(["nds-tabs", { "nds-tabs--bordered": hasBorder }])}>
+        {children}
+      </div>
     </TabsContext.Provider>
   );
 };
@@ -53,6 +61,8 @@ Tabs.propTypes = {
   defaultSelectedIndex: PropTypes.number,
   /** Callback invoked with `tabId` of the tab as the argument */
   onTabChange: PropTypes.func,
+  /** Shows bottom border when `true` */
+  hasBorder: PropTypes.bool,
 };
 
 Tabs.List = TabsList;

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -2,7 +2,10 @@
   display: flex;
   justify-content: flex-start;
   align-items: flex-end;
-  border-bottom: var(--border-size-s) solid var(--border-color-light);
+
+  .nds-tabs--bordered & {
+    border-bottom: var(--border-size-s) solid var(--border-color-light);
+  }
 }
 
 .nds-tabs-tabItem {

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -48,6 +48,24 @@ WithoutPanels.parameters = {
   },
 };
 
+export const WithoutBorder = () => (
+  <Tabs hasBorder={false}>
+    <Tabs.List>
+      <Tabs.Tab label="Apples" tabId="apple" />
+      <Tabs.Tab label="Oranges" tabId="orange" />
+      <Tabs.Tab label="Pineapples" tabId="pineapple" />
+    </Tabs.List>
+  </Tabs>
+);
+WithoutBorder.parameters = {
+  docs: {
+    description: {
+      story:
+        "You can render tabs without a border via the `hasBorder` prop. This is useful when the element directly below the tabs list has a top border already.",
+    },
+  },
+};
+
 export default {
   title: "Components/Tabs",
   component: Tabs,


### PR DESCRIPTION
Related:
- https://github.com/narmi/banking/pull/15117/files#diff-72afc0afce8484875275ed7d185ed2eb558b302e8f697a13259afe46b3033ebcR13

Adds `hasBorder` prop to `Tabs`.

<img width="777" alt="Screen Shot 2022-01-28 at 10 23 26 AM" src="https://user-images.githubusercontent.com/231252/151573910-1e56a5f0-702b-4c1c-9bb5-4db7097a9f7b.png">

<img width="809" alt="Screen Shot 2022-01-28 at 10 23 14 AM" src="https://user-images.githubusercontent.com/231252/151573943-649a31e0-e96c-459b-855b-8264423ca956.png">

