### PR TITLE
fix(numberformat): Catch error in case of browser unsupported currency format

### DIFF
--- a/src/formatters/formatNumber.js
+++ b/src/formatters/formatNumber.js
@@ -37,7 +37,13 @@ const formatNumber = (input, style = "currency") => {
     formatterOpts.currency = "USD";
   }
 
-  return new Intl.NumberFormat("en-US", formatterOpts).format(number);
+  try {
+    return new Intl.NumberFormat("en-US", formatterOpts).format(number);
+  }
+  catch {
+    formatterOpts.currencyDisplay = "symbol"
+    return new Intl.NumberFormat("en-US", formatterOpts).format(number);
+  }
 };
 
 export default formatNumber;


### PR DESCRIPTION
Partially address https://github.com/narmi/banking/issues/18403

Adds support to older browsers who do not support the `narrowSymbol` as a currencyDisplay option in the Int.NumberFormat (https://caniuse.com/?search=currencyDisplay)