### PR TITLE
fix(Button): make secondary hover color consistent in all contexts

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -1,5 +1,7 @@
 .nds-button,
 .nds-button.resetButton {
+  --button-radius: 20px;
+
   display: inline-flex;
   position: relative;
   cursor: pointer;
@@ -10,7 +12,7 @@
   justify-content: center;
   align-items: center;
   min-height: 40px;
-  border-radius: 20px;
+  border-radius: var(--button-radius);
 
   /* mobile buttons have slightly taller padding for ease of tapping */
   @media (max-width: $mobile_size) {
@@ -40,9 +42,21 @@
 
 .nds-button--secondary,
 .nds-button--secondary.resetButton {
+  position: relative;
   color: var(--theme-primary);
   background-color: var(--color-white);
   border: var(--border-size-s) solid var(--theme-primary);
+
+  // adds a white shim behind the button so that the transparent
+  // hover color appears the same regardless of context
+  &::before {
+    content: "";
+    border-radius: var(--button-radius);
+    background-color: var(--color-white);
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+  }
 
   &:hover {
     background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));


### PR DESCRIPTION
fixes #626 

The `kind="secondary"` Button will now mix hover color against white to avoid  the "bleed thru" problem when placed on dark backgrounds:

<img width="285" alt="Screen Shot 2022-03-21 at 4 36 38 PM" src="https://user-images.githubusercontent.com/231252/159360016-5425b518-fb72-4ee5-9d96-a01e89eecc35.png">
<img width="162" alt="Screen Shot 2022-03-21 at 4 36 45 PM" src="https://user-images.githubusercontent.com/231252/159360020-632c77aa-4240-4358-b455-cd1f574556da.png">

