### PR TITLE
feat(helper-classes): add border helpers

### DIFF
--- a/src/helper-classes/border.scss
+++ b/src/helper-classes/border.scss
@@ -1,0 +1,64 @@
+/**
+* Helpers for adding standard borders
+*/
+.border--all {
+  border: var(--border-size-default) solid var(--border-color-default);
+}
+@each $side in (top, right, bottom, left) {
+  .border--#{$side} {
+    border-#{$side}: var(--border-size-default)
+      solid
+      var(--border-color-default);
+  }
+}
+
+/**
+* Helpers for border radius
+*
+* Shorthand values are:
+* top-left | top-right | bottom-right | bottom-left
+*/
+.rounded--all {
+  border-radius: var(--border-radius-default);
+}
+.rounded--top {
+  border-radius: var(--border-radius-default) var(--border-radius-default) 0 0;
+}
+.rounded--right {
+  border-radius: 0 var(--border-radius-default) var(--border-radius-default) 0;
+}
+.rounded--bottom {
+  border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+}
+.rounded--left {
+  border-radius: var(--border-radius-default) 0 0 var(--border-radius-default);
+}
+@each $amount in (s, m, l) {
+  .rounded--all--#{$amount} {
+    border-radius: var(--border-radius-#{$amount});
+  }
+  .rounded--top--#{$amount} {
+    border-radius: var(--border-radius-#{$amount})
+      var(--border-radius-#{$amount})
+      0
+      0;
+  }
+  .rounded--right--#{$amount} {
+    border-radius: 0
+      var(--border-radius-#{$amount})
+      var(--border-radius-#{$amount})
+      0;
+  }
+  .rounded--bottom--#{$amount} {
+    border-radius: 0
+      0
+      var(--border-radius-#{$amount})
+      var(--border-radius-#{$amount});
+  }
+  .rounded--left--#{$amount} {
+    border-radius: var(--border-radius-#{$amount})
+      0
+      0
+      var(--border-radius-#{$amount});
+  }
+}

--- a/src/helper-classes/index.stories.mdx
+++ b/src/helper-classes/index.stories.mdx
@@ -19,17 +19,19 @@ to compose styles without needing to write additional CSS. This can be useful fo
 
 <Preview>
   <Story name="Using Helper Classes">
-    <div className="fontFamily--default padding--all--m bgColor--smokeGrey">
-      <p>
-        Message in a "smokeGrey" padded box with some{" "}
-        <span className="fontWeight--bold fontColor--error">
+    <div className="fontFamily--default">
+      <div className="bgColor--blueGrey padding--all--m rounded--top--l border--bottom">
+        Message in a "blueGrey" padded element with a rounded top and bottom
+        border
+      </div>
+      <div className="bgColor--blueGrey padding--all--m rounded--bottom--l">
+        This element has some{" "}
+        <span className="fontSize--xs fontColor--azul">small azul text</span>{" "}
+        and some{" "}
+        <span className="fontColor--error fontWeight--bold">
           bold error text
         </span>
-        .
-      </p>
-      <p className="fontSize--xs fontColor--azul margin--bottom--xl">
-        extra small azul text with extra large bottom margin
-      </p>
+      </div>
     </div>
   </Story>
 </Preview>
@@ -185,6 +187,24 @@ Useful for loading states, modals, and other designs that require a transparent 
 | -------------- | ----------------------------------- |
 | `scrim--light` | Sets a light transparent background |
 | `scrim--dark`  | Sets a dark transparent background  |
+
+## Border
+
+### Adding borders
+
+| Class            | Description                                   |
+| ---------------- | --------------------------------------------- |
+| `border--all`    | adds standard border to all sides of element  |
+| `border--<side>` | adds standard border to given side of element |
+
+### Adjusting border radius
+
+| Class                       | Description                                                      |
+| --------------------------- | ---------------------------------------------------------------- |
+| `rounded--all`              | adds standard border radius to all sides of element              |
+| `rounded--all--<amount>`    | rounds all corners of element by _amount_ (`s`, `m`, `l`)        |
+| `rounded--<side>`           | rounds the corners of the given _side_                           |
+| `rounded--<side>--<amount>` | rounds the corners of a given _side_ by _amount_ (`s`, `m`, `l`) |
 
 ## Lists
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -63,6 +63,7 @@ $desktop-big: 1440px;
 @import "helper-classes/spacing";
 @import "helper-classes/font";
 @import "helper-classes/background";
+@import "helper-classes/border";
 @import "helper-classes/forms";
 @import "helper-classes/scroll";
 @import "helper-classes/lists";

--- a/tokens/src/border/border.stories.mdx
+++ b/tokens/src/border/border.stories.mdx
@@ -17,3 +17,9 @@ import TokenTable, { toTokenRows } from "helpers/TokenTable";
 <Story name="Size">
   <TokenTable rows={toTokenRows(border, "size")} />
 </Story>
+
+## Border Radius
+
+<Story name="Radius">
+  <TokenTable rows={toTokenRows(border, "radius")} />
+</Story>

--- a/tokens/src/border/radius.json
+++ b/tokens/src/border/radius.json
@@ -1,7 +1,10 @@
 {
   "border": {
     "radius": {
-      "default": { "value": "4px" }
+      "s": { "value": "4px" },
+      "m": { "value": "8px" },
+      "l": { "value": "20px" },
+      "default": { "value": "{border.radius.s.value}" }
     }
   }
 }


### PR DESCRIPTION
fixes #615 

- adds `s` and `l` border radius tokens
- adds border radius token documentation
- adds helper classes for border radius `rounded--<side>(--<amount)`
- adds helper classes for adding borders `border--<side>`
- updates helper classes example in documentation


New token docs:
<img width="1016" alt="Screen Shot 2022-03-21 at 5 49 37 PM" src="https://user-images.githubusercontent.com/231252/159369298-437d5088-3e50-4b26-9fff-44905f9fb817.png">

New helper class docs:
<img width="662" alt="Screen Shot 2022-03-21 at 5 34 42 PM" src="https://user-images.githubusercontent.com/231252/159369340-a1cc41d2-c596-4d2f-9549-6cba8c1a6d7d.png">

Updated helper classes example:
<img width="1041" alt="Screen Shot 2022-03-21 at 5 46 34 PM" src="https://user-images.githubusercontent.com/231252/159369364-7b8caa93-d706-4aac-816c-b07cb383fafc.png">


