### PR TITLE
feat(DropdownTrigger): add component for triggering popovers

### DIFF
--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -1,0 +1,96 @@
+import React from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+
+/**
+ * Generic trigger button for dropdowns. `DropdownTrigger` can be composed with
+ * other components like `Popover` to create a wide range of dropdown, popover, and menu components.
+ *
+ * The entire clickable area is a `button` element to ensure dropdown triggers are accessible.
+ *
+ *  **Additional props will be spread on the `button` element.**
+ */
+const DropdownTrigger = React.forwardRef(
+  (
+    {
+      isOpen = false,
+      showOpenIndicator = true,
+      labelText,
+      labelProps,
+      displayValue,
+      errorText,
+      minWidth = "auto",
+      ...otherProps
+    },
+    ref
+  ) => (
+    <>
+      <div className="nds-dropdownTrigger" style={{ minWidth }}>
+        <button
+          ref={ref}
+          data-testid="dropdownTriggerButton"
+          className={cc([
+            "nds-dropdownTrigger-button button--reset padding--x--s",
+            "bgColor--white rounded--all",
+            {
+              "nds-dropdownTrigger-button--hasValue": Boolean(displayValue),
+              "nds-dropdownTrigger-button--hasError": Boolean(errorText),
+            },
+          ])}
+          aria-expanded={isOpen ? "true" : "false"}
+          {...otherProps}
+        >
+          {labelText && (
+            <label className="nds-dropdownTrigger-label" {...labelProps}>
+              {labelText}
+            </label>
+          )}
+          {displayValue && <span>{displayValue}</span>}
+          {showOpenIndicator && (
+            <span
+              role="img"
+              aria-label={isOpen ? "popup open" : "popup closed"}
+              className={cc([
+                "nds-dropdownTrigger-chevron fontSize--l fontColor--secondary",
+                `narmi-icon-chevron-${isOpen ? "up" : "down"}`,
+              ])}
+            />
+          )}
+        </button>
+      </div>
+      {errorText && (
+        <div className="nds-dropdownTrigger-error fontColor--error">
+          <span role="img" className="narmi-icon-x-circle fontSize--s" />
+          <span className="padding--left--xxs fontColor--error fontSize--xs">
+            {errorText}
+          </span>
+        </div>
+      )}
+    </>
+  )
+);
+
+DropdownTrigger.propTypes = {
+  /** Set this to `true` when the associated popup is open */
+  isOpen: PropTypes.bool,
+  /** Set to `false` to hide the chevron icon indicating open state */
+  showOpenIndicator: PropTypes.bool,
+  /** Text of `label` element */
+  labelText: PropTypes.string,
+  /** Props to spread onto the `label` element */
+  labelProps: PropTypes.object,
+  /**
+   * Renders a string or node as the value displayed in the `DropdownTrigger`
+   * Usually, this represents the name of a selected option
+   */
+  displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** Error message. When this prop is passed, an error state is dsiplayed */
+  errorText: PropTypes.string,
+  /**
+   * Sets a mimimum width.
+   * Use the full CSS value with the unit (e.g. "400px")
+   */
+  minWidth: PropTypes.string,
+};
+
+export default DropdownTrigger;

--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -1,0 +1,51 @@
+.nds-dropdownTrigger {
+  position: relative;
+  height: 48px;
+  display: flex;
+  align-items: center;
+}
+.nds-dropdownTrigger-button {
+  height: 100%;
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border-color-default) !important;
+
+  &:focus {
+    outline: none;
+    border-color: var(--theme-primary) !important;
+  }
+
+  &--hasError {
+    border-color: var(--color-errorDark) !important;
+  }
+}
+
+.nds-dropdownTrigger-label {
+  color: var(--color-mediumGrey);
+}
+
+// float the label to top like a text input
+// when there's a value to display
+.nds-dropdownTrigger-button--hasValue {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  & .nds-dropdownTrigger-label {
+    font-size: var(--font-size-xs);
+  }
+}
+
+.nds-dropdownTrigger-chevron {
+  position: absolute;
+  right: var(--space-s);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.nds-dropdownTrigger-error {
+  .narmi-icon-x-circle::before {
+    position: relative;
+    top: 1px;
+  }
+}

--- a/src/DropdownTrigger/index.stories.js
+++ b/src/DropdownTrigger/index.stories.js
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import DropdownTrigger from "./";
+import Popover from "../Popover";
+import RadioButtons from "../RadioButtons";
+
+const Template = (args) => <DropdownTrigger {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  labelText: "State",
+};
+
+export const LabelOnly = () => <DropdownTrigger labelText="Filters (6)" />;
+LabelOnly.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `displayValue` can be omitted if you only need to render a label",
+    },
+  },
+};
+
+export const ErrorState = () => (
+  <DropdownTrigger
+    labelText="Account"
+    displayValue="Checking (1234)"
+    errorText="This account is not eligible"
+  />
+);
+ErrorState.parameters = {
+  docs: {
+    description: {
+      story: "Pass `errorText` to enable the error state of `DropdownTrigger`",
+    },
+  },
+};
+
+export const ComposingWithPopover = () => {
+  const [fondueType, setFondueType] = useState("");
+
+  const popoverContent = (
+    <div className="padding--top padding--x">
+      <RadioButtons
+        name="fondueType"
+        options={{
+          Chocolate: "Chocolate",
+          Cheese: "Cheese",
+        }}
+        onChange={({ target }) => {
+          setFondueType(target.value);
+        }}
+      />
+    </div>
+  );
+
+  return (
+    <>
+      <Popover content={popoverContent} matchTriggerWidth>
+        <DropdownTrigger
+          labelText="Fondue Preference"
+          displayValue={fondueType}
+          minWidth="340px"
+        />
+      </Popover>
+    </>
+  );
+};
+ComposingWithPopover.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `DropdownTrigger` component was designed to be composed with `Popover` or any other modal UI element. In this example, `DropdownTrigger` is used as a triggering element for the `Popover` component.",
+    },
+  },
+};
+
+export default {
+  title: "Components/DropdownTrigger",
+  component: DropdownTrigger,
+  argTypes: {
+    displayValue: {
+      options: ["", "NY", "CA"],
+    },
+  },
+};

