### PR TITLE
refactor: enable `jsx-a11y/anchor-is-valid` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/no-noninteractive-tabindex": "off",
-    "jsx-a11y/anchor-is-valid": "off",
     "jsx-a11y/label-has-associated-control": "off",
     "jsx-a11y/interactive-supports-focus": "off",
     "react/prop-types": "off",

--- a/src/Card/index.stories.js
+++ b/src/Card/index.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/no-unescaped-entities */
+/* eslint-disable react/no-unescaped-entities,jsx-a11y/anchor-is-valid */
 import React, { useRef, useState } from "react";
 import Card from "./";
 import Button from "../Button";

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react";
 import Button from "../Button";
 import Row from "./";

--- a/src/SeparatorList/index.stories.js
+++ b/src/SeparatorList/index.stories.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react";
 import SeparatorList from "./";
 


### PR DESCRIPTION
relates to:
- #482 

enable `jsx-a11y/anchor-is-valid` lint rule