### PR TITLE
fix(Toggle): allow accessible labelling of Toggles

### DIFF
--- a/src/Toggle/index.js
+++ b/src/Toggle/index.js
@@ -5,7 +5,12 @@ import cc from "classcat";
 /**
  * Checkbox behavior with the visual treatment of a physical toggle switch.
  */
-const Toggle = ({ defaultActive = false, onChange = () => {} }) => {
+const Toggle = ({
+  defaultActive = false,
+  onChange = () => {},
+  labelledBy,
+  label,
+}) => {
   const [isActive, setIsActive] = useState(defaultActive);
 
   const toggleActive = () => {
@@ -13,7 +18,7 @@ const Toggle = ({ defaultActive = false, onChange = () => {} }) => {
     setIsActive(!isActive);
   };
 
-  return (
+  const buttonJsx = (
     <button
       className={cc([
         "resetButton",
@@ -25,11 +30,21 @@ const Toggle = ({ defaultActive = false, onChange = () => {} }) => {
       type="button"
       role="switch"
       aria-checked={isActive.toString()}
-      value={isActive ? "on" : "off"}
       onClick={toggleActive}
+      aria-labelledBy={labelledBy}
     >
       <span className="nds-toggle-indicator elevation--low" />
+      <span className="nds-toggle-buttonText">{isActive ? "on" : "off"}</span>
     </button>
+  );
+
+  return label ? (
+    <label className="alignChild--center--center">
+      {buttonJsx}
+      <span className="padding--left--xs">{label}</span>
+    </label>
+  ) : (
+    buttonJsx
   );
 };
 
@@ -41,6 +56,10 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
   /** When set to `true`, the toggle will initially render as active */
   defaultActive: PropTypes.bool,
+  /** Label element to render to the right of the toggle */
+  label: PropTypes.string,
+  /** ID of element that labels the toggle control (e.g. `my-label-element`)*/
+  labelledBy: PropTypes.string,
 };
 
 export default Toggle;

--- a/src/Toggle/index.scss
+++ b/src/Toggle/index.scss
@@ -1,4 +1,5 @@
 .nds-toggle {
+  display: inline-block;
   position: relative;
   border-radius: 24px;
   height: 24px;
@@ -28,4 +29,18 @@
 
 .nds-toggle--active .nds-toggle-indicator {
   left: 28px;
+}
+
+/**
+* Hide the "on" : "off" button text visually, but
+* still visible to screen readers and other assistive technology
+*/
+.nds-toggle-buttonText {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/src/Toggle/index.stories.js
+++ b/src/Toggle/index.stories.js
@@ -1,9 +1,27 @@
 import React from "react";
 import Toggle from "./";
+import Row from "../Row";
 
 const Template = (args) => <Toggle {...args} />;
 
 export const Overview = Template.bind({});
+
+export const WithLabel = () => (
+  <Toggle defaultActive={true} label="Include hidden accounts" />
+);
+
+export const WithCustomLabel = () => (
+  <div className="padding--y--xs border--top">
+    <Row alignItems="center">
+      <Row.Item>
+        <label id="my-custom-label">Custom label on the left</label>
+      </Row.Item>
+      <Row.Item shrink>
+        <Toggle labelledBy="my-custom-label" />
+      </Row.Item>
+    </Row>
+  </div>
+);
 
 export default {
   title: "Components/Toggle",


### PR DESCRIPTION
fixes #542 

Adds some features to `Toggle` for accessibility:
- allow a built-in label via `label` prop
- allow a custom label detached from the `Toggle` via `labelledBy` prop
- set readable button text that is visually hidden

Adds stories for usage examples of labeling a `Toggle`