### PR TITLE
test(index): basic example consumer unit test

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -19,4 +19,5 @@ jobs:
         run: |
           echo "The job was automatically triggered by a ${{ github.event_name }} event."
           npm install
+          npm run build
           npm run test

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "jsx", "vue"],
   moduleDirectories: ["node_modules", "src"],
   testEnvironment: "jest-environment-jsdom",
-  setupFilesAfterEnv: ["./setupTests.js"],
+  setupFilesAfterEnv: ["<rootDir>/setupTests.js"],
+  moduleNameMapper: {
+    "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
+  },
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { Button, formatNumber } from "../dist";
+
+describe("Example consumer import check", () => {
+  it("can import a component and render it without errors", () => {
+    expect(() => render(<Button label="test" />)).not.toThrow();
+  });
+
+  it("can import a formatter function and invoke it without errors", () => {
+    expect(() => {
+      formatNumber("10");
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
fixes #560 

A little something to save us from the embarrassment of breaking all exports by making a mistake in `src/index.js`. It's not a full example consumer, but it's better than nothing.

When I recreate the issue we encountered a week or so ago (`module.exports = componentsList`) in the index file, the unit test catches the problem:

<img width="714" alt="Screen Shot 2022-02-03 at 5 55 07 PM" src="https://user-images.githubusercontent.com/231252/152443315-57d706c8-dc26-44d2-b37a-a8ac9320ac77.png">

