### PR TITLE
feat(Select): add `value` prop to enable fully controlled mode

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -42,7 +42,7 @@ export const getSelectedItemDisplay = (item) => {
  */
 export const getItemByValue = (value, items) => {
   const founditem = items
-    .filter((item) => !isAction(item)) // action items may not be selected by default
+    .filter((item) => !isAction(item)) // action items are not selectable
     .filter(({ props }) => props.value === value)
     .pop();
 

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -96,11 +96,41 @@ InAForm.parameters = {
   },
 };
 
+export const Controlled = () => {
+  const [value, setValue] = useState("");
+  return (
+    <>
+      <Select label="Account" value={value} onChange={setValue}>
+        <Select.Item value="checking1234">Checking (1234)</Select.Item>
+        <Select.Item value="savings4321">Savings (4321)</Select.Item>
+      </Select>
+      <div className="margin--top">
+        <button
+          onClick={() => {
+            setValue("");
+          }}
+        >
+          Clear selection
+        </button>
+      </div>
+    </>
+  );
+};
+Controlled.parameters = {
+  docs: {
+    description: {
+      story:
+        "You can programmatically select selection by updating the `value` prop. When `value` is passed, the component becomes **fully controlled** and you must use the `onChange` prop to update the `value`.",
+    },
+  },
+};
+
 export default {
   title: "Components/Select",
   component: Select,
   subcomponents: { SelectItem, SelectAction },
   argTypes: {
     children: { control: false },
+    onChange: { action: "Select change" },
   },
 };

--- a/src/Select/index.test.js
+++ b/src/Select/index.test.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, screen, fireEvent, prettyDOM } from "@testing-library/react";
-import Select, { isAction, getSelectedItemDisplay } from "./";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Select, { isAction, getSelectedItemDisplay, getItemByValue } from "./";
 
 describe("Select", () => {
   /**
@@ -19,6 +19,17 @@ describe("Select", () => {
     const action = <Select.Action onSelect={() => {}}>{kids}</Select.Action>;
     expect(getSelectedItemDisplay(item)).toBeTruthy();
     expect(getSelectedItemDisplay(action)).toBeFalsy();
+  });
+
+  it("getItemByValue: gets correct item from list by value or an empty string", () => {
+    const MOCK_ITEM_FOO = <Select.Item value="foo"></Select.Item>;
+    const MOCK_ITEM_BAR = <Select.Item value="bar"></Select.Item>;
+    expect(getItemByValue("foo", [MOCK_ITEM_BAR, MOCK_ITEM_FOO])).toBe(
+      MOCK_ITEM_FOO
+    );
+    expect(getItemByValue("doesNotExist", [MOCK_ITEM_BAR, MOCK_ITEM_FOO])).toBe(
+      ""
+    );
   });
 
   it("renders as expected with basic props", () => {


### PR DESCRIPTION
fixes #580 

Adds `value` prop to `Select` to enable a fully controlled mode.

<img width="1039" alt="Screen Shot 2022-04-06 at 12 42 08 PM" src="https://user-images.githubusercontent.com/231252/162025887-b65666b6-45c3-4f9b-8af0-7278b69927d6.png">

