### PR TITLE
fix(Tag): adjust sizes on variants

### DIFF
--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -16,7 +16,7 @@ const Tag = ({
 }) => {
   return (
     <div className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}>
-      <Row alignItems="center" gapSize="xs">
+      <Row alignItems="center" gapSize="xxs">
         <Row.Item shrink>{label}</Row.Item>
         {kind === "dismissible" && (
           <Row.Item shrink>
@@ -25,6 +25,11 @@ const Tag = ({
               role="button"
               tabIndex={0}
               onClick={onDismiss}
+              onKeyUp={({ key }) => {
+                if (key === "Enter" || key == " ") {
+                  onDismiss();
+                }
+              }}
             />
           </Row.Item>
         )}

--- a/src/Tag/index.scss
+++ b/src/Tag/index.scss
@@ -1,29 +1,30 @@
 .nds-tag {
-  padding: 0 var(--space-xs);
+  padding: 0 var(--space-s);
   border-radius: 16px;
   display: inline-flex;
   align-items: center;
   font-size: var(--font-size-xs);
-  height: 26px; // per design
+  height: 23px;
   .narmi-icon-x {
     cursor: pointer;
-    font-size: var(--font-size-s);
     display: inline-block;
     transform: translateY(1px);
   }
 }
 .nds-tag--dismissible {
+  height: 25px;
+  padding-right: var(--space-xs);
   color: var(--color-white);
   background: var(--theme-tertiary);
   border: 1px solid var(--theme-tertiary);
 }
 .nds-tag--outline {
   color: var(--theme-primary);
+  font-size: 10px;
   background: transparent;
   border: 1px solid var(--theme-primary);
 }
 .nds-tag--subdued {
   color: var(--theme-primary);
-  background: var(--bgColor-smokeGrey);
-  border: 1px solid var(--bgColor-smokeGrey);
+  background: rgba(var(--theme-rgb-primary), var(--alpha-10));
 }

--- a/src/Tag/index.stories.js
+++ b/src/Tag/index.stories.js
@@ -9,7 +9,7 @@ const InteractiveTemplate = (args) => {
     <div>
       {isTagVisible ? (
         <Tag
-          label={"My cool tag"}
+          label={"Label"}
           kind={"dismissible"}
           onDismiss={() => {
             setTagVisible(false);
@@ -32,7 +32,7 @@ const InteractiveTemplate = (args) => {
 export const Overview = Template.bind({});
 Overview.args = {
   kind: "subdued",
-  label: "My cool tag",
+  label: "Label",
 };
 
 export const UsingWithState = InteractiveTemplate.bind({});


### PR DESCRIPTION
fixes #683 

Match variants to figma designs.

<img width="340" alt="Screen Shot 2022-04-13 at 3 45 24 PM" src="https://user-images.githubusercontent.com/231252/163258412-8a1ee879-36bd-4dfc-8384-732aadbf9bac.png">
<img width="105" alt="Screen Shot 2022-04-13 at 3 45 19 PM" src="https://user-images.githubusercontent.com/231252/163258415-94ff8788-3829-4879-8bc3-c3212201e44e.png">
<img width="101" alt="Screen Shot 2022-04-13 at 3 45 14 PM" src="https://user-images.githubusercontent.com/231252/163258418-c8111434-c1c6-4b2c-98ae-0b1485c7d4bc.png">
<img width="83" alt="Screen Shot 2022-04-13 at 3 45 09 PM" src="https://user-images.githubusercontent.com/231252/163258420-faab60a0-ea11-447d-b6fc-5dd15aa9c846.png">

