### PR TITLE
fix(Tag): make themable; prevent auto height using inline-block display

### DIFF
--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import Row from "../Row";
 
 const noop = () => {};
 
 /**
  * A rounded rectangle inline label.
- * The user has the option of firing a callback for 'dismissible' Tags.  
+ * The user has the option of firing a callback for 'dismissible' Tags.
  */
 const Tag = ({
   kind = "subdued", // outline, subdued, x-tag (cactus400) #7fbc5b; #7FBC5B oneof
@@ -14,10 +15,21 @@ const Tag = ({
   label,
 }) => {
   return (
-      <div className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}>
-        <span className="nds-tag-content">{label}</span>
-        {kind === 'dismissible' ? <span className="narmi-icon-x" role="button" tabIndex={0} onClick={onDismiss}/>  : '' }
-      </div>
+    <div className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}>
+      <Row alignItems="center" gapSize="xs">
+        <Row.Item shrink>{label}</Row.Item>
+        {kind === "dismissible" && (
+          <Row.Item shrink>
+            <span
+              className="narmi-icon-x"
+              role="button"
+              tabIndex={0}
+              onClick={onDismiss}
+            />
+          </Row.Item>
+        )}
+      </Row>
+    </div>
   );
 };
 

--- a/src/Tag/index.scss
+++ b/src/Tag/index.scss
@@ -1,30 +1,27 @@
 .nds-tag {
-  padding:var(--space-xs);
+  padding: var(--space-xs) var(--space-s);
   border-radius: 16px;
-  display: flex;
-  align-items: baseline;
+  display: inline-block;
   font-size: var(--font-size-xs);
   .narmi-icon-x {
-    color: var(--color-white);
     cursor: pointer;
-    margin-left: 8px;
-    font-size:var(--font-size-xs);
-    position: relative;
-    top: 1px;
+    font-size: var(--font-size-xs);
+    display: inline-block;
+    transform: translateY(1px);
   }
 }
 .nds-tag--dismissible {
   color: var(--color-white);
-  background: var(--color-cactus);
-  border: 1px solid var(--color-cactus);
+  background: var(--theme-tertiary);
+  border: 1px solid var(--theme-tertiary);
 }
 .nds-tag--outline {
-  color: var(--color-pine);
+  color: var(--theme-primary);
   background: transparent;
-  border: 1px solid var(--color-pine);
+  border: 1px solid var(--theme-primary);
 }
 .nds-tag--subdued {
-  color: var(--color-pine);
+  color: var(--theme-primary);
   background: var(--bgColor-smokeGrey);
   border: 1px solid var(--bgColor-smokeGrey);
 }


### PR DESCRIPTION
fixes #601 

- Changes some colors to use `--theme` colors
- Changes `display` property of the Tag to use `inline-block` so as to avoid auto height/width behavior of a flex
- Uses `Row` to eliminate some extra styles