### PR TITLE
docs(helper-classes): add whiteSpace class docs

### DIFF
--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -84,6 +84,7 @@
   // "box" display mode to set content flow
   display: -webkit-box;
   -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 @each $clamp in (2, 3, 4) {
   .whiteSpace--truncate--multiLine--#{$clamp} {

--- a/src/helper-classes/font.stories.mdx
+++ b/src/helper-classes/font.stories.mdx
@@ -4,6 +4,7 @@ import {
   fontSize as fontSizeHelpers,
   fontWeight as fontWeightHelpers,
   fontFamily as fontFamilyHelpers,
+  whiteSpace,
 } from "dist/docs/classManifest";
 import ClassExample from "helpers/ClassExample";
 
@@ -62,5 +63,32 @@ Adjusts font family.
     hideBorder
   >
     <div>The quick brown fox jumps over the lazy dog</div>
+  </ClassExample>
+</Story>
+
+# Whitespace control
+
+Whitespace helpers adjust text truncation and wrapping behavior.
+Single line and multiline truncation are both supported.
+
+<Story name="Whitespace Control">
+  <ClassExample
+    signature="whiteSpace--<'singleLine'|'truncate'>(--multiline--<'2'|'3'|'4'>)"
+    classCategory={whiteSpace}
+  >
+    <p>
+      At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+      praesentium voluptatum deleniti atque corrupti quos dolores et quas
+      molestias excepturi sint occaecati cupiditate non provident, similique
+      sunt in culpa qui officia deserunt mollitia animi, id est laborum et
+      dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
+      Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil
+      impedit quo minus id quod maxime placeat facere possimus, omnis voluptas
+      assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut
+      officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates
+      repudiandae sint et molestiae non recusandae. Itaque earum rerum hic
+      tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias
+      consequatur aut perferendis doloribus asperiores repellat
+    </p>
   </ClassExample>
 </Story>


### PR DESCRIPTION
fixes #646 

Adds missing docs for `whiteSpace` helper classes (truncation)

<img width="1075" alt="Screen Shot 2022-03-29 at 5 11 41 PM" src="https://user-images.githubusercontent.com/231252/160708040-f9d7ebad-6b55-409e-a9f0-1dcc7ed71237.png">

