### PR TITLE
fix(helper-classes): fix alignChild base selector to apply to any order

### DIFF
--- a/src/helper-classes/position.scss
+++ b/src/helper-classes/position.scss
@@ -13,7 +13,7 @@ $yAlign: (
   bottom: flex-end,
 );
 
-[class^="alignChild--"] {
+[class*="alignChild--"] {
   display: flex;
 }
 


### PR DESCRIPTION
fixes https://github.com/narmi/banking/issues/16249

### The bug

This works:
```jsx
className="alignChild--center--center otherClass" 
```

This does **NOT** work:
```jsx
className="otherClass alignChild--center--center" 
```

### The fix

The base selector for the `alignChild` helpers were using the _begins with_ operator, which assumes the alignChild class is the first class in the class attribute.

The issue is fixed by using the _includes_ operator in the attribute selector. 