### PR TITLE
refactor: enable `jsx-key` and `prop-types` react lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,6 @@ module.exports = {
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/no-noninteractive-tabindex": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "react/prop-types": "off",
-    "react/jsx-key": "off",
     "no-unused-vars": "off",
   },
 };

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -43,6 +43,10 @@ const Button = ({
     </div>
   );
 
+  Icon.propTypes = {
+    name: PropTypes.string.isRequired,
+  };
+
   return (
     <AsElement
       elementType={as}

--- a/src/Dropdown/index.js
+++ b/src/Dropdown/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */ // this file will be removed in a future release
 import React, { useState, useEffect } from "react";
 import TextInput from "../TextInput";
 import PropTypes from "prop-types";

--- a/src/Dropdown/index.stories.js
+++ b/src/Dropdown/index.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-key */
 import React, { useState } from "react";
 import Dropdown from "./";
 import Modal from "../Modal";

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -20,14 +20,22 @@ const Error = ({ error }) => {
   );
 };
 
+Error.propTypes = {
+  error: PropTypes.string,
+};
+
 const Input = ({
   id,
   label,
   icon,
   disabled,
+  multiline = false,
   decoration,
   error,
   search,
+  onClick,
+  style,
+  children,
   ...props
 }) => {
   const className = [
@@ -39,17 +47,17 @@ const Input = ({
   ].join(" ");
 
   return (
-    <div className={className} onClick={props.onClick} style={props.style}>
+    <div className={className} onClick={onClick} style={style}>
       <div className="nds-input-box">
         {icon ? <div className={`nds-input-icon ${icon}`}></div> : ""}
         <div
           className={`nds-input-column ${
-            !label || (icon && !props.multiline) ? "no-label" : ""
+            !label || (icon && !multiline) ? "no-label" : ""
           }`}
         >
-          {props.children}
+          {children}
           {decoration}
-          {!props.multiline ? <label htmlFor={id}>{label}</label> : ""}
+          {!multiline ? <label htmlFor={id}>{label}</label> : ""}
         </div>
       </div>
       <Error error={error} />
@@ -58,22 +66,20 @@ const Input = ({
 };
 
 Input.propTypes = {
+  id: PropTypes.string,
   label: PropTypes.string,
-  placeholder: PropTypes.string,
   icon: PropTypes.node,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   multiline: PropTypes.bool,
+  disabled: PropTypes.bool,
+  search: PropTypes.bool,
+  onClick: PropTypes.func,
+  style: PropTypes.object,
   error: PropTypes.string,
-};
-
-Input.defaultProps = {
-  label: null,
-  placeholder: "",
-  icon: null,
-  decoration: null,
-  error: null,
-  multiline: false,
-  React,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
 };
 
 export default Input;

--- a/src/PlainButton/index.js
+++ b/src/PlainButton/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */ // deprecated; will remove this file in a future release
 import React from "react";
 
 /**

--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -24,6 +24,10 @@ RowItem.propTypes = {
   shrink: PropTypes.bool,
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "li"]),
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
 };
 
 export default RowItem;

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -54,6 +54,8 @@ Row.propTypes = {
   justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "ul"]),
+  /** Children must be of type `Row.Item` */
+  children: PropTypes.arrayOf(PropTypes.node).isRequired,
 };
 
 Row.Item = RowItem;

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React from "react";
 import Button from "../Button";
 import Row from "./";

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -164,6 +164,10 @@ Select.propTypes = {
    * When passed, this will cause the trigger to render in error state.
    */
   errorText: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
 };
 
 Select.Item = SelectItem;

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/no-unescaped-entities */
+/* eslint-disable react/jsx-key,react/no-unescaped-entities */
 import React, { useState } from "react";
 import Select from "./";
 import SelectItem from "./SelectItem";

--- a/src/SeparatorList/index.js
+++ b/src/SeparatorList/index.js
@@ -7,11 +7,15 @@ import PropTypes from "prop-types";
 const SeparatorList = ({ separator = "|", items = [] }) => (
   <ul className="list--reset nds-typography nds-separatorList">
     {items.map((item, i) => {
-      const itemProps = { key: i };
+      const itemProps = {};
       if (i !== items.length - 1) {
         itemProps["data-separator"] = separator;
       }
-      return <li {...itemProps}>{item}</li>;
+      return (
+        <li key={`${i}-${separator}`} {...itemProps}>
+          {item}
+        </li>
+      );
     })}
   </ul>
 );

--- a/src/SeparatorList/index.stories.js
+++ b/src/SeparatorList/index.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React from "react";
 import SeparatorList from "./";
 

--- a/src/SeparatorList/index.test.js
+++ b/src/SeparatorList/index.test.js
@@ -2,7 +2,11 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import SeparatorList from "./";
 
-const items = [<span>One</span>, <span>Two</span>, <span>Three</span>];
+const items = [
+  <span key="one">One</span>,
+  <span key="two">Two</span>,
+  <span key="three">Three</span>,
+];
 
 describe("SeparatorList", () => {
   it("renders all items", () => {

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -9,7 +9,6 @@ const TextInput = (props) => {
   const {
     formatter,
     multiline,
-    search,
     defaultValue,
     onChange,
     onBlur,

--- a/src/icons/Icons.stories.js
+++ b/src/icons/Icons.stories.js
@@ -10,7 +10,7 @@ export const Icons = () => {
     <div className="nds-typography">
       <div className="icon-demo">
         {iconSelection.icons.map((icon) => (
-          <div className="icon-demo-box">
+          <div key={icon.properties.name} className="icon-demo-box">
             <span
               className={`icon-demo-icon narmi-icon-${icon.properties.name}`}
             >

--- a/src/util/AsElement.js
+++ b/src/util/AsElement.js
@@ -48,6 +48,10 @@ const AsElement = ({ elementType = "div", children, ...rest }) => {
 AsElement.propTypes = {
   /** element to render  */
   elementType: PropTypes.oneOf(VALID_ELEMENTS).isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
 };
 
 export default AsElement;


### PR DESCRIPTION
relates to:
- #482 

Enable `react/jsx-key` and `react/prop-types` lint rules.