### PR TITLE
refactor: enable all remaining disabled lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,15 +16,4 @@ module.exports = {
     browser: true,
     "jest/globals": true,
   },
-  rules: {
-    /**
-     * Temporarily disabled rules.
-     *
-     * This allows us to introduce linting without 100+
-     * code changes. We can enable rules and fix their errors
-     * one at a time until no rules are disabled.
-     */
-    "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/no-static-element-interactions": "off",
-  },
 };

--- a/src/ContentCard/index.js
+++ b/src/ContentCard/index.js
@@ -21,6 +21,15 @@ const ContentCard = ({
       tabIndex={isInteractive ? "0" : undefined}
       aria-pressed={isInteractive ? isSelected : undefined}
       onClick={isInteractive ? onClick : undefined}
+      onKeyUp={
+        isInteractive
+          ? ({ key }) => {
+              if (key === "Enter") {
+                onClick();
+              }
+            }
+          : undefined
+      }
       className={cc([
         "nds-contentCard",
         `nds-contentCard--${type}`,

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -70,6 +70,8 @@ const Dialog = ({
     }
   };
 
+  // the shim has events for mouse users only; does not require a role
+  /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
     <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
       <div
@@ -109,6 +111,7 @@ const Dialog = ({
       </div>
     </div>
   );
+  /* eslint-enable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
 
   return <>{isOpen && ReactDOM.createPortal(dialogJSX, document.body)}</>;
 };

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */ // file will be removed in a future release
 import React from "react";
 import PropTypes from "prop-types";
 

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -120,6 +120,11 @@ const Pagination = ({
               aria-disabled={!showPrev}
               aria-label="Previous page"
               onClick={handlePrevClick}
+              onKeyUp={({ key }) => {
+                if (key === "Enter") {
+                  handlePrevClick();
+                }
+              }}
               className={cc([
                 "nds-pagination-page",
                 "padding--none",
@@ -139,6 +144,11 @@ const Pagination = ({
                 tabIndex={0}
                 aria-label="First page"
                 onClick={handlePageClick}
+                onKeyUp={(e) => {
+                  if (e.key === "Enter") {
+                    handlePageClick(e);
+                  }
+                }}
                 data-page={firstPage}
                 className="nds-pagination-page"
               >
@@ -165,6 +175,11 @@ const Pagination = ({
                 ])}
                 data-page={page}
                 onClick={handlePageClick}
+                onKeyUp={(e) => {
+                  if (e.key === "Enter") {
+                    handlePageClick(e);
+                  }
+                }}
                 aria-label={`Page ${page}`}
                 aria-current={i === selectedIndex && "page"}
               >
@@ -185,6 +200,11 @@ const Pagination = ({
                 tabIndex={0}
                 aria-label="Last page"
                 onClick={handlePageClick}
+                onKeyUp={(e) => {
+                  if (e.key === "Enter") {
+                    handlePageClick(e);
+                  }
+                }}
                 data-page={lastPage}
                 className="nds-pagination-page"
               >
@@ -200,6 +220,11 @@ const Pagination = ({
               aria-disabled={!showNext}
               aria-label="Next page"
               onClick={handleNextClick}
+              onKeyUp={({ key }) => {
+                if (key === "Enter") {
+                  handleNextClick();
+                }
+              }}
               className={cc([
                 "nds-pagination-page",
                 "padding--none",


### PR DESCRIPTION
fixes #482 

Enable all remaining lint rules (mostly about static element roles and click events having keyboard events)