### PR TITLE
Feat/662 responsive dialog

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -15,7 +15,7 @@
   border-radius: var(--button-radius);
 
   /* mobile buttons have slightly taller padding for ease of tapping */
-  @media (max-width: $mobile_size) {
+  @media (max-width: #{map.get($breakpoints, "s")}) {
     min-height: 48px;
   }
 }
@@ -74,7 +74,7 @@
     margin: 10px 0;
   }
 
-  @media (min-width: $desktop-small) {
+  @media (min-width: #{map.get($breakpoints, "l")}) {
     margin: 0 12px;
     font-weight: var(--font-weight-semibold);
     display: inline-block;

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -24,7 +24,7 @@
     background-color: RGBA(var(--nds-primary-color), var(--subdued-5-opacity));
   }
 
-  @media (max-width: $mobile_size) {
+  @media (max-width: #{map.get($breakpoints, "s")}) {
     padding: 0;
   }
 

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -9,26 +9,35 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  padding: var(--space-default); /* create space around viewport edges */
   z-index: 2;
+
+  // create spaces around viewport edges for tablet or larger
+  @include atMediaUp("s") {
+    padding: var(--space-default);
+  }
 }
 
 .nds-dialog {
   position: relative;
-  border-radius: var(--border-radius-default);
   background-color: var(--bgColor-white);
   box-shadow: var(--elevation-high);
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
 
-  /**
-  * `width` is configured via props; below are constraints
-  * for small screens and large modals.
-  */
-  max-height: 100%; /* prevent modal from being taller than the shim content box */
-  min-height: 240px; /* prevent content area from collapsing to 0 */
-  min-width: 240px; /* should be no narrower than this, even on phones */
+  // the modal dialog takes over the whole screen by default
+  // (small veiwports)
+  height: 100vh;
+  width: 100vw;
+
+  // for tablet or larger, display the modal dialog as a floating box.
+  @include atMediaUp("s") {
+    height: auto;
+    border-radius: var(--border-radius-default);
+    max-height: 100%; // prevent modal from being taller than the shim content box
+    min-height: 240px; // prevent content area from collapsing to 0
+    min-width: 240px; // should be no narrower than this on larger viewports
+  }
 }
 
 .nds-dialog-header {

--- a/src/base-styles/grid.scss
+++ b/src/base-styles/grid.scss
@@ -1,5 +1,10 @@
 $column_count: 12;
 
+$mobile_size: map.get($breakpoints, "s");
+$tablet: map.get($breakpoints, "m");
+$desktop-small: map.get($breakpoints, "l");
+$desktop-big: map.get($breakpoints, "xl");
+
 .nds-container {
   display: block;
   margin: 0 auto;

--- a/src/base-styles/grid.scss
+++ b/src/base-styles/grid.scss
@@ -1,6 +1,6 @@
 $column_count: 12;
 
-$mobile_size: map.get($breakpoints, "s");
+$mobile_size: 375px; // legacy breakpoint size for mobile
 $tablet: map.get($breakpoints, "m");
 $desktop-small: map.get($breakpoints, "l");
 $desktop-big: map.get($breakpoints, "xl");

--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -1,0 +1,25 @@
+/**
+* Sass helpers
+* Global mixins, placeholders, functions, and vars
+*/
+
+$breakpoints: (
+  "s": 375px,
+  "m": 768px,
+  "l": 1280px,
+  "xl": 1440px,
+);
+
+/**
+* Mobile first style media query helper.
+* Styles wrapped in this mixin will apply to screens
+* of the given breakpoint size _and larger_.
+*
+* @include atMediaUp(m) { styles for M size or larger }
+*/
+@mixin atMediaUp($breakpointName) {
+  $minWidth: map.get($breakpoints, $breakpointName);
+  @media (screen) and (min-width: #{$minWidth}) {
+    @content;
+  }
+}

--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -3,11 +3,19 @@
 * Global mixins, placeholders, functions, and vars
 */
 
+/**
+* Breakpoints are mobile first, meaning default styles are for mobile-sized
+* screens and these breakpoints are for targeting larger viewports.
+*/
 $breakpoints: (
-  "s": 375px,
+  // larger than most phones
+  "s": 480px,
+  // larger than most tablets
   "m": 768px,
+  // larger than some laptop screens
   "l": 1280px,
-  "xl": 1440px,
+  // larger than many desktop screens
+  "xl": 1440px
 );
 
 /**
@@ -19,7 +27,7 @@ $breakpoints: (
 */
 @mixin atMediaUp($breakpointName) {
   $minWidth: map.get($breakpoints, $breakpointName);
-  @media (screen) and (min-width: #{$minWidth}) {
+  @media only screen and (min-width: #{$minWidth}) {
     @content;
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,4 @@
-$mobile_size: 375px;
-$tablet: 768px;
-$desktop-small: 1280px;
-$desktop-big: 1440px;
+@use "sass:map";
 
 // NDS Tokens
 @import "../dist/tokens/css/tokens.css";
@@ -32,6 +29,7 @@ $desktop-big: 1440px;
 @import "icons/icons.css";
 
 // base styles
+@import "base-styles/scss-utils"; // this must come first
 @import "base-styles/reset";
 @import "base-styles/defaults";
 @import "base-styles/typography";


### PR DESCRIPTION
fixes #662 

- Sets up new mobile first breakpoints and sass helpers
- Update `Dialog` styles to take over the full screen by default and act as a floating box for "s" or larger viewports

https://user-images.githubusercontent.com/231252/162836869-03f10a1a-a65c-49af-94bc-44710aa362b6.mp4


