### PR TITLE
fix(Tag): bump font size; fix height to 26px

### DIFF
--- a/src/Tag/index.scss
+++ b/src/Tag/index.scss
@@ -1,11 +1,13 @@
 .nds-tag {
-  padding: var(--space-xxs) var(--space-s);
+  padding: 0 var(--space-xs);
   border-radius: 16px;
-  display: inline-block;
-  font-size: var(--font-size-xs);
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-s);
+  height: 26px; // per design
   .narmi-icon-x {
     cursor: pointer;
-    font-size: var(--font-size-xs);
+    font-size: var(--font-size-s);
     display: inline-block;
     transform: translateY(1px);
   }


### PR DESCRIPTION
fixes #637 

- bumps font size to 14px
- fix height of tag to `26px`
- maintain 4px padding on either side

<img width="387" alt="Screen Shot 2022-03-31 at 6 20 35 PM" src="https://user-images.githubusercontent.com/231252/161159328-5d490fd2-0b57-4481-99ef-cad55389c787.png">

