### PR TITLE
fix(TextInput): enable horizontal scrolling for long unbroken lines

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -168,6 +168,7 @@
   &,
   & > textarea {
     max-height: 80vh; // avoid growing larger than viewport height
+    overflow-wrap: anywhere; // always break line if it exceeds available width
   }
 
   // This pseudo-element is an auto height invisible container that


### PR DESCRIPTION
fixes https://github.com/narmi/banking/issues/17201

Prevent long unbroken lines of text in a textarea from exceeding the bounds of its parent box.