### PR TITLE
feat(Button): add `startIcon` and `endIcon` props for Button icons

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,6 +16,7 @@ module.exports = {
   ],
   webpackFinal: (config) => {
     config.resolve.alias = {
+      src: path.resolve(__dirname, "../src"),
       dist: path.resolve(__dirname, "../dist"),
       helpers: path.resolve(__dirname, "helpers"),
     };

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/setupTests.js"],
   moduleNameMapper: {
     "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
+    "^src(.*)": "<rootDir>/src$1",
   },
 };

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -1,7 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
-import AsElement from "../util/AsElement";
+import iconSelection from "src/icons/selection.json";
+import AsElement from "src/util/AsElement";
+import Row from "src/Row";
+
+export const VALID_ICON_NAMES = iconSelection.icons.map(
+  (icon) => icon.properties.name
+);
 
 /**
  * Narmi style action buttons.
@@ -15,6 +21,8 @@ import AsElement from "../util/AsElement";
 const Button = ({
   disabled = false,
   kind = "primary",
+  startIcon = null,
+  endIcon = null,
   children,
   label,
   onClick = () => {},
@@ -28,6 +36,12 @@ const Button = ({
   if (!buttonLabel) {
     buttonLabel = children;
   }
+
+  const Icon = ({ name }) => (
+    <div className="alignChild--center--center">
+      <i role="img" aria-label={name} className={`narmi-icon-${name}`} />
+    </div>
+  );
 
   return (
     <AsElement
@@ -47,7 +61,21 @@ const Button = ({
       disabled={isButtonElement && disabled ? true : undefined}
       data-testid="nds-button"
     >
-      <div className="nds-button-content">{buttonLabel}</div>
+      <div className="nds-button-content">
+        <Row gapSize="s" alignItems="center">
+          {startIcon && (
+            <Row.Item shrink>
+              <Icon name={startIcon} />
+            </Row.Item>
+          )}
+          <Row.Item>{buttonLabel}</Row.Item>
+          {endIcon && (
+            <Row.Item shrink>
+              <Icon name={endIcon} />
+            </Row.Item>
+          )}
+        </Row>
+      </div>
     </AsElement>
   );
 };
@@ -63,6 +91,10 @@ Button.propTypes = {
   kind: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
+  /** Name of Narmi icon to place at the start of the label */
+  startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** Name of Narmi icon to place at the end of the label */
+  endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /**
    * **⚠️ DEPRECATED**
    *

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Button from "./";
+import Button, { VALID_ICON_NAMES } from "./";
 
 const Template = (args) => <Button {...args} />;
 
@@ -14,5 +14,7 @@ export default {
   argTypes: {
     onClick: { action: "clicked" },
     children: { control: false },
+    startIcon: { options: ["", ...VALID_ICON_NAMES] },
+    endIcon: { options: ["", ...VALID_ICON_NAMES] },
   },
 };

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -61,4 +61,20 @@ describe("Button", () => {
     const button = getButton();
     expect(button).toHaveClass("nds-button--plain");
   });
+
+  it("renders startIcon when passed", () => {
+    const iconName = "anchor";
+    render(<Button label={LABEL} startIcon={iconName} />);
+    const icon = screen.getByLabelText(iconName);
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass(`narmi-icon-${iconName}`);
+  });
+
+  it("renders endIcon when passed", () => {
+    const iconName = "star";
+    render(<Button label={LABEL} endIcon={iconName} />);
+    const icon = screen.getByLabelText(iconName);
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass(`narmi-icon-${iconName}`);
+  });
 });

--- a/src/icons/Icons.stories.js
+++ b/src/icons/Icons.stories.js
@@ -1,5 +1,5 @@
 import React from "react";
-import IconSelection from "dist/icons/selection.json";
+import iconSelection from "dist/icons/selection.json";
 
 export default {
   title: "Style/Icons",
@@ -9,7 +9,7 @@ export const Icons = () => {
   return (
     <div className="nds-typography">
       <div className="icon-demo">
-        {IconSelection.icons.map((icon) => (
+        {iconSelection.icons.map((icon) => (
           <div className="icon-demo-box">
             <span
               className={`icon-demo-icon narmi-icon-${icon.properties.name}`}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
   resolve: {
     modules: [path.join(__dirname, "src"), "node_modules"],
     alias: {
-      components: path.join(__dirname, "src", "components"),
+      src: path.join(__dirname, "src"),
     },
     extensions: [".js", ".jsx"],
     preferRelative: true,


### PR DESCRIPTION
fixes #551 

Adds support for prepending or appending an icon to `Button` labels by icon name.
Also adds webpack and jest alias for importing `src` directories.

```jsx
<Button kind="plain" label="Edit Preferences" iconEnd="edit" />
```
<img width="200" alt="Screen Shot 2022-02-25 at 2 14 45 PM" src="https://user-images.githubusercontent.com/231252/155780990-eaba7668-aaad-40a4-8623-ecb2de9b0d70.png">

```jsx
<Button kind="secondary" label="Do Business" iconStart="briefcase" />
```
<img width="241" alt="Screen Shot 2022-02-25 at 2 15 31 PM" src="https://user-images.githubusercontent.com/231252/155781504-34576825-c07e-4b32-9dcc-d0757f423bd9.png">

```jsx
<Button label="Dock boat randomly" iconStart="anchor" iconEnd="shuffle" />
```
<img width="342" alt="Screen Shot 2022-02-25 at 2 16 39 PM" src="https://user-images.githubusercontent.com/231252/155782119-693797c3-a821-47bb-bac4-60b2026275eb.png">

