### PR TITLE
fix(TextInput): use CSS grid for multiline autogrow

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -1,3 +1,16 @@
+// Sass placeholder for styles shared between
+// `textarea` and the psuedo-element that enables CSS auto growing
+%shared-multiline-styles {
+  line-height: 1.2;
+  vertical-align: middle;
+  font-weight: 400;
+  line-height: normal;
+  font-family: var(--nds-font-family);
+  border: none;
+  outline: 0;
+  padding: 0;
+}
+
 .nds-input {
   display: flex;
   flex-flow: column nowrap;
@@ -91,23 +104,14 @@
     }
   }
 
-  input,
-  textarea {
+  input {
     color: RGB(var(--nds-grey));
-    line-height: normal;
-    font-weight: 400;
   }
 
   textarea {
-    line-height: 1.2;
-    vertical-align: middle;
+    @extend %shared-multiline-styles;
     color: var(--nds-grey-text);
-    font-family: var(--nds-font-family);
-    border: none;
-    outline: 0;
-    padding: 0;
     width: 100%;
-    overflow: hidden;
     resize: none;
   }
 
@@ -155,5 +159,33 @@
       color: var(--nds-medium-grey);
       font-weight: 400;
     }
+  }
+}
+
+.nds-input-multiline-grid {
+  display: grid;
+
+  &,
+  & > textarea {
+    max-height: 80vh; // avoid growing larger than viewport height
+  }
+
+  // This pseudo-element is an auto height invisible container that
+  // gets filled in with the value of the text area
+  &::after {
+    content: attr(data-textarea-value) " "; // space prevents jumpy updates
+    white-space: pre-wrap; // match textarea default wrapping
+    visibility: hidden;
+
+    // match styling of textarea to keep things aligned
+    @extend %shared-multiline-styles;
+  }
+
+  // The growth of the psuedo-element will expand the grid container.
+  // The textarea will grow with it, as it is placed over the entire grid area
+  &::after,
+  & > textarea {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
   }
 }

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
 import Input from "../Input";
 
@@ -34,14 +34,6 @@ const TextInput = (props) => {
     setInputValue(ref.current.value);
   }
 
-  function handleKeyUp(e) {
-    e.target.style.height = "inherit";
-    e.target.style.height = `${e.target.scrollHeight}px`;
-  }
-  useEffect(
-    () => (multiline ? handleKeyUp({ target: ref.current }) : undefined),
-    []
-  );
   return (
     <Input
       onClick={() => {
@@ -50,17 +42,21 @@ const TextInput = (props) => {
       {...props}
     >
       {multiline ? (
-        <textarea
-          onKeyUp={handleKeyUp}
-          key={"nds-text"}
-          wrap="soft"
-          ref={ref}
-          value={inputValue}
-          onChange={_onChange}
-          onBlur={_onBlur}
-          required
-          {...nativeElementProps}
-        />
+        <div
+          className="nds-input-multiline-grid"
+          data-textarea-value={inputValue}
+        >
+          <textarea
+            key={"nds-text"}
+            wrap="soft"
+            ref={ref}
+            value={inputValue}
+            onChange={_onChange}
+            onBlur={_onBlur}
+            required
+            {...nativeElementProps}
+          />
+        </div>
       ) : (
         <input
           key={"nds-text"}

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -42,6 +42,10 @@ export const Example = () => {
   );
 };
 
+export const MultiLine = () => {
+  return <TextInput multiline />;
+};
+
 export const AsColorInput = () => {
   const [color, setColor] = useState("#915F6D");
   return (


### PR DESCRIPTION
fixes #577 
fixes https://github.com/narmi/banking/issues/16010

Refactors multiline mode to use a CSS-only implementation of auto growing the textarea.

The textarea is wrapped in a 1x1 grid container and placed over the entire grid area. The grid container has a data attribute that we update with the value of the textarea. That data attribute is then used to render content into an invisible pseudo-element which causes the grid container to expand or contract to fit the content.