### PR TITLE
chore(formatters): minor correction to jsdoc for formatDate function

### DIFF
--- a/src/formatters/formatDate.js
+++ b/src/formatters/formatDate.js
@@ -4,7 +4,7 @@
  * @example
  * import { formatDate } from '@narmi/design_system';
  *
- * formatDate(new Date('July 4, 2022'), 'short'); // '7/4/2022'
+ * formatDate(new Date('July 4, 2022'), 'short'); // '7/4/22'
  * formatDate(new Date('7/4/2022'), 'long');      // 'July 4, 2022'
  *
  * @param {Date} date native date object


### PR DESCRIPTION
Currently the documentation looks as below, which is not quite correct. For `short` type formatting, years are outputted as two digits. 

<img width="704" alt="image" src="https://user-images.githubusercontent.com/4285085/161410801-d8aa08f0-3fdf-4e6a-99f6-01f7aa65c995.png">
