### PR TITLE
fix(peers): allow React 17 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^16",
-        "react-dom": "^16"
+        "react": "^16 || ^17",
+        "react-dom": "^16 || ^17"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "stats:classes": "node ./scripts/class-adoption.mjs"
   },
   "peerDependencies": {
-    "react": "^16",
-    "react-dom": "^16"
+    "react": "^16 || ^17",
+    "react-dom": "^16 || ^17"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",


### PR DESCRIPTION
Allows consumers to use React 17 as a peer dependency.

Here's NDS running with React 17 to verify it works: https://codesandbox.io/s/competent-leavitt-4e70pf?file=/src/App.js