### PR TITLE
fix(ContentCard): update styles to match design specs

### DIFF
--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -3,6 +3,7 @@
   display: block;
   width: 100%;
   text-align: left;
+  background-color: var(--color-white);
 }
 
 .nds-contentCard--elevated {

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import ContentCard from "./";
-import Row from "../Row";
 
 const Template = (args) => (
   <div className="bgColor--snowGrey alignChild--center--center padding--all--xl">
@@ -33,22 +32,13 @@ export const SelectableCard = () => {
       onClick={handleClick}
       isSelected={isCardSelected}
     >
-      <Row>
-        <Row.Item>
-          <h3 className="fontSize--heading4 padding--bottom--xs">
-            Selectable card
-          </h3>
-          <div className="fontSize--s fontColor--secondary">
-            This card is currently{" "}
-            <em>{isCardSelected ? "selected" : "not selected"}</em>
-          </div>
-        </Row.Item>
-        {isCardSelected && (
-          <Row.Item shrink>
-            <span className="narmi-icon-check color--successDark fontSize--heading2" />
-          </Row.Item>
-        )}
-      </Row>
+      <h3 className="fontSize--heading4 padding--bottom--xs">
+        Selectable card
+      </h3>
+      <div className="fontSize--s fontColor--secondary">
+        This card is currently{" "}
+        <em>{isCardSelected ? "selected" : "not selected"}</em>
+      </div>
     </ContentCard>
   );
 };


### PR DESCRIPTION
fixes #705 

- make default `ContentCard` background white instead of transparent
- clean up story for interactive `ContentCard`