### PR TITLE
fix(Button): remove uncessary role attr; update docs for anchor buttons

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -45,8 +45,8 @@ const Button = ({
 
   return (
     <AsElement
-      role={isButtonElement ? undefined : "button"}
       elementType={as}
+      tabIndex={0}
       onClick={onClick}
       {...otherProps}
       className={cc([
@@ -81,7 +81,12 @@ const Button = ({
 };
 
 Button.propTypes = {
-  /** The html element to render as the root node of `Button` */
+  /**
+   * The html element to render as the root node of `Button`.
+   *
+   * When rendering as an "a" you **MUST** pass an `href` attribute
+   * for the anchor to be valid.
+   */
   as: PropTypes.oneOf(["a", "button"]),
   /** Renders the button label */
   label: PropTypes.string,

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -13,13 +13,14 @@ describe("Button", () => {
     expect(button).toBeInTheDocument();
     expect(button).not.toHaveAttribute("role", "button"); // should be a button element
     expect(button).toHaveClass("nds-button--primary");
+    expect(button).toHaveClass("resetButton");
   });
 
-  it("has expected classes for primary button as='button'", () => {
+  it("has expected classes for primary button as='a'", () => {
     render(<Button as="a" label={LABEL} />);
     const button = getButton();
     expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute("role", "button");
+    expect(button).not.toHaveClass("resetButton");
   });
 
   it("fires click callback as anchor", () => {


### PR DESCRIPTION
fixes #619 

- removes `role="button"` because it's not helpful anchor elements and redundant for button elements
- update tests accordingly
- add (hopefully) helpful note about making anchor elements valid by including an `href` attribute
- force element to always be focusable via tabIndex