### PR TITLE
feat(Tabs): add `selectedIndex` prop to enable fully controlled Tabs

### DIFF
--- a/src/Tabs/TabsList.js
+++ b/src/Tabs/TabsList.js
@@ -5,7 +5,7 @@ import TabsContext from "./context";
 const noop = () => {};
 
 const TabsList = ({ children }) => {
-  const { tabIds, setTabIds, changeTabs, selectedIndex, hasPanels } =
+  const { tabIds, setTabIds, changeTabs, currentIndex, hasPanels } =
     useContext(TabsContext);
   const childArray = React.Children.toArray(children);
 
@@ -21,13 +21,13 @@ const TabsList = ({ children }) => {
     let newIndex;
     switch (key) {
       case "ArrowLeft":
-        newIndex = selectedIndex - 1;
+        newIndex = currentIndex - 1;
         if (newIndex >= 0) {
           changeTabs(tabIds[newIndex]);
         }
         break;
       case "ArrowRight":
-        newIndex = selectedIndex + 1;
+        newIndex = currentIndex + 1;
         if (newIndex <= tabIds.length - 1) {
           changeTabs(tabIds[newIndex]);
         }

--- a/src/Tabs/TabsPanel.js
+++ b/src/Tabs/TabsPanel.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import TabsContext from "./context";
 
 const TabsPanel = ({ children, tabId }) => {
-  const { selectedIndex, tabIds, hasPanels, setHasPanels } =
+  const { currentIndex, tabIds, hasPanels, setHasPanels } =
     useContext(TabsContext);
-  const selectedId = tabIds[selectedIndex];
+  const selectedId = tabIds[currentIndex];
 
   useEffect(() => {
     if (!hasPanels) {

--- a/src/Tabs/TabsTab.js
+++ b/src/Tabs/TabsTab.js
@@ -4,9 +4,9 @@ import TabsContext from "./context";
 import cc from "classcat";
 
 const TabsTab = ({ label, tabId }) => {
-  const { selectedIndex, tabIds, hasPanels, changeTabs } =
+  const { currentIndex, tabIds, hasPanels, changeTabs } =
     useContext(TabsContext);
-  const isSelected = tabId === tabIds[selectedIndex];
+  const isSelected = tabId === tabIds[currentIndex];
 
   return (
     <li

--- a/src/Tabs/context.js
+++ b/src/Tabs/context.js
@@ -5,9 +5,8 @@ const TabsContext = createContext({
   tabIds: [],
   setTabIds: () => {},
 
-  // index of tab in source order that is selected
-  selectedIndex: 0,
-  setSelectedIndex: () => {},
+  // index of tab in source order that is currently selected
+  currentIndex: 0,
 
   // only set if there is a TabsPanel present inside Tabs.
   // used to determine when to add aria labelling attributes

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -18,16 +18,23 @@ const noop = () => {};
 const Tabs = ({
   children,
   defaultSelectedIndex = 0,
+  selectedIndex = null,
   onTabChange = noop,
   hasBorder = true,
 }) => {
   const [tabIds, setTabIds] = useState([]);
   const [hasPanels, setHasPanels] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(defaultSelectedIndex);
+  const [currentIndex, setCurrentIndex] = useState(defaultSelectedIndex);
+  const isControlledComponent = selectedIndex !== null;
 
   const changeTabs = (tabId) => {
-    onTabChange(tabId);
-    setSelectedIndex(tabIds.indexOf(tabId));
+    const tabIndex = tabIds.indexOf(tabId);
+
+    onTabChange(tabIndex);
+
+    if (!isControlledComponent) {
+      setCurrentIndex(tabIndex);
+    }
   };
 
   return (
@@ -35,8 +42,7 @@ const Tabs = ({
       value={{
         tabIds,
         setTabIds,
-        selectedIndex,
-        setSelectedIndex,
+        currentIndex: isControlledComponent ? selectedIndex : currentIndex,
         hasPanels,
         setHasPanels,
         changeTabs,
@@ -56,10 +62,16 @@ Tabs.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
-   * Sets default tab selection by index in source order
+   * Sets _default_ tab selection by index in source order
    */
   defaultSelectedIndex: PropTypes.number,
-  /** Callback invoked with `tabId` of the tab as the argument */
+  /**
+   * Sets selected tab by index, making Tabs **fully controlled**.
+   * When using this prop, you must use the `onTabChange` callback
+   * to update the value of this prop to update the selected tab.
+   */
+  selectedIndex: PropTypes.number,
+  /** Callback invoked with the index of the tab the user is moving selection to */
   onTabChange: PropTypes.func,
   /** Shows bottom border when `true` */
   hasBorder: PropTypes.bool,

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Tabs from "./";
 
 const Template = (args) => (
@@ -62,6 +62,40 @@ WithoutBorder.parameters = {
     description: {
       story:
         "You can render tabs without a border via the `hasBorder` prop. This is useful when the element directly below the tabs list has a top border already.",
+    },
+  },
+};
+
+export const FullyControlledTabs = () => {
+  const [selectedTab, setSelectedTab] = useState(1);
+
+  return (
+    <Tabs
+      selectedIndex={selectedTab}
+      onTabChange={(index) => setSelectedTab(index)}
+    >
+      <Tabs.List>
+        <Tabs.Tab label="Apples" tabId="apple" />
+        <Tabs.Tab label="Oranges" tabId="orange" />
+        <Tabs.Tab label="Pineapples" tabId="pineapple" />
+      </Tabs.List>
+      <Tabs.Panel tabId="apple">
+        <div className="padding--all--s">🍎🍎🍎</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="orange">
+        <div className="padding--all--s">🍊🍊🍊</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="pineapple">
+        <div className="padding--all--s">🍍🍍🍍</div>
+      </Tabs.Panel>
+    </Tabs>
+  );
+};
+FullyControlledTabs.parameters = {
+  docs: {
+    description: {
+      story:
+        "Using the `selectedIndex` prop will make Tabs fully controlled. When using this prop, you **must** use the `onTabChange` callback to respond to user events and update the selected tab.",
     },
   },
 };

--- a/src/Tabs/index.test.js
+++ b/src/Tabs/index.test.js
@@ -104,7 +104,7 @@ describe("Tabs", () => {
 
     expect(handleTabChange).not.toHaveBeenCalled();
     fireEvent.click(secondTab);
-    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[1]);
+    expect(handleTabChange).toHaveBeenCalledWith(1);
 
     expect(secondTab).toHaveAttribute("aria-selected", "true");
     [firstTab, thirdTab].forEach((tab) => {
@@ -126,7 +126,7 @@ describe("Tabs", () => {
     // arrow to second tab
     expect(handleTabChange).not.toHaveBeenCalled();
     fireEvent.keyDown(firstTab, { key: "ArrowRight" });
-    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[1]);
+    expect(handleTabChange).toHaveBeenCalledWith(1);
 
     expect(secondTab).toHaveAttribute("aria-selected", "true");
     [firstTab, thirdTab].forEach((tab) => {
@@ -140,7 +140,7 @@ describe("Tabs", () => {
 
     // arrow back to first tab
     fireEvent.keyDown(secondTab, { key: "ArrowLeft" });
-    expect(handleTabChange).toHaveBeenCalledWith(TAB_IDS[0]);
+    expect(handleTabChange).toHaveBeenCalledWith(0);
 
     expect(firstTab).toHaveAttribute("aria-selected", "true");
     [secondTab, thirdTab].forEach((tab) => {
@@ -191,6 +191,46 @@ describe("Tabs", () => {
     [firstTab, secondTab, thirdTab].forEach((tab) => {
       expect(tab).not.toHaveAttribute("role", "tab");
       expect(tab).not.toHaveAttribute("aria-controls");
+    });
+  });
+
+  describe("Controlled Tabs", () => {
+    it("sets initial selected tab correctly when `selectedIndex` is passed", () => {
+      renderTabsWithoutPanels({ selectedIndex: 1 });
+      const { firstTab, secondTab, thirdTab } = getTabs();
+
+      expect(secondTab).toHaveAttribute("aria-selected", "true");
+      [firstTab, thirdTab].forEach((tab) => {
+        expect(tab).toHaveAttribute("aria-selected", "false");
+      });
+    });
+
+    it("does NOT change tab selection in uncontrolled manner when `selectedIndex` is passed", () => {
+      const handleTabChange = jest.fn();
+      renderTabsWithoutPanels({
+        selectedIndex: 2,
+        onTabChange: handleTabChange,
+      });
+      const { firstTab, secondTab, thirdTab } = getTabs();
+
+      // third tab is set as selected initially
+      expect(thirdTab).toHaveAttribute("aria-selected", "true");
+      [firstTab, secondTab].forEach((tab) => {
+        expect(tab).toHaveAttribute("aria-selected", "false");
+      });
+
+      // callback fired as expected, with the new tab index
+      expect(handleTabChange).not.toHaveBeenCalled();
+      fireEvent.click(firstTab);
+      expect(handleTabChange).toHaveBeenCalledWith(0);
+
+      // because this is in controlled mode and our handler doesn't update the
+      // `selectedIndex` prop, the selected tab should NOT update,
+      // leaving the third tab in a selected state
+      expect(thirdTab).toHaveAttribute("aria-selected", "true");
+      [firstTab, secondTab].forEach((tab) => {
+        expect(tab).toHaveAttribute("aria-selected", "false");
+      });
     });
   });
 });


### PR DESCRIPTION
fixes #570 

Adds `selectedIndex` prop that allows consumers to optionally use `Tabs` as a fully controlled component.

<img width="963" alt="Screen Shot 2022-02-24 at 6 55 02 PM" src="https://user-images.githubusercontent.com/231252/155627405-76b63ce6-be02-4ff7-b5e4-74528b397d4c.png">

<img width="1034" alt="Screen Shot 2022-02-24 at 6 53 55 PM" src="https://user-images.githubusercontent.com/231252/155627411-b6b7b53d-8736-49bd-9efd-8fe0a8359f8a.png">

