### PR TITLE
fix(helper-classes): add default space axis helpers

### DIFF
--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -50,8 +50,9 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `margin--<side>`           | Adds margin of default space to given _side_ of element          |
 | `margin--<side>--none`     | Removes margin from given _side_ of element                      |
 | `margin--<side>--<amount>` | Adds a margin of a given _amount_ to the given _side_ of element |
+| `margin--<axis>`           | Adds default space margin to x or y _axis_                       |
 | `margin--<axis>--none`     | Removes margin from given _axis_ of element                      |
-| `margin--<axis>--<amount>` | Adds a margin to x or y _axis_ of element for given amount       |
+| `margin--<axis>--<amount>` | Adds margin to x or y _axis_ of element for given amount         |
 
 ### Padding
 
@@ -67,8 +68,9 @@ Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
 | `padding--<side>`           | Adds padding of default space to given _side_ of element          |
 | `padding--<side>--none`     | Removes padding from given _side_ of element                      |
 | `padding--<side>--<amount>` | Adds a padding of a given _amount_ to the given _side_ of element |
+| `margin--<axis>`            | Adds default space padding to x or y _axis_                       |
 | `padding--<axis>--none`     | Removes padding from given _axis_ of element                      |
-| `padding--<axis>--<amount>` | Adds a padding to x or y _axis_ of element for given amount       |
+| `padding--<axis>--<amount>` | Adds padding to x or y _axis_ of element for given amount         |
 
 ## Position
 

--- a/src/helper-classes/spacing.scss
+++ b/src/helper-classes/spacing.scss
@@ -14,6 +14,16 @@ $sizes: xxs, xs, s, m, l, xl;
     #{$property}: 0 !important;
   }
 
+  // default spacing on an axis (`<margin|padding>--<axis>--none`)
+  .#{$property}--x {
+    #{$property}-left: var(--space-default) !important;
+    #{$property}-right: var(--space-default) !important;
+  }
+  .#{$property}--y {
+    #{$property}-top: var(--space-default) !important;
+    #{$property}-bottom: var(--space-default) !important;
+  }
+
   // negate spacing on an axis (`<margin|padding>--<axis>--none`)
   .#{$property}--x--none {
     #{$property}-left: 0 !important;


### PR DESCRIPTION
fixes #596 

Adds spacing axis helpers for default spacing. For example, `padding--x` or `margin--y`.