### PR TITLE
feat(helper-classes): add text flow control helpers

### DIFF
--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -67,3 +67,27 @@
 .fontWeight--default {
   font-weight: var(--font-weight-default) !important;
 }
+
+/**
+* whitespace text flow helpers
+*/
+.whiteSpace--singleLine {
+  white-space: nowrap;
+}
+.whiteSpace--truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+%whiteSpace--truncate--multiLine {
+  // uses experimental, but widely supported
+  // "box" display mode to set content flow
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+}
+@each $clamp in (2, 3, 4) {
+  .whiteSpace--truncate--multiLine--#{$clamp} {
+    @extend %whiteSpace--truncate--multiLine;
+    -webkit-line-clamp: #{$clamp};
+  }
+}

--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -141,6 +141,16 @@ Valid vertical alignments are (`top`, `center`, `bottom`).
 | `fontWeight--bold`     | Sets font weight to `var(--font-weight-bold)`                 |
 | `fontWeight--default`  | Sets font weight to `var(--font-weight-default)` (normal/400) |
 
+### Wrap control and truncation
+
+| Class                                | Description                                           |
+| ------------------------------------ | ----------------------------------------------------- |
+| `whiteSpace--singleLine`             | Prevents flowing text from wrapping                   |
+| `whiteSpace--truncate`               | Force text onto a single line and truncate with '...' |
+| `whiteSpace--truncate--multiline--2` | Clamp text to two lines (truncated with '...')        |
+| `whiteSpace--truncate--multiline--3` | Clamp text to three lines (truncated with '...')      |
+| `whiteSpace--truncate--multiline--4` | Clamp text to four lines (truncated with '...')       |
+
 ## Color
 
 ### Background colors


### PR DESCRIPTION
fixes #539 


Adds helpers to control text wrapping and truncation. Supports multiline truncation via `line-clamp` because we don't support IE.