### PR TITLE
fix(Popover): add focus trap for a11y

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useLayer } from "react-laag";
+import useFocusTrap from "@charlietango/use-focus-trap";
 
 /**
  * Generic Popover component. Renders a floating element that can contain any content,
@@ -23,6 +24,7 @@ const Popover = ({
   matchTriggerWidth = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
+  const focusTrapRef = useFocusTrap(isOpen);
 
   const closePopover = () => {
     setIsOpen(false);
@@ -89,10 +91,12 @@ const Popover = ({
           {isOpen && (
             <div
               {...layerProps}
-              className="nds-typography nds-popover round--all bgColor--white"
+              className="nds-typography nds-popover rounded--all bgColor--white"
               style={layerStyle}
             >
-              {content}
+              <div ref={focusTrapRef} tabIndex={-1}>
+                {content}
+              </div>
             </div>
           )}
         </>

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -25,6 +25,23 @@ Overview.argTypes = {
   content: { control: false },
 };
 
+export const FocusManagement = Template.bind({});
+FocusManagement.args = {
+  children: <Button type="secondary">Click to show Popover</Button>,
+  content: (
+    <div className="padding--all">
+      Focus will be trapped to{" "}
+      <a _target="blank" href="http://narmi.com" className="fontWeight--bold">
+        focusable
+      </a>{" "}
+      <a _target="blank" href="http://narmi.com" className="fontWeight--bold">
+        elements
+      </a>{" "}
+      within the Popover while it is open.
+    </div>
+  ),
+};
+
 export default {
   title: "Components/Popover",
   component: Popover,


### PR DESCRIPTION
fixes #632 

Accessibility enhancement.
When the popover is open, focus is "trapped" in the popover content. This makes it easier to keyboard navigate the contents of a popover.