### PR TITLE
fix(Checkbox): enable keyboard navigation for a11y

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -11,16 +11,23 @@
   align-items: center;
   input {
     position: absolute;
-    opacity: 0;
     cursor: pointer;
-    height: 0;
-    width: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
     &:checked ~ .narmi-icon-check {
       background-color: RGB(var(--nds-primary-color));
       border: 1px solid RGB(var(--nds-primary-color));
       &:after {
         display: block;
       }
+    }
+    &:focus ~ .narmi-icon-check {
+      border: 2px solid var(--theme-primary);
     }
   }
 
@@ -39,7 +46,7 @@
     line-height: 18px;
     box-sizing: content-box;
     &:hover {
-      border: 2px solid RGB(var(--nds-primary-color));
+      border: 2px solid var(--theme-primary);
     }
     &:after {
       color: red;

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -9,6 +9,15 @@ Overview.args = {
   name: "spam",
 };
 
+export const MultipleCheckboxes = () => (
+  <>
+    <h3 className="margin--bottom">Permissions</h3>
+    <Checkbox label="See statements and documents" name="view" />
+    <Checkbox label="Make deposits" name="deposit" />
+    <Checkbox label="Make withdraws" name="widthdraw" />
+  </>
+);
+
 export default {
   title: "Components/Checkbox",
   component: Checkbox,


### PR DESCRIPTION
fixes #642 

Similar to #648 - when an element is fully hidden with `display: none` _or_ has `0, 0` dimensions, the browser and screen readers treat the element like it doesn't exist, which is why we were missing keyboard navigability on our checkbox component.

The fix is to hide the native input with a CSS technique that only hides it visually.