### PR TITLE
fix(DateInput): resolve test warning when rendered as a controlled component

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -59,6 +59,7 @@ const DateInput = ({
         type="date"
         required
         placeholder={props.label}
+        readOnly
         {...props}
       />
     </Input>

--- a/src/DateInput/index.test.js
+++ b/src/DateInput/index.test.js
@@ -1,0 +1,23 @@
+import React, { useState } from "react";
+import { render } from "@testing-library/react";
+import DateInput from "./";
+
+describe("DateInput", () => {
+  it("functions properly as a controlled component", () => {
+    const ControllingComponent = () => {
+      const [value, setValue] = useState("2022-02-05");
+      return (
+        <DateInput
+          label="Date (mm/dd/yyyy)"
+          altInput={true}
+          altFormat={"m/d/Y"}
+          value={value}
+          onChange={setValue}
+        />
+      );
+    }
+    render(
+      <ControllingComponent />
+    );
+  });
+});


### PR DESCRIPTION
I was seeing this test warning in a consumer, but wrote a test here to verify that it's the fault of the NDS component. With the fix, the test passes with no warnings. 

The fix seems a bit odd at first, but within the `DateInput` component, the native `input` element is read-only when the component itself is controlled - we pass it a `value` prop, but not an `onChange`, because flatpickr handles the magic in between. 

![image](https://user-images.githubusercontent.com/4285085/152653077-47d5df77-3184-462f-b70f-44ec52e9bd7f.png)
