### PR TITLE
fix(Dialog): more robustly check if a click event target is not inside the Dialog, before calling dismiss method.

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -69,8 +69,8 @@ const Dialog = ({
   }, [isOpen]);
 
   useEffect(() => {
-    document.addEventListener("click", handleClick);
-    return () => document.removeEventListener("click", handleClick);
+    window.addEventListener("click", handleClick);
+    return () => window.removeEventListener("click", handleClick);
   }, [handleClick]);
 
   const dialogJSX = (

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -62,15 +62,16 @@ const Dialog = ({
     };
   }, [handleKeyDown, checkContentOverflow, isOpen]);
 
-  const handleClick = (event) => {
-    const isClickInside = dialogRef?.current?.contains(event?.target);
+  const handleClick = React.useCallback((event) => {
+    if (!document.body.contains(event.target)) return;
+    const isClickInside = dialogRef.current?.contains(event.target);
     if (isOpen && !isClickInside) onUserDismiss();
-  };
+  }, [isOpen]);
 
   useEffect(() => {
-    window.addEventListener("click", handleClick);
-    return () => window.removeEventListener("click", handleClick);
-  }, [isOpen]);
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [handleClick]);
 
   const dialogJSX = (
     <div className="nds-shim--dark">


### PR DESCRIPTION
An interesting error occurred where if the click event for a target INSIDE the Dialog caused that element to be unmounted, the Dialog would call `onUserDismiss` and subsequently close.

