### PR TITLE
fix(Pagination): accommodate large numbers in page styles; address design feedback

### DIFF
--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -112,7 +112,7 @@ const Pagination = ({
   const pagination = (
     <div className="nds-typography nds-pagination">
       <nav aria-label="pagination">
-        <Row gapSize="xs" alignItems="center" as="ul">
+        <Row gapSize="xxs" alignItems="center" as="ul">
           <Row.Item as="li" shrink>
             <span
               role="button"
@@ -121,12 +121,13 @@ const Pagination = ({
               onClick={handlePrevClick}
               className={cc([
                 "nds-pagination-page",
+                "padding--none",
                 {
                   "nds-pagination-page--disabled": !showPrev,
                 },
               ])}
             >
-              <i role="image" className="narmi-icon-chevron-left"></i>
+              <i role="img" className="narmi-icon-chevron-left fontSize--l"></i>
             </span>
           </Row.Item>
 
@@ -196,12 +197,16 @@ const Pagination = ({
               onClick={handleNextClick}
               className={cc([
                 "nds-pagination-page",
+                "padding--none",
                 {
                   "nds-pagination-page--disabled": !showNext,
                 },
               ])}
             >
-              <i role="image" className="narmi-icon-chevron-right"></i>
+              <i
+                role="img"
+                className="narmi-icon-chevron-right fontSize--l"
+              ></i>
             </span>
           </Row.Item>
         </Row>

--- a/src/Pagination/index.scss
+++ b/src/Pagination/index.scss
@@ -22,15 +22,16 @@
   justify-content: center;
   align-items: center;
   height: 28px;
-  width: 28px;
-  border-radius: 50%;
+  min-width: 28px;
+  border-radius: 28px;
+  padding: 0 var(--space-xs);
 }
 
 .nds-pagination-page {
   cursor: pointer;
 
   &:hover {
-    background-color: var(--bgColor-smokeGrey);
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-20));
   }
 
   &--selected {


### PR DESCRIPTION
fixes #558 

- Fix a11y issue with invalid `role` attributes on icons
- Allow page number circles to expand for larger numbers
- Update hover color to subdued 20% theme primary
- Increase chevron size (per design)

<img width="579" alt="Screen Shot 2022-03-01 at 7 01 15 PM" src="https://user-images.githubusercontent.com/231252/156269420-a428f14e-b17e-4c01-9508-51d464ede99e.png">

