### PR TITLE
refactor: enable `label-has-associated-control` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,5 @@ module.exports = {
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/no-noninteractive-tabindex": "off",
-    "jsx-a11y/label-has-associated-control": "off",
   },
 };

--- a/src/Toggle/index.stories.js
+++ b/src/Toggle/index.stories.js
@@ -10,6 +10,8 @@ export const WithLabel = () => (
   <Toggle defaultActive={true} label="Include hidden accounts" />
 );
 
+// eslint doesn't have visibility of the `aria-labelledby` prop inside Toggle
+/* eslint-disable jsx-a11y/label-has-associated-control */
 export const WithCustomLabel = () => (
   <div className="padding--y--xs border--top">
     <Row alignItems="center">
@@ -22,6 +24,7 @@ export const WithCustomLabel = () => (
     </Row>
   </div>
 );
+/* eslint-enable jsx-a11y/label-has-associated-control */
 
 export default {
   title: "Components/Toggle",


### PR DESCRIPTION
relates to:
- #482 

Enable rule and suppress false error in Toggle story