### PR TITLE
feat(Checkbox): add `card` variant

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -1,26 +1,60 @@
 // https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_custom_checkbox
-
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
+import cc from "classcat";
 
 /**
  * Narmi styled checkbox with built-in label.
  */
 const Checkbox = ({
   label,
-  onChange,
+  onChange = () => {},
   id,
   name,
   defaultChecked,
+  checked = false,
   value,
+  kind = "normal",
   ...rest
 }) => {
+  const [isChecked, setIsChecked] = useState(
+    checked || defaultChecked || false
+  );
+  const [isFocused, setIsFocused] = useState(false);
+  const isCard = kind === "card";
+
+  const handleChange = () => {
+    setIsChecked((isChecked) => !isChecked);
+    onChange();
+  };
+
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
+
   return (
     <>
-      <label className="nds-checkbox nds-typography">
+      <label
+        className={cc([
+          "nds-typograhy",
+          `nds-checkbox nds-checkbox--${kind}`,
+          {
+            "nds-checkbox--checked": isChecked,
+            "nds-checkbox--focused": isFocused,
+            "padding--all rounded--all border--all": isCard,
+          },
+        ])}
+      >
         {label}
         <input
-          onChange={onChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          checked={isChecked}
           defaultChecked={defaultChecked}
           name={name}
           id={id}
@@ -43,10 +77,23 @@ Checkbox.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** `name` attribute of `input` */
   name: PropTypes.string,
-  /** Sets the checkbox to checked by default, [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) */
+  /**
+   * ⚠️ DEPRECATED
+   *
+   * Uncontrolled Checkbox props will be removed in a future release.
+   * Use `checked` instead to use Checkbox as a fully controlled input.
+   */
   defaultChecked: PropTypes.bool,
+  /** Sets the checkbox checked value */
+  checked: PropTypes.bool,
   /** Sets the `value` attribute of the `input` */
   value: PropTypes.string,
+  /**
+   * `normal` - visually matche a checkbox input
+   *
+   * `card` - visually present as a toggleable card
+   */
+  kind: PropTypes.oneOf(["normal", "card"]),
 };
 
 export default Checkbox;

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -1,16 +1,8 @@
 .nds-checkbox {
-  display: flex;
-  width: fit-content;
-  position: relative;
-  padding-left: 28px;
-  margin-bottom: 12px;
   cursor: pointer;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 20px;
-  align-items: center;
+  margin-bottom: var(--space-s);
+
   input {
-    position: absolute;
     cursor: pointer;
     clip: rect(0 0 0 0);
     clip-path: inset(50%);
@@ -19,15 +11,29 @@
     position: absolute;
     white-space: nowrap;
     width: 1px;
-    &:checked ~ .narmi-icon-check {
+  }
+}
+
+.nds-checkbox--normal {
+  display: flex;
+  width: fit-content;
+  position: relative;
+  align-items: center;
+  padding-left: 28px;
+
+  &.nds-checkbox--focused {
+    .narmi-icon-check {
+      border: 2px solid var(--theme-primary);
+    }
+  }
+
+  &.nds-checkbox--checked {
+    .narmi-icon-check {
       background-color: RGB(var(--nds-primary-color));
       border: 1px solid RGB(var(--nds-primary-color));
       &:after {
         display: block;
       }
-    }
-    &:focus ~ .narmi-icon-check {
-      border: 2px solid var(--theme-primary);
     }
   }
 
@@ -50,6 +56,46 @@
     }
     &:after {
       color: red;
+    }
+  }
+}
+
+.nds-checkbox--card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--color-white);
+  color: var(--color-primary);
+  font-weight: var(--font-weight-semibold);
+
+  .narmi-icon-check {
+    display: none;
+  }
+
+  &.nds-checkbox--checked,
+  &.nds-checkbox--focused {
+    border-color: var(--theme-primary);
+  }
+
+  &:hover,
+  &.nds-checkbox--checked {
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+  }
+
+  &.nds-checkbox--checked {
+    .narmi-icon-check {
+      margin-left: var(--space-default);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--space-default);
+      height: var(--space-default);
+      border-radius: 100%;
+      background-color: var(--theme-primary);
+      color: var(--color-white);
+      font-size: var(--font-size-s);
+      font-weight: var(--font-weight-default);
     }
   }
 }

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -18,6 +18,20 @@ export const MultipleCheckboxes = () => (
   </>
 );
 
+export const AsCard = Template.bind({});
+AsCard.args = {
+  label: "Checbox of 'card' kind",
+  name: "card_kind",
+  kind: "card",
+};
+AsCard.parameters = {
+  docs: {
+    description: {
+      story: "Renders a checkbox input and label styled as a card",
+    },
+  },
+};
+
 export default {
   title: "Components/Checkbox",
   component: Checkbox,

--- a/src/Checkbox/index.test.js
+++ b/src/Checkbox/index.test.js
@@ -19,26 +19,38 @@ describe("Checkbox", () => {
     expect(input).toHaveAttribute("name", name);
   });
 
+  it("renders with expected classes for card kind", () => {
+    render(<Checkbox label={LABEL} kind="card" />);
+    const { label } = getElements();
+    expect(label).toHaveClass("nds-checkbox--card");
+    expect(label).toHaveClass("border--all");
+  });
+
   it("changes value on label click", () => {
     render(<Checkbox label={LABEL} />);
     const { label, input } = getElements();
     expect(input).not.toBeChecked();
+    expect(label).not.toHaveClass("nds-checkbox--checked");
     fireEvent.click(label);
     expect(input).toBeChecked();
+    expect(label).toHaveClass("nds-checkbox--checked");
   });
 
   it("shows correct initial state for defaultChecked", () => {
     render(<Checkbox label={LABEL} defaultChecked />);
-    const { input } = getElements();
+    const { label, input } = getElements();
     expect(input).toBeChecked();
+    expect(label).toHaveClass("nds-checkbox--checked");
   });
 
   it("allows uncontrolled value changes if defaultChecked", () => {
     render(<Checkbox label={LABEL} defaultChecked />);
-    const { input } = getElements();
+    const { label, input } = getElements();
     expect(input).toBeChecked();
+    expect(label).toHaveClass("nds-checkbox--checked");
     fireEvent.click(input);
     expect(input).not.toBeChecked();
+    expect(label).not.toHaveClass("nds-checkbox--checked");
   });
 
   it("fires onChange callback", () => {


### PR DESCRIPTION
related to:
#616 

Adds a card style variant to our `Checkbox` component. Internal state was necessary to support visual feedback for focus states when navigating via keyboard.

https://user-images.githubusercontent.com/231252/161630812-46af669b-3f20-48cb-a1c1-e5df0ae0bcad.mp4
