### PR TITLE
refactor: enable `no-noninteractive-tabindex` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,5 @@ module.exports = {
      */
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
-    "jsx-a11y/no-noninteractive-tabindex": "off",
   },
 };

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -79,6 +79,7 @@ const Popover = ({
         style={{ display: wrapperDisplay }}
         onClick={togglePopover}
         onKeyDown={handleKeyDown}
+        role="button"
         tabIndex="0"
         data-testid="nds-popover-trigger"
         aria-haspopup="true"

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -55,6 +55,7 @@ const Tooltip = ({
         onBlur={closePopover}
         onMouseEnter={openPopover}
         onMouseLeave={closePopover}
+        role="button"
         tabIndex="0"
         data-testid="nds-tooltip-trigger"
       >


### PR DESCRIPTION
related to:
- #482 

Enables lint rule `no-noninteractive-tabindex`; sets correct `role` for popover and tooltip triggers