### PR TITLE
feat(TextInput): add icon support to TextInput

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -69,6 +69,7 @@ const Input = ({
 Input.propTypes = {
   id: PropTypes.string,
   label: PropTypes.string,
+  /** full `narmi-icon-<shape>` className */
   icon: PropTypes.node,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   multiline: PropTypes.bool,

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -1,12 +1,18 @@
 import React, { useRef, useState } from "react";
 import PropTypes from "prop-types";
 import Input from "../Input";
+import iconSelection from "src/icons/selection.json";
+
+export const VALID_ICON_NAMES = iconSelection.icons.map(
+  (icon) => icon.properties.name
+);
 
 /**
  * Narmi flavored text input with floating label
  */
 const TextInput = (props) => {
   const {
+    icon,
     formatter,
     multiline,
     defaultValue,
@@ -39,6 +45,7 @@ const TextInput = (props) => {
         ref.current?.focus();
       }}
       {...props}
+      icon={icon ? `narmi-icon-${icon}` : undefined}
     >
       {multiline ? (
         <div
@@ -85,6 +92,8 @@ TextInput.propTypes = {
   multiline: PropTypes.bool,
   /** function that formats the input value on blur */
   formatter: PropTypes.func,
+  /** Name of Narmi icon to place at the start of the input box */
+  icon: PropTypes.oneOf(VALID_ICON_NAMES),
 };
 
 TextInput.defaultProps = {

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import TextInput from "./";
+import TextInput, { VALID_ICON_NAMES } from "./";
 
 const Template = (args) => <TextInput {...args} />;
 
@@ -46,6 +46,12 @@ export const MultiLine = () => {
   return <TextInput multiline />;
 };
 
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  label: "Search",
+  icon: "search",
+};
+
 export const AsColorInput = () => {
   const [color, setColor] = useState("#915F6D");
   return (
@@ -79,5 +85,6 @@ export default {
   argTypes: {
     onChange: { action: "change" },
     onBlur: { action: "blur" },
+    icon: { options: ["", ...VALID_ICON_NAMES] },
   },
 };


### PR DESCRIPTION
fixes #197
fixes #713 

Support icon in `TextInput`. 

Our underlying `Input` component already supported this, so it was just a matter of adding a prop with the proper validation on `TextInput`.

<img width="739" alt="Screen Shot 2022-05-10 at 9 56 55 AM" src="https://user-images.githubusercontent.com/231252/167646836-97e2869a-7d29-4de3-aca9-cfbe8996a159.png">

