### PR TITLE
feat(Button): add `kind="negative"` for negating action buttons

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -93,7 +93,7 @@ Button.propTypes = {
   /** disables the button when set to `true` */
   disabled: PropTypes.bool,
   /** style of button to render */
-  kind: PropTypes.oneOf(["primary", "secondary", "menu", "plain"]),
+  kind: PropTypes.oneOf(["primary", "secondary", "negative", "menu", "plain"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
   /** Name of Narmi icon to place at the start of the label */

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -83,7 +83,9 @@
 }
 
 .nds-button--plain,
-.nds-button--plain.resetButton {
+.nds-button--plain.resetButton,
+.nds-button--negative,
+.nds-button--negative.resetButton {
   color: var(--theme-secondary);
   font-weight: var(--font-weight-semibold);
   border-radius: 0;
@@ -96,12 +98,21 @@
   }
 }
 
+.nds-button--negative,
+.nds-button--negative.resetButton {
+  color: var(--theme-primary);
+  &:hover {
+    color: var(--theme-primary);
+  }
+}
+
 .nds-button--disabled {
   pointer-events: none;
   color: var(--color-white);
 
   &.nds-button--menu,
-  &.nds-button--plain {
+  &.nds-button--plain,
+  &.nds-button--negative {
     color: var(--font-color-hint);
   }
   &.nds-button--primary {

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -1,11 +1,45 @@
 import React from "react";
 import Button, { VALID_ICON_NAMES } from "./";
+import Row from "../Row";
 
 const Template = (args) => <Button {...args} />;
 
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Submit",
+};
+
+export const PlainButton = Template.bind({});
+PlainButton.args = {
+  label: "Edit",
+  kind: "plain",
+};
+PlainButton.parameters = {
+  docs: {
+    description: {
+      story:
+        'A Button of `kind="plain"` is a button styled to look like a link.',
+    },
+  },
+};
+
+export const ConfirmAndCancel = () => (
+  <Row alignItems="center" justifyContent="end">
+    <Row.Item shrink>
+      <Button kind="negative" label="Cancel" />
+    </Row.Item>
+    <Row.Item shrink>
+      <Button kind="primary" label="Confirm" />
+    </Row.Item>
+  </Row>
+);
+ConfirmAndCancel.parameters = {
+  docs: {
+    description: {
+      story:
+        "When presenting the user with positive/negative options, use the `negative` button for the negating action and `primary` for confirm. The confirming action should always be on the right.",
+    },
+  },
 };
 
 export default {


### PR DESCRIPTION
fixes #651 

Adds `kind="negative"` to `Button`. This is for use in the ["Component button" pattern](https://zeroheight.com/8ac87d4ba/p/612bfa-button/t/4358c3).

<img width="636" alt="Screen Shot 2022-03-31 at 5 51 21 PM" src="https://user-images.githubusercontent.com/231252/161155316-6a5d22f0-593b-4415-907e-7b10d508a964.png">


