### PR TITLE
feat(Select): add `Select` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@charlietango/use-focus-trap": "^1.3.0",
         "classcat": "^5.0.3",
+        "downshift": "^6.1.7",
         "flatpickr": "^4.6.9",
         "raf-schd": "^4.0.3",
         "react-laag": "^2.0.3"
@@ -1912,7 +1913,6 @@
       "version": "7.16.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
       "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -14879,8 +14879,7 @@
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
-      "dev": true
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -16664,7 +16663,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
       "integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.14.8",
         "compute-scroll-into-view": "^1.0.17",
@@ -31779,8 +31777,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-laag": {
       "version": "2.0.3",
@@ -32250,8 +32247,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -35921,8 +35917,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -39875,7 +39870,6 @@
       "version": "7.16.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
       "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -50087,8 +50081,7 @@
     "compute-scroll-into-view": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
-      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==",
-      "dev": true
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -51518,7 +51511,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
       "integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.14.8",
         "compute-scroll-into-view": "^1.0.17",
@@ -63004,8 +62996,7 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "react-laag": {
       "version": "2.0.3",
@@ -63377,8 +63368,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -66341,8 +66331,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "@charlietango/use-focus-trap": "^1.3.0",
     "classcat": "^5.0.3",
+    "downshift": "^6.1.7",
     "flatpickr": "^4.6.9",
     "raf-schd": "^4.0.3",
     "react-laag": "^2.0.3"

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -45,9 +45,12 @@ const DropdownMenu = ({ open, onClose, children, ...rest }) => {
 };
 
 /**
- * Combobox UI for filling an `input` value from a list of options
+ * **⚠️ DEPRECATED ⚠️**
+ *
+ * This component will be removed in a future release.
+ * Please use `Select` instead
  */
-const Dropdown = ({error, ...props}) => {
+const Dropdown = ({ error, ...props }) => {
   const [open, setOpen] = useState(props.defaultOpen);
   const [value, setValue] = useState(props.defaultValue || "");
 

--- a/src/Select/SelectAction.js
+++ b/src/Select/SelectAction.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const SelectAction = ({ onSelect, children }) => <>{children}</>;
+
+SelectAction.propTypes = {
+  /** Side effect to run on selection */
+  onSelect: PropTypes.func.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default SelectAction;

--- a/src/Select/SelectItem.js
+++ b/src/Select/SelectItem.js
@@ -1,0 +1,21 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const SelectItem = ({ value, children }) => <>{children}</>;
+
+SelectItem.propTypes = {
+  /**
+   * String representation of the option.
+   *
+   * This value is also used as a typeahead; if a user types "n" while
+   * the Select is open, highlight will move to the first item with a
+   * value starting with `n`.
+   */
+  value: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default SelectItem;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,0 +1,156 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useSelect } from "downshift";
+import cc from "classcat";
+import DropdownTrigger from "../DropdownTrigger";
+
+const noop = () => {};
+
+/**
+ * @param {Object} item a Select.Item or Select.Action component
+ * @returns {Boolean} true if the item is a Select.Action
+ */
+const isAction = (item) => {
+  let result = false;
+  if (item) {
+    result = item.type.name === "SelectAction";
+  }
+  return result;
+};
+
+/**
+ * Sets the selected value in the DropdownTrigger.
+ * A Select.Action should _not_ display as selected in the button.
+ *
+ * @param {Object} item the currently selected Select.Item or Select.Action
+ * @returns {String|Node} The value to display in the trigger button
+ */
+const getSelectedItemDsiplay = (item) => {
+  let result = "";
+  if (item && !isAction(item)) {
+    result = item.props.children;
+  }
+  return result;
+};
+
+/**
+ * Accessible custom select control for giving users the ability to select one option from a list of options.
+ * `Select` supports the ability to pass in a `<Select.Action>` that acts as an option that only triggers a side effect.
+ */
+const Select = ({
+  label,
+  children,
+  onChange = noop,
+  defaultValue,
+  defaultOpen = false,
+}) => {
+  // only include valid Select children in options items
+  const items = React.Children.toArray(children).filter((child) =>
+    ["SelectItem", "SelectAction"].includes(child.type.name)
+  );
+
+  const defaultSelectedItem = items
+    .filter((item) => !isAction(item))
+    .filter((item) => item.props.value === defaultValue)
+    .pop();
+
+  const {
+    isOpen,
+    selectedItem,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    highlightedIndex,
+    getItemProps,
+  } = useSelect({
+    items,
+    defaultSelectedItem,
+    initialIsOpen: defaultOpen,
+    itemToString: (item) => item.props.value || item.props.children, // typeahead string
+    onSelectedItemChange: ({ selectedItem }) => {
+      // for Select.Action items, we only fire the side effect
+      if (isAction(selectedItem)) {
+        selectedItem.props.onSelect();
+      } else {
+        onChange(selectedItem);
+      }
+    },
+  });
+
+  return (
+    <div className="nds-select">
+      <DropdownTrigger
+        isOpen={isOpen}
+        labelText={label}
+        displayValue={getSelectedItemDsiplay(selectedItem)}
+        labelProps={{ ...getLabelProps() }}
+        {...getToggleButtonProps()}
+      />
+      <ul
+        className={cc([
+          "nds-select-list",
+          "list--reset bgColor--white rounded--all border--all",
+          { "nds-select-list--active": isOpen },
+        ])}
+        {...getMenuProps()}
+      >
+        {isOpen &&
+          items.map((item, index) => (
+            <li
+              key={`${item}${index}`}
+              className={cc([
+                "nds-select-item",
+                "alignChild--left--center padding--x--s padding--y--xs",
+                {
+                  "nds-select-item--highlighted": highlightedIndex === index,
+                  "rounded--top": index === 0,
+                  "rounded--bottom": index === items.length - 1,
+                },
+              ])}
+              {...getItemProps({ item, index })}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+};
+
+Select.propTypes = {
+  /** Label for the select control */
+  label: PropTypes.string.isRequired,
+  /** Change callback. Called with value string from the selected item */
+  onChange: PropTypes.func,
+  /**
+   * Use to set a default selection by passing the `value` prop
+   * of one of the `<Select.Item>` children.
+   */
+  defaultValue: PropTypes.string,
+  /** Open the dropdown on rendder if `true` */
+  defaultOpen: PropTypes.bool,
+};
+
+const SelectItem = ({ value, children }) => <>{children}</>;
+
+SelectItem.propTypes = {
+  /**
+   * String representation of the option.
+   *
+   * This value is also used as a typeahead; if a user types "n" while
+   * the Select is open, highlight will move to the first item with a
+   * value starting with `n`.
+   */
+  value: PropTypes.string.isRequired,
+};
+
+const SelectAction = ({ onSelect, children }) => <>{children}</>;
+
+SelectAction.propTypes = {
+  /** Side effect to run on selection */
+  onSelect: PropTypes.func.isRequired,
+};
+
+Select.Item = SelectItem;
+Select.Action = SelectAction;
+export default Select;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -3,6 +3,10 @@ import PropTypes from "prop-types";
 import { useSelect } from "downshift";
 import cc from "classcat";
 import DropdownTrigger from "../DropdownTrigger";
+import SelectItem from "./SelectItem";
+import SelectAction from "./SelectAction";
+
+// TODO: test in a modal
 
 const noop = () => {};
 
@@ -10,7 +14,7 @@ const noop = () => {};
  * @param {Object} item a Select.Item or Select.Action component
  * @returns {Boolean} true if the item is a Select.Action
  */
-const isAction = (item) => {
+export const isAction = (item) => {
   let result = false;
   if (item) {
     result = item.type.name === "SelectAction";
@@ -25,7 +29,7 @@ const isAction = (item) => {
  * @param {Object} item the currently selected Select.Item or Select.Action
  * @returns {String|Node} The value to display in the trigger button
  */
-const getSelectedItemDsiplay = (item) => {
+export const getSelectedItemDisplay = (item) => {
   let result = "";
   if (item && !isAction(item)) {
     result = item.props.children;
@@ -35,7 +39,8 @@ const getSelectedItemDsiplay = (item) => {
 
 /**
  * Accessible custom select control for giving users the ability to select one option from a list of options.
- * `Select` supports the ability to pass in a `<Select.Action>` that acts as an option that only triggers a side effect.
+ * `Select` also supports the ability to pass in a `<Select.Action>` that acts as an option that only triggers a side effect.
+ * Typeahead is enabled based on the `value` prop of `<Select.Item>` elements passed in.
  */
 const Select = ({
   label,
@@ -43,6 +48,7 @@ const Select = ({
   onChange = noop,
   defaultValue,
   defaultOpen = false,
+  errorText,
 }) => {
   // only include valid Select children in options items
   const items = React.Children.toArray(children).filter((child) =>
@@ -50,10 +56,11 @@ const Select = ({
   );
 
   const defaultSelectedItem = items
-    .filter((item) => !isAction(item))
+    .filter((item) => !isAction(item)) // action items may not be selected by default
     .filter((item) => item.props.value === defaultValue)
     .pop();
 
+  /** @see https://www.downshift-js.com/use-select */
   const {
     isOpen,
     selectedItem,
@@ -72,7 +79,7 @@ const Select = ({
       if (isAction(selectedItem)) {
         selectedItem.props.onSelect();
       } else {
-        onChange(selectedItem);
+        onChange(selectedItem.props.value);
       }
     },
   });
@@ -82,8 +89,9 @@ const Select = ({
       <DropdownTrigger
         isOpen={isOpen}
         labelText={label}
-        displayValue={getSelectedItemDsiplay(selectedItem)}
+        displayValue={getSelectedItemDisplay(selectedItem)}
         labelProps={{ ...getLabelProps() }}
+        errorText={errorText}
         {...getToggleButtonProps()}
       />
       <ul
@@ -127,28 +135,13 @@ Select.propTypes = {
    * of one of the `<Select.Item>` children.
    */
   defaultValue: PropTypes.string,
-  /** Open the dropdown on rendder if `true` */
+  /** Open the dropdown on render if `true` */
   defaultOpen: PropTypes.bool,
-};
-
-const SelectItem = ({ value, children }) => <>{children}</>;
-
-SelectItem.propTypes = {
   /**
-   * String representation of the option.
-   *
-   * This value is also used as a typeahead; if a user types "n" while
-   * the Select is open, highlight will move to the first item with a
-   * value starting with `n`.
+   * Error message.
+   * When passed, this will cause the trigger to render in error state.
    */
-  value: PropTypes.string.isRequired,
-};
-
-const SelectAction = ({ onSelect, children }) => <>{children}</>;
-
-SelectAction.propTypes = {
-  /** Side effect to run on selection */
-  onSelect: PropTypes.func.isRequired,
+  errorText: PropTypes.string,
 };
 
 Select.Item = SelectItem;

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -1,0 +1,30 @@
+// make sure we don't need to flex center the outer wrapper??
+.nds-select {
+  position: relative;
+}
+
+.nds-select-list {
+  visibility: hidden;
+  position: absolute;
+  z-index: 3;
+  border-color: var(--theme-primary) !important;
+  top: 0;
+  right: 0;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.nds-select-list--active {
+  visibility: visible;
+}
+
+.nds-select-item {
+  cursor: pointer;
+  &:hover,
+  &--highlighted {
+    background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+  }
+}

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -1,4 +1,3 @@
-// make sure we don't need to flex center the outer wrapper??
 .nds-select {
   position: relative;
 }

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -1,21 +1,51 @@
-import React from "react";
+import React, { useState } from "react";
 import Select from "./";
+import SelectItem from "./SelectItem";
+import SelectAction from "./SelectAction";
 
 const Template = (args) => <Select {...args} />;
+
+const children = [
+  <Select.Item value="coffee">
+    <span className="narmi-icon-coffee padding--right--xs" /> Coffee
+  </Select.Item>,
+  <Select.Item value="film">
+    <span className="narmi-icon-film padding--right--xs" /> Film
+  </Select.Item>,
+  <Select.Item value="truck">
+    <span className="narmi-icon-truck padding--right--xs" /> Truck
+  </Select.Item>,
+];
 
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Favorite icon",
+  children,
+};
+
+export const DefaultSelection = Template.bind({});
+DefaultSelection.args = {
+  label: "Favorite icon",
+  children,
+  defaultValue: "film",
+};
+
+export const ErrorState = Template.bind({});
+ErrorState.args = {
+  label: "Account",
   children: [
-    <Select.Item value="coffee">
-      <span className="narmi-icon-coffee padding--right--xs" /> Coffee
-    </Select.Item>,
-    <Select.Item value="film">
-      <span className="narmi-icon-film padding--right--xs" /> Film
-    </Select.Item>,
-    <Select.Item value="truck">
-      <span className="narmi-icon-truck padding--right--xs" /> Truck
-    </Select.Item>,
+    <Select.Item value="checking1234">Checking (1234)</Select.Item>,
+    <Select.Item value="checkint4321">Checking (4321)</Select.Item>,
+  ],
+  defaultValue: "checking1234",
+  errorText: "Checking (1234) is not eligible",
+};
+
+export const WithAction = Template.bind({});
+WithAction.args = {
+  label: "Account",
+  children: [
+    ...children,
     <Select.Action
       onSelect={() => {
         alert("side effect triggered - no option selected");
@@ -27,14 +57,49 @@ Overview.args = {
     </Select.Action>,
   ],
 };
+WithAction.parameters = {
+  docs: {
+    description: {
+      story:
+        "If you need an option that triggers a side effect, use a `<Select.Action>` child. An action item will not update selection and con not be selected by default.",
+    },
+  },
+};
 
-// using as a form element
-// a `hidden` input can work natively in a `form`, or as a bridge to a form library of your choice.
-// state + setting hidden input value
+export const InAForm = () => {
+  const [inputValue, setInputValue] = useState("");
+  return (
+    <>
+      <div className="margin--bottom">
+        <input type="text" name="account" value={inputValue} readOnly />
+        <p className="fontSize--xs">
+          (
+          <i>
+            Typically this would be a <code>hidden</code> input.
+          </i>
+          )
+        </p>
+      </div>
+      <Select label="Account" onChange={setInputValue}>
+        <Select.Item value="checking1234">Checking (1234)</Select.Item>
+        <Select.Item value="savings4321">Savings (4321)</Select.Item>
+      </Select>
+    </>
+  );
+};
+InAForm.parameters = {
+  docs: {
+    description: {
+      story:
+        "A hidden input works natively in a `form`, or as a bridge to a form management library of your choice.",
+    },
+  },
+};
 
 export default {
   title: "Components/Select",
   component: Select,
+  subcomponents: { SelectItem, SelectAction },
   argTypes: {
     children: { control: false },
   },

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -1,0 +1,41 @@
+import React from "react";
+import Select from "./";
+
+const Template = (args) => <Select {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  label: "Favorite icon",
+  children: [
+    <Select.Item value="coffee">
+      <span className="narmi-icon-coffee padding--right--xs" /> Coffee
+    </Select.Item>,
+    <Select.Item value="film">
+      <span className="narmi-icon-film padding--right--xs" /> Film
+    </Select.Item>,
+    <Select.Item value="truck">
+      <span className="narmi-icon-truck padding--right--xs" /> Truck
+    </Select.Item>,
+    <Select.Action
+      onSelect={() => {
+        alert("side effect triggered - no option selected");
+      }}
+    >
+      <span className="fontColor--pine fontWeight--bold">
+        <span className="narmi-icon-plus padding--right--xs" /> Add new icon
+      </span>
+    </Select.Action>,
+  ],
+};
+
+// using as a form element
+// a `hidden` input can work natively in a `form`, or as a bridge to a form library of your choice.
+// state + setting hidden input value
+
+export default {
+  title: "Components/Select",
+  component: Select,
+  argTypes: {
+    children: { control: false },
+  },
+};

--- a/src/Select/index.test.js
+++ b/src/Select/index.test.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, prettyDOM } from "@testing-library/react";
+import DropdownTrigger from "./";
+
+describe("DropdownTrigger", () => {
+  it("Renders with default props as expected", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeInTheDocument();
+  });
+
+  it("Does NOT show label when `labelText` is not passed", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.getByText("Account")).toBeInTheDocument();
+  });
+
+  it("Moves label into floating position when a displayValue is passed", () => {
+    render(<DropdownTrigger labelText="Account" displayValue="Value" />);
+    expect(screen.getByTestId("dropdownTriggerButton")).toHaveClass(
+      "nds-dropdownTrigger-button--hasValue"
+    );
+  });
+
+  it("Does NOT show open indicator when showOpenIndicator is set to false", () => {
+    render(<DropdownTrigger labelText="Account" showOpenIndicator={false} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("Shows correct label and icon in closed state", () => {
+    render(<DropdownTrigger labelText="Account" />);
+    expect(screen.queryByRole("img")).toHaveClass("narmi-icon-chevron-down");
+  });
+
+  it("Shows correct label and icon in open state", () => {
+    render(<DropdownTrigger labelText="Account" isOpen />);
+    expect(screen.queryByRole("img")).toHaveClass("narmi-icon-chevron-up");
+  });
+
+  it("Renders error state correctly when `errorText` is passed", () => {
+    render(<DropdownTrigger labelText="Account" errorText="You did an oops" />);
+    expect(screen.getByText("You did an oops")).toBeInTheDocument();
+  });
+
+  it("spreads labelProps on label element correctly", () => {
+    render(
+      <DropdownTrigger
+        labelText="Account"
+        labelProps={{
+          htmlFor: "somefield",
+        }}
+      />
+    );
+    expect(screen.getByText("Account")).toHaveAttribute("for", "somefield");
+  });
+
+  it("spreads extra props onto the button element", () => {
+    render(<DropdownTrigger labelText="Account" aria-haspopup="true" />);
+    expect(screen.getByTestId("dropdownTriggerButton")).toHaveAttribute(
+      "aria-haspopup",
+      "true"
+    );
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import PlainButton from "./PlainButton";
 import Popover from "./Popover";
 import RadioButtons from "./RadioButtons";
 import Row from "./Row";
+import Select from "./Select";
 import SeparatorList from "./SeparatorList";
 import Tabs from "./Tabs";
 import Tag from "./Tag";
@@ -42,6 +43,7 @@ export {
   Popover,
   RadioButtons,
   Row,
+  Select,
   SeparatorList,
   Tabs,
   Tag,

--- a/src/index.scss
+++ b/src/index.scss
@@ -53,6 +53,7 @@ $desktop-big: 1440px;
 @import "Tooltip/";
 @import "Row/";
 @import "Pagination/";
+@import "Select/";
 @import "SeparatorList/";
 @import "Popover/";
 @import "Toggle/";


### PR DESCRIPTION
fixes #630 

Add `Select` component and deprecates `Dropdown`. We are going the route toward dropdowns tailored to their specific needs rather than a general purpose component which can not easily be made accessible.

This uses our `DropdownTrigger` in combination with the `downshift` library for managing a11y attributes, keyboard events, and focus.

----

## 🔍 Reviewing this PR

I recommend getting context for these changes by running the branch locally:

```sh
git checkout -t origin/feat/630-select-component
npm install
npm run build
npm run storybook
```

## Example
![Mar-24-2022 16-01-21](https://user-images.githubusercontent.com/231252/160000697-235ff523-99a6-4191-a856-bc7be5f4dc17.gif)
