### PR TITLE
refactor: enable `jsx-a11y/interactive-supports-focus` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
     "jsx-a11y/no-noninteractive-tabindex": "off",
     "jsx-a11y/anchor-is-valid": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "jsx-a11y/interactive-supports-focus": "off",
     "react/prop-types": "off",
     "react/jsx-key": "off",
     "no-unused-vars": "off",

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -116,6 +116,7 @@ const Pagination = ({
           <Row.Item as="li" shrink>
             <span
               role="button"
+              tabIndex={0}
               aria-disabled={!showPrev}
               aria-label="Previous page"
               onClick={handlePrevClick}
@@ -135,6 +136,7 @@ const Pagination = ({
             <Row.Item as="li" shrink>
               <span
                 role="button"
+                tabIndex={0}
                 aria-label="First page"
                 onClick={handlePageClick}
                 data-page={firstPage}
@@ -154,6 +156,7 @@ const Pagination = ({
             <Row.Item as="li" key={page} shrink>
               <span
                 role="button"
+                tabIndex={0}
                 className={cc([
                   "nds-pagination-page",
                   {
@@ -179,6 +182,7 @@ const Pagination = ({
             <Row.Item as="li" shrink>
               <span
                 role="button"
+                tabIndex={0}
                 aria-label="Last page"
                 onClick={handlePageClick}
                 data-page={lastPage}
@@ -192,6 +196,7 @@ const Pagination = ({
           <Row.Item as="li" shrink>
             <span
               role="button"
+              tabIndex={0}
               aria-disabled={!showNext}
               aria-label="Next page"
               onClick={handleNextClick}


### PR DESCRIPTION
relates to:
- #482

Enable focus lint rule and fix pagination buttons 