### PR TITLE
docs(Popover): fix overview example

### DIFF
--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -1,9 +1,20 @@
 import React from "react";
 import Popover from "./";
 import Button from "../Button";
-import TextInput from "../TextInput";
 
-const Template = (args) => <Popover {...args} />;
+const Template = (args) => (
+  <div
+    style={{
+      height: "200px",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+    }}
+  >
+    <Popover {...args} />
+  </div>
+);
 
 export const Overview = Template.bind({});
 Overview.args = {
@@ -20,19 +31,4 @@ export default {
   argTypes: {
     children: { control: false },
   },
-  decorators: [
-    (Story) => (
-      <div
-        style={{
-          height: "200px",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
-      >
-        <Story />
-      </div>
-    ),
-  ],
 };


### PR DESCRIPTION
fixes #576 

Fixes code example for `Popover` overview story. The decoarator was obscuring the component props passed through

<img width="667" alt="Screen Shot 2022-03-02 at 3 01 53 PM" src="https://user-images.githubusercontent.com/231252/156440424-3a173535-df23-4cfc-90d8-d80bd5f953b1.png">
