### PR TITLE
fix(Select): fix children filtering for SSR & React 17

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -15,7 +15,7 @@ const noop = () => {};
 export const isAction = (item) => {
   let result = false;
   if (item) {
-    result = item.type.name === "SelectAction";
+    result = "onSelect" in item.props;
   }
   return result;
 };
@@ -63,10 +63,11 @@ const Select = ({
   defaultOpen = false,
   errorText,
 }) => {
-  // only include valid Select children in options items
-  const items = React.Children.toArray(children).filter((child) =>
-    ["SelectItem", "SelectAction"].includes(child.type.name)
+  // The menu should only render children that have `value` or `onSelect` prop
+  const items = React.Children.toArray(
+    children.filter(({ props }) => "value" in props || "onSelect" in props)
   );
+
   const downshiftOpts = {
     id: "nds-select",
     items,


### PR DESCRIPTION
relates to #712 

As it turns out, the `child.type` property isn't totally reliable across React 16-17 and between client side and server side rendering.

This PR changes the children filtering behavior in `Select` to use the more reliable `props` object to detect if its children are valid `Select.Item` or `Select.Action` components.