### PR TITLE
fix(Dialog): add focus trap to prevent focusing hidden elements

### DIFF
--- a/VENDOR_LISCENSE.md
+++ b/VENDOR_LISCENSE.md
@@ -86,3 +86,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+## `@charlietango/use-focus-trap`
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Charlie Tango
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.2",
       "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
       "dependencies": {
+        "@charlietango/use-focus-trap": "^1.3.0",
         "classcat": "^5.0.3",
         "flatpickr": "^4.6.9",
         "raf-schd": "^4.0.3",
@@ -1978,6 +1979,15 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@charlietango/use-focus-trap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@charlietango/use-focus-trap/-/use-focus-trap-1.3.0.tgz",
+      "integrity": "sha512-OQNP8HUVwgDb8z/ZyDAukEwoxs2tBuJI3f0p4rPSueZuB5Jp9+w+m9RHCcWL+amAetLXXrE6T+53bp9mYqHblA==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -39920,6 +39930,12 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@charlietango/use-focus-trap": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@charlietango/use-focus-trap/-/use-focus-trap-1.3.0.tgz",
+      "integrity": "sha512-OQNP8HUVwgDb8z/ZyDAukEwoxs2tBuJI3f0p4rPSueZuB5Jp9+w+m9RHCcWL+amAetLXXrE6T+53bp9mYqHblA==",
+      "requires": {}
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "author": "@narmi",
   "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
   "dependencies": {
+    "@charlietango/use-focus-trap": "^1.3.0",
     "classcat": "^5.0.3",
     "flatpickr": "^4.6.9",
     "raf-schd": "^4.0.3",

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import rafSchd from "raf-schd";
+import useFocusTrap from "@charlietango/use-focus-trap";
 import cc from "classcat";
 import useLockBodyScroll from "./useLockBodyScroll";
 
@@ -38,6 +39,7 @@ const Dialog = ({
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
   const shimRef = useRef(null);
+  const focusTrapRef = useFocusTrap(isOpen);
   useLockBodyScroll(isOpen);
 
   // `rafSchd` uses `requestAnimationFrame` to schedule the state update
@@ -76,6 +78,7 @@ const Dialog = ({
         aria-modal="true"
         className="nds-dialog"
         style={{ width }}
+        ref={focusTrapRef}
       >
         <div className={`nds-dialog-header nds-dialog-header--${headerStyle}`}>
           <h4 id="aria-dialog-label">{title}</h4>

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -110,6 +110,29 @@ ScrollingContent.parameters = {
   },
 };
 
+export const FocusManagement = InteractiveTemplate.bind({});
+FocusManagement.args = {
+  title: "Tab through this Dialog",
+  children: (
+    <div>
+      Focus will be trapped to{" "}
+      <a _target="blank" href="http://narmi.com">
+        focusable elements
+      </a>{" "}
+      within the Dialog. Background content is marked as hidden via ARIA
+      attributes.
+    </div>
+  ),
+};
+FocusManagement.parameters = {
+  docs: {
+    description: {
+      story:
+        "For accessibility purposes, only elements within the Dialog can be focused while the Dialog is open.",
+    },
+  },
+};
+
 export default {
   title: "Components/Dialog",
   component: Dialog,


### PR DESCRIPTION
fixes #359 

Adds focus trap to dialog that prevents keyboard navigation to hidden elements behind the dialog as an accessibility fix