### PR TITLE
feat(Select): add checkmark to selected item in menu list

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -41,6 +41,7 @@
   right: var(--space-s);
   top: 50%;
   transform: translateY(-50%);
+  z-index: 999; /* appear above popovers per design */
 }
 
 .nds-dropdownTrigger-error {

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -101,6 +101,8 @@ const Select = ({
     getItemProps,
   } = useSelect(downshiftOpts);
 
+  const hasSelectedItem = selectedItem !== undefined;
+
   return (
     <div className="nds-select">
       <DropdownTrigger
@@ -130,10 +132,16 @@ const Select = ({
                   "nds-select-item--highlighted": highlightedIndex === index,
                   "rounded--top": index === 0,
                   "rounded--bottom": index === items.length - 1,
+                  // make a left gutter for the checkmark if any item selected
+                  "nds-select-item--hasGutter": hasSelectedItem,
                 },
               ])}
               {...getItemProps({ item, index })}
             >
+              {hasSelectedItem &&
+                selectedItem.props.value === item.props.value && (
+                  <span className="narmi-icon-check fontSize--l fontWeight--bold" />
+                )}
               {item}
             </li>
           ))}

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -24,8 +24,19 @@
 
 .nds-select-item {
   cursor: pointer;
+  position: relative;
+  min-height: var(--space-xl);
   &:hover,
   &--highlighted {
     background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+  }
+  &--hasGutter {
+    padding-left: var(--space-xl) !important;
+  }
+  .narmi-icon-check {
+    position: absolute;
+    left: var(--space-s);
+    top: 50%;
+    transform: translateY(-50%);
   }
 }

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -18,8 +18,8 @@ const children = [
   <Select.Item value="truck">
     <span className="narmi-icon-truck padding--right--xs" /> Truck
   </Select.Item>,
-  <Select.Item value="coffee">
-    <span className="narmi-icon-coffee padding--right--xs" /> Coffee
+  <Select.Item value="blob">
+    <span className="narmi-icon-blob padding--right--xs" /> Blob
   </Select.Item>,
 ];
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -35,6 +35,16 @@
 @import "base-styles/typography";
 @import "base-styles/grid";
 
+// Helper classes
+@import "helper-classes/position";
+@import "helper-classes/spacing";
+@import "helper-classes/font";
+@import "helper-classes/background";
+@import "helper-classes/border";
+@import "helper-classes/forms";
+@import "helper-classes/scroll";
+@import "helper-classes/lists";
+
 // Components
 @import "RadioButtons/";
 @import "Input/";
@@ -58,13 +68,3 @@
 @import "Toggle/";
 @import "Tabs/";
 @import "Tag/";
-
-// Helper classes
-@import "helper-classes/position";
-@import "helper-classes/spacing";
-@import "helper-classes/font";
-@import "helper-classes/background";
-@import "helper-classes/border";
-@import "helper-classes/forms";
-@import "helper-classes/scroll";
-@import "helper-classes/lists";


### PR DESCRIPTION
fixes #703 

- Moves helper classes above component-specific styles. This **will not** affect consumers of NDS, but does allow component-specific CSS to override any helper classes applied to NDS components. This is probably the way it should have been from the beginning.
- Make the chevron from `DropdownTrigger` float above any dropdowns or popovers per design
- When an item in `Select` is selected, add a gutter to menu items and show a checkbox on the selected item