### PR TITLE
fix(formatNumber): use default NumberFormat behavior for percentage f…

### DIFF
--- a/src/formatters/formatDate.test.js
+++ b/src/formatters/formatDate.test.js
@@ -21,6 +21,12 @@ describe("formatDate", () => {
       expect(actual).toEqual(expected);
     });
 
+    it("no leading zero on day", () => {
+      const actual = formatDate(new Date("2021-10-4"), style);
+      const expected = "10/4/21";
+      expect(actual).toEqual(expected);
+    });
+
     it("all digits for MM DD dates", () => {
       const actual = formatDate(MOCK_DATES.wallaceShawnBirthday, style);
       const expected = "11/12/22";

--- a/src/formatters/formatNumber.js
+++ b/src/formatters/formatNumber.js
@@ -7,8 +7,9 @@
  * formatNumber(1234.56, 'currency'); // '$1,234.56'
  * formatNumber(34.4, 'currency');    // '$34.40'
  * formatNumber(-12, 'currency');     // '-$12'
- * formatNumber('3.40', 'percent');   // '3.4%'
- * formatNumber(2, 'percent');        // '2%'
+ * formatNumber('0.0342', 'percent'); // '3.42%'
+ * formatNumber(0.0023, 'percent');   // '0.23%'
+ * formatNumber(0.215555, 'percent'); // '21.56%'
  *
  * @param {String|Number} input string or number to format into a number string
  * @param {String} style format style (`currency` or `percent`)
@@ -32,13 +33,8 @@ const formatNumber = (input, style = "currency") => {
     );
   }
 
-  switch (style) {
-    case "currency":
-      formatterOpts.currency = "USD";
-      break;
-    case "percent":
-      number = number / 100;
-      break;
+  if (style === "currency") {
+    formatterOpts.currency = "USD";
   }
 
   return new Intl.NumberFormat("en-US", formatterOpts).format(number);

--- a/src/formatters/formatNumber.test.js
+++ b/src/formatters/formatNumber.test.js
@@ -61,27 +61,27 @@ describe("formatNumber", () => {
       expect(actual).toEqual(expected);
     });
 
-    it("formats between 0 and 1 correctly", () => {
+    it("formats less than 1% as expected", () => {
+      const actual = formatNumber("0.0023", style);
+      const expected = "0.23%";
+      expect(actual).toEqual(expected);
+    });
+
+    it("formats to two decimal places correctly", () => {
       const actual = formatNumber("0.12", style);
-      const expected = "0.12%";
+      const expected = "12%";
       expect(actual).toEqual(expected);
     });
 
-    it("only shows two decimal places", () => {
-      const actual = formatNumber("9.12345", style);
-      const expected = "9.12%";
+    it("handles empty tens place correctly", () => {
+      const actual = formatNumber("0.0342", style);
+      const expected = "3.42%";
       expect(actual).toEqual(expected);
     });
 
-    it("does not add trailing zero if only one decimal", () => {
-      const actual = formatNumber("4.9", style);
-      const expected = "4.9%";
-      expect(actual).toEqual(expected);
-    });
-
-    it("shows thousands separators (just in case)", () => {
-      const actual = formatNumber("1200", style);
-      const expected = "1,200%";
+    it("returns decimal precision of 2, rounding up tens place", () => {
+      const actual = formatNumber("0.21555", style);
+      const expected = "21.56%";
       expect(actual).toEqual(expected);
     });
   });


### PR DESCRIPTION
fixes #556 

Makes the NDS `formatNumber` behave like `Intl.NumberFormat`.