### PR TITLE
fix(Input): add margin between error message icon and text

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -14,7 +14,7 @@ const Error = ({ error }) => {
   if (!error) return null;
   return (
     <div className="nds-input-error">
-      <div className="fontSize--s narmi-icon-x-circle" />
+      <div className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
       {error}
     </div>
   );


### PR DESCRIPTION
Adds space to keep us more in line with the style guide 

previous:
<img width="228" alt="image" src="https://user-images.githubusercontent.com/4285085/153277149-1d990904-fd22-4bce-989b-9aa2eca891fd.png">


new:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/4285085/153277095-90c7227f-316a-42dc-b372-9aae8bbae5ce.png">
