### PR TITLE
docs(storybook): add props tables for subcomponents

### DIFF
--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+import AsElement from "../util/AsElement";
+
+/**
+ * Child component of `Row`.
+ * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
+ */
+const RowItem = ({ shrink = false, as = "div", children }) => (
+  <AsElement
+    elementType={as}
+    className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}
+  >
+    {children}
+  </AsElement>
+);
+
+RowItem.propTypes = {
+  /**
+   * When `true`, the row item shrinks to content size of its children.
+   * Otherwise, the item will expand to fill remaining space in the row.
+   */
+  shrink: PropTypes.bool,
+  /** The html element to render as the root node of `Row` */
+  as: PropTypes.oneOf(["div", "li"]),
+};
+
+export default RowItem;

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import cc from "classcat";
 import AsElement from "../util/AsElement";
+import RowItem from "./RowItem";
 
 /**
  * builds style object for `Row`
@@ -54,29 +54,6 @@ Row.propTypes = {
   justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "ul"]),
-};
-
-/**
- * Child component of `Row`.
- * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
- */
-const RowItem = ({ shrink = false, as = "div", children }) => (
-  <AsElement
-    elementType={as}
-    className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}
-  >
-    {children}
-  </AsElement>
-);
-
-RowItem.propTypes = {
-  /**
-   * When `true`, the row item shrinks to content size of its children.
-   * Otherwise, the item will expand to fill remaining space in the row.
-   */
-  shrink: PropTypes.bool,
-  /** The html element to render as the root node of `Row` */
-  as: PropTypes.oneOf(["div", "li"]),
 };
 
 Row.Item = RowItem;

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Button from "../Button";
 import Row from "./";
+import RowItem from "./RowItem";
 
 const Template = (args) => (
   <div className="nds-typography">
@@ -184,6 +185,7 @@ AsProp.parameters = {
 export default {
   title: "Components/Row",
   component: Row,
+  subcomponents: { RowItem },
   argTypes: {
     children: { control: false },
   },

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -1,5 +1,8 @@
 import React, { useState } from "react";
 import Tabs from "./";
+import TabsList from "./TabsList";
+import TabsPanel from "./TabsPanel";
+import TabsTab from "./TabsTab";
 
 const Template = (args) => (
   <Tabs {...args}>
@@ -103,6 +106,7 @@ FullyControlledTabs.parameters = {
 export default {
   title: "Components/Tabs",
   component: Tabs,
+  subcomponents: { TabsList, TabsTab, TabsPanel },
   argTypes: {
     onTabChange: { action: "tab change" },
   },


### PR DESCRIPTION
Configure stories to output props tables for sub components like `Row.Item` and `Tabs.Panel`.

<img width="1057" alt="Screen Shot 2022-03-24 at 2 50 29 PM" src="https://user-images.githubusercontent.com/231252/159990449-5c5e4d57-46cb-47d7-be7c-bab9aacb75fd.png">
<img width="1051" alt="Screen Shot 2022-03-24 at 2 56 21 PM" src="https://user-images.githubusercontent.com/231252/159990451-f7542cf9-bf39-4724-8acf-c688bd3c872c.png">

