### PR TITLE
fix(RadioButtons): fix keyboard navigation for a11y

### DIFF
--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -7,21 +7,24 @@
     padding-left: 34px;
     margin-bottom: var(--space-m);
     cursor: pointer;
-    font-size: 16px;
     line-height: 1.25;
-    font-family: var(--nds-font-family);
     font-weight: 400;
 
     input {
       position: absolute;
-      opacity: 0;
-      display: none;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
       cursor: pointer;
 
       &:checked {
         ~ .nds-checkmark {
           background-color: transparent;
-          border: 2px solid RGB(var(--nds-primary-color));
+          border: 2px solid var(--theme-primary);
 
           &:after {
             display: block;
@@ -30,6 +33,7 @@
       }
     }
 
+    input:focus ~ .nds-checkmark,
     &:hover input ~ .nds-checkmark {
       border: 2px solid RGB(var(--nds-primary-color));
     }


### PR DESCRIPTION
fixes #634 

When you use `display: none`, the element is fully removed from document flow and the browser treats the element as if it is not in the DOM. Screen readers and keyboard navigation behaves as if the element doesn't exist.

We were hiding the native `input type="radio"` elements using `display: none`. This PR uses some different CSS to visually hide the input without making the element inaccessible to screen readers and keyboard navigation.