### PR TITLE
Feat/616 radiobuttons card variant

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -80,6 +80,7 @@
 
   &:hover,
   &.nds-checkbox--checked {
+    color: var(--theme-primary);
     background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
   }
 

--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -1,47 +1,94 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
+import cc from "classcat";
 
 /*
 The Narmi RadioButtons component expects an "options" Prop, which is an object where the keys are the radiobutton
 labels and the values are the radiobutton values. An "initialvalue" Prop can be passed to set a default checked
 radiobutton.
 
-i.e.
-    <RadioButtons
-      initialValue={"true"}
-      options={{ "True": "true", "False": "false" }}
-    />
+```
+  <RadioButtons
+    initialValue={"secondValue"}
+    options={{ "First Label": "firstValue", "Second Label": "secondValue" }}
+  />
+```
 */
 
-const RadioButtons = ({ options, name, initialValue, ...containerProps }) => {
+const RadioButtons = ({
+  options,
+  name,
+  initialValue,
+  kind = "normal",
+  onChange = () => {},
+  ...containerProps
+}) => {
+  const [checkedValue, setCheckedValue] = useState(initialValue);
+  const [focusedValue, setFocusedValue] = useState(null);
+
+  const handleChange = (e) => {
+    setCheckedValue(e.target.value);
+    onChange(e);
+  };
+
+  const handleFocus = ({ target }) => {
+    setFocusedValue(target.value);
+  };
+
+  const handleBlur = () => {
+    setFocusedValue(null);
+  };
+
   return (
-    <div className="nds-radiobutton-group nds-typography" {...containerProps}>
+    <div
+      className="nds-radiobuttons nds-typography"
+      onChange={handleChange}
+      {...containerProps}
+    >
       {Object.entries(options).map(([label, value]) => (
-        <div className="nds-radiobutton-container" key={value}>
-          <label className="nds-label">
-            {label}
-            <input
-              type="radio"
-              defaultChecked={initialValue === value}
-              value={value}
-              name={name}
-            />
-            <div className="nds-checkmark"></div>
-          </label>
-        </div>
+        <label
+          className={cc([
+            "nds-radiobuttons-option",
+            `nds-radiobuttons-option--${kind}`,
+            {
+              "nds-radiobuttons-option--checked": checkedValue == value,
+              "nds-radiobuttons-option--focused": focusedValue == value,
+            },
+          ])}
+          key={value}
+        >
+          {label}
+          <input
+            type="radio"
+            checked={checkedValue === value}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            value={value}
+            name={name}
+          />
+          <div className="nds-checkmark"></div>
+        </label>
       ))}
     </div>
   );
 };
 
 RadioButtons.propTypes = {
+  /** Map of label strings to input values */
   options: PropTypes.object,
+  /** name of radiogroup */
   name: PropTypes.string,
+  /** initially selected option by input value */
   initialValue: PropTypes.any,
-};
-
-RadioButtons.defaultProps = {
-  initialValue: false,
+  /** change callback invoked with input value */
+  onChange: PropTypes.func,
+  /**
+   * `normal` - display input and label normally
+   *
+   * `card` - display input and label as a toggleable card
+   */
+  kind: PropTypes.oneOf(["normal", "card"]),
 };
 
 export default RadioButtons;

--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 
-/*
+/**
 The Narmi RadioButtons component expects an "options" Prop, which is an object where the keys are the radiobutton
 labels and the values are the radiobutton values. An "initialvalue" Prop can be passed to set a default checked
 radiobutton.
@@ -14,7 +14,6 @@ radiobutton.
   />
 ```
 */
-
 const RadioButtons = ({
   options,
   name,
@@ -41,7 +40,7 @@ const RadioButtons = ({
 
   return (
     <div
-      className="nds-radiobuttons nds-typography"
+      className={`nds-radiobuttons nds-radiobuttons--${kind}`}
       onChange={handleChange}
       {...containerProps}
     >
@@ -49,10 +48,10 @@ const RadioButtons = ({
         <label
           className={cc([
             "nds-radiobuttons-option",
-            `nds-radiobuttons-option--${kind}`,
             {
               "nds-radiobuttons-option--checked": checkedValue == value,
               "nds-radiobuttons-option--focused": focusedValue == value,
+              "padding--all rounded--all border--all": kind === "card",
             },
           ])}
           key={value}
@@ -67,7 +66,13 @@ const RadioButtons = ({
             value={value}
             name={name}
           />
-          <div className="nds-checkmark"></div>
+          <div
+            role="img"
+            className={cc([
+              "nds-radio",
+              { "narmi-icon-check": kind === "card" },
+            ])}
+          />
         </label>
       ))}
     </div>

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -1,17 +1,16 @@
-.nds-radiobuttons {
-  display: inline-block;
-  input {
-    position: absolute;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
+// input style shared between variants
+.nds-radiobuttons input {
+  position: absolute;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
+// base option styles
 .nds-radiobuttons-option {
   display: block;
   position: relative;
@@ -19,48 +18,95 @@
   cursor: pointer;
 }
 
-.nds-radiobuttons-option--normal {
-  padding-left: 34px;
+// normal variant of radiobuttons
+.nds-radiobuttons--normal {
+  display: inline-block;
 
-  .nds-checkmark {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 20px;
-    width: 20px;
-    background-color: transparent;
-    border: 1px solid RGB(var(--nds-lightest-grey));
-    border-radius: 50%;
+  .nds-radiobuttons-option {
+    padding-left: 34px;
 
-    &:after {
-      content: "";
+    .nds-radio {
       position: absolute;
-      display: none;
-      top: 50%;
-      left: 50%;
-      width: 12px;
-      height: 12px;
-      transform: translate(-50%, -50%);
+      top: 0;
+      left: 0;
+      height: 20px;
+      width: 20px;
+      background-color: transparent;
+      border: 1px solid RGB(var(--nds-lightest-grey));
       border-radius: 50%;
-      background: RGB(var(--nds-primary-color));
+
+      &:after {
+        content: "";
+        position: absolute;
+        display: none;
+        top: 50%;
+        left: 50%;
+        width: 12px;
+        height: 12px;
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+        background: RGB(var(--nds-primary-color));
+      }
+    }
+
+    &:hover .nds-radio,
+    &.nds-radiobuttons-option--focused .nds-radio,
+    &.nds-radiobuttons-option--checked .nds-radio {
+      border: 2px solid var(--theme-primary);
+    }
+
+    &.nds-radiobuttons-option--checked .nds-radio {
+      background-color: transparent;
+
+      &:after {
+        display: block;
+      }
     }
   }
+}
 
-  .nds-radiobuttons-option--checked {
-    outline: 12px dotted lawngreen;
-  }
+// card style radiobuttons variant
+.nds-radiobuttons--card {
+  display: block;
 
-  &.nds-radiobuttons-option--checked .nds-checkmark {
-    background-color: transparent;
-    border: 2px solid var(--theme-primary);
+  .nds-radiobuttons-option {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    background-color: var(--color-white);
+    color: var(--color-primary);
+    font-weight: var(--font-weight-semibold);
 
-    &:after {
-      display: block;
+    .narmi-icon-check {
+      display: none;
     }
-  }
 
-  &.nds-radiobuttons--focused,
-  &:hover input ~ .nds-checkmark {
-    border: 2px solid RGB(var(--nds-primary-color));
+    &:hover,
+    &.nds-radiobuttons-option--focused,
+    &.nds-radiobuttons-option--checked {
+      border-color: var(--theme-primary);
+    }
+
+    &:hover,
+    &.nds-radiobuttons-option--checked {
+      color: var(--theme-primary);
+      background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+    }
+
+    &.nds-radiobuttons-option--checked .narmi-icon-check {
+      margin-left: var(--space-default);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: var(--space-default);
+      height: var(--space-default);
+      border-radius: 100%;
+      background-color: var(--theme-primary);
+      color: var(--color-white);
+      font-size: var(--font-size-s);
+      font-weight: var(--font-weight-default);
+    }
   }
 }

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -1,65 +1,66 @@
-.nds-radiobutton-group {
+.nds-radiobuttons {
   display: inline-block;
+  input {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}
 
-  .nds-label {
-    display: block;
-    position: relative;
-    padding-left: 34px;
-    margin-bottom: var(--space-m);
-    cursor: pointer;
-    line-height: 1.25;
-    font-weight: 400;
+.nds-radiobuttons-option {
+  display: block;
+  position: relative;
+  margin-bottom: var(--space-m);
+  cursor: pointer;
+}
 
-    input {
+.nds-radiobuttons-option--normal {
+  padding-left: 34px;
+
+  .nds-checkmark {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 20px;
+    width: 20px;
+    background-color: transparent;
+    border: 1px solid RGB(var(--nds-lightest-grey));
+    border-radius: 50%;
+
+    &:after {
+      content: "";
       position: absolute;
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-      cursor: pointer;
-
-      &:checked {
-        ~ .nds-checkmark {
-          background-color: transparent;
-          border: 2px solid var(--theme-primary);
-
-          &:after {
-            display: block;
-          }
-        }
-      }
-    }
-
-    input:focus ~ .nds-checkmark,
-    &:hover input ~ .nds-checkmark {
-      border: 2px solid RGB(var(--nds-primary-color));
-    }
-
-    .nds-checkmark {
-      position: absolute;
-      top: 0;
-      left: 0;
-      height: 20px;
-      width: 20px;
-      background-color: transparent;
-      border: 1px solid RGB(var(--nds-lightest-grey));
+      display: none;
+      top: 50%;
+      left: 50%;
+      width: 12px;
+      height: 12px;
+      transform: translate(-50%, -50%);
       border-radius: 50%;
-
-      &:after {
-        content: "";
-        position: absolute;
-        display: none;
-        top: 50%;
-        left: 50%;
-        width: 12px;
-        height: 12px;
-        transform: translate(-50%, -50%);
-        border-radius: 50%;
-        background: RGB(var(--nds-primary-color));
-      }
+      background: RGB(var(--nds-primary-color));
     }
+  }
+
+  .nds-radiobuttons-option--checked {
+    outline: 12px dotted lawngreen;
+  }
+
+  &.nds-radiobuttons-option--checked .nds-checkmark {
+    background-color: transparent;
+    border: 2px solid var(--theme-primary);
+
+    &:after {
+      display: block;
+    }
+  }
+
+  &.nds-radiobuttons--focused,
+  &:hover input ~ .nds-checkmark {
+    border: 2px solid RGB(var(--nds-primary-color));
   }
 }

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -39,4 +39,7 @@ export const Example = () => {
 export default {
   title: "Components/RadioButtons",
   component: RadioButtons,
+  artTypes: {
+    onChange: { action: "change" },
+  },
 };

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -36,6 +36,25 @@ export const Example = () => {
   );
 };
 
+export const AsCard = Template.bind({});
+AsCard.args = {
+  options: {
+    OptionA: "A",
+    OptionB: "B",
+    OptionC: "C",
+  },
+  name: "options",
+  kind: "card",
+};
+AsCard.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a cards. The cards will grow to fill the width of their parent container.",
+    },
+  },
+};
+
 export default {
   title: "Components/RadioButtons",
   component: RadioButtons,

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -43,7 +43,7 @@ AsCard.args = {
     OptionB: "B",
     OptionC: "C",
   },
-  name: "options",
+  name: "card_options",
   kind: "card",
 };
 AsCard.parameters = {


### PR DESCRIPTION
fixes #616 

- Added support for "card" variant with `kind` prop
- Added internal state to manage focus/checked styling to ensure a11y for both variants
- Added missing prop definition for `onClick`

This component seems to be missing unit tests - we'll add those in a [separate ticket](https://github.com/narmi/design_system/issues/663)

<img width="924" alt="Screen Shot 2022-04-06 at 10 22 23 AM" src="https://user-images.githubusercontent.com/231252/161997056-86549ccb-fb3a-478d-b2c6-4dff808a9827.png">