--- a/src/DropdownTrigger/index.test.js
+++ b/src/DropdownTrigger/index.test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, prettyDOM } from "@testing-library/react";
+import DropdownTrigger from "./";
+
+describe("DropdownTrigger", () => {
+  it("Renders with default props as expected", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeInTheDocument();
+  });
+
+  it("Does NOT show label when `labelText` is not passed", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("Moves label into floating position when a displayValue is passed", () => {
+    render(<DropdownTrigger labelText="Account" displayValue="Value" />);
+    expect(screen.getByTestId("dropdownTriggerButton")).toHaveClass(
+      "nds-dropdownTrigger-button--hasValue"
+    );
+  });
+
+  it("Does NOT show open indicator when showOpenIndicator is set to false", () => {
+    render(<DropdownTrigger labelText="Account" showOpenIndicator={false} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("Shows correct label and icon in closed state", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.queryByRole("img")).toHaveClass("narmi-icon-chevron-down");
+  });
+
+  it("Shows correct label and icon in open state", () => {
+    render(<DropdownTrigger labelText="Account" isOpen />);
+    expect(screen.queryByRole("img")).toHaveClass("narmi-icon-chevron-up");
+  });
+
+  it("Renders error state correctly when `errorText` is passed", () => {
+    render(<DropdownTrigger labelText="Account" errorText="You did an oops" />);
+    expect(screen.getByText("You did an oops")).toBeInTheDocument();
+  });
+
+  it("spreads labelProps on label element correctly", () => {
+    render(
+      <DropdownTrigger
+        labelText="Account"
+        labelProps={{
+          htmlFor: "somefield",
+        }}
+      />
+    );
+    expect(screen.getByText("Account")).toHaveAttribute("for", "somefield");
+  });
+
+  it("spreads extra props onto the button element", () => {
+    render(<DropdownTrigger labelText="Account" aria-haspopup="true" />);
+    expect(screen.getByTestId("dropdownTriggerButton")).toHaveAttribute(
+      "aria-haspopup",
+      "true"
+    );
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Checkbox from "./Checkbox";
 import DateInput from "./DateInput";
 import Dialog from "./Dialog";
 import Dropdown from "./Dropdown";
+import DropdownTrigger from "./DropdownTrigger";
 import Input from "./Input";
 import LoadingShim from "./LoadingShim";
 import LoadingSkeleton from "./LoadingSkeleton";
@@ -31,6 +32,7 @@ export {
   DateInput,
   Dialog,
   Dropdown,
+  DropdownTrigger,
   Input,
   LoadingShim,
   LoadingSkeleton,

--- a/src/index.scss
+++ b/src/index.scss
@@ -49,6 +49,7 @@ $desktop-big: 1440px;
 @import "Modal/";
 @import "Checkbox/";
 @import "Dropdown/";
+@import "DropdownTrigger/";
 @import "Tooltip/";
 @import "Row/";
 @import "Pagination/";


### PR DESCRIPTION
relates to:
- #630 

Part one of accessibility fixes for our dropdowns.

This component is intended to be used as a trigger button for menus, multiselects, selects, and other popovers. It mostly mimics the behavior of a `TextInput` visually, but as a button element.

<img width="1059" alt="Screen Shot 2022-03-23 at 9 48 04 PM" src="https://user-images.githubusercontent.com/231252/159826603-04479159-add4-41ec-9eb6-e33a3ced1447.png">
<img width="1043" alt="Screen Shot 2022-03-23 at 9 48 13 PM" src="https://user-images.githubusercontent.com/231252/159826605-43938db2-905d-4f5e-86c0-a8ae340311b6.png">
<img width="1046" alt="Screen Shot 2022-03-23 at 9 48 34 PM" src="https://user-images.githubusercontent.com/231252/159826607-13fbdd70-91c3-492a-9a64-97b543a0c75c.png">

