### PR TITLE
Fix/719 props consistency

### DIFF
--- a/src/ContentCard/index.js
+++ b/src/ContentCard/index.js
@@ -6,13 +6,15 @@ import cc from "classcat";
  * Narmi style content containers, with support for rendering as an interactive button.
  */
 const ContentCard = ({
-  type = "plain",
+  type = "plain", // DEPRECATED
+  kind = "plain",
   paddingSize = "l",
   onClick = () => {},
   isSelected = false,
   children,
 }) => {
-  const isInteractive = type === "interactive";
+  const variant = type !== undefined ? type : kind; // support deprecated prop
+  const isInteractive = variant === "interactive";
 
   return (
     <div
@@ -32,7 +34,7 @@ const ContentCard = ({
       }
       className={cc([
         "nds-contentCard",
-        `nds-contentCard--${type}`,
+        `nds-contentCard--${variant}`,
         `padding--all--${paddingSize}`,
         "rounded--all bgColor--white",
         { "button--reset": isInteractive },
@@ -56,7 +58,7 @@ ContentCard.propTypes = {
    */
   paddingSize: PropTypes.oneOf(["xs", "s", "m", "l", "xl", "none"]),
   /**
-   * Type of card to render.
+   * Kind of card to render.
    *
    * `plain`: flat, rounded rect
    *
@@ -64,6 +66,8 @@ ContentCard.propTypes = {
    *
    * `interactive`: rounded rect with border, hover styles, and click handler
    */
+  kind: PropTypes.oneOf(["plain", "elevated", "interactive"]),
+  /** DEPRECATED - use `kind` instead. This will be removed in a future release */
   type: PropTypes.oneOf(["plain", "elevated", "interactive"]),
   /**
    * Only valid for `interactive` card type.

--- a/src/ContentCard/index.js
+++ b/src/ContentCard/index.js
@@ -6,7 +6,7 @@ import cc from "classcat";
  * Narmi style content containers, with support for rendering as an interactive button.
  */
 const ContentCard = ({
-  type = "plain", // DEPRECATED
+  type, // DEPRECATED
   kind = "plain",
   paddingSize = "l",
   onClick = () => {},

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -55,6 +55,7 @@ export default {
   title: "Components/ContentCard",
   component: ContentCard,
   argTypes: {
+    type: { table: { disable: true } },
     onClick: { action: "clicked (only fires for `interactive` type)" },
     children: { control: false },
   },

--- a/src/ContentCard/index.test.js
+++ b/src/ContentCard/index.test.js
@@ -17,12 +17,12 @@ describe("Toggle", () => {
   });
 
   it("sets correct classes for elevated card", () => {
-    render(<ContentCard type="elevated">lol</ContentCard>);
+    render(<ContentCard kind="elevated">lol</ContentCard>);
     expect(screen.getByTestId(testId)).toHaveClass("nds-contentCard--elevated");
   });
 
-  it("sets correct attributes and classes for interactive type", () => {
-    render(<ContentCard type="interactive">lol</ContentCard>);
+  it("sets correct attributes and classes for interactive kind", () => {
+    render(<ContentCard kind="interactive">lol</ContentCard>);
     const card = screen.getByTestId(testId);
     expect(screen.queryByRole("button")).toBeInTheDocument();
     expect(card).toHaveAttribute("aria-pressed", "false");
@@ -30,10 +30,10 @@ describe("Toggle", () => {
     expect(card).toHaveClass("nds-contentCard--interactive");
   });
 
-  it("fires onClick handler for `interactive` type", () => {
+  it("fires onClick handler for `interactive` kind", () => {
     const handleClick = jest.fn();
     render(
-      <ContentCard type="interactive" onClick={handleClick}>
+      <ContentCard kind="interactive" onClick={handleClick}>
         lol
       </ContentCard>
     );
@@ -42,7 +42,7 @@ describe("Toggle", () => {
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it("does NOT fire onClick handler for non-interactive types", () => {
+  it("does NOT fire onClick handler for non-interactive kind", () => {
     const handleClick = jest.fn();
     render(<ContentCard onClick={handleClick}>lol</ContentCard>);
     expect(handleClick).not.toHaveBeenCalled();
@@ -52,7 +52,7 @@ describe("Toggle", () => {
 
   it("sets correct attributes for `isSelected`", () => {
     render(
-      <ContentCard type="interactive" isSelected={true} onCLick={() => {}}>
+      <ContentCard kind="interactive" isSelected={true} onCLick={() => {}}>
         lol
       </ContentCard>
     );
@@ -60,7 +60,7 @@ describe("Toggle", () => {
     expect(card).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("does NOT set classes or attributes for `isSelected` for non-interactive types", () => {
+  it("does NOT set classes or attributes for `isSelected` for non-interactive kind", () => {
     render(<ContentCard isSelected={true}>lol</ContentCard>);
     const card = screen.getByTestId(testId);
     expect(card).not.toHaveAttribute("aria-pressed");

--- a/src/ContentCard/index.test.js
+++ b/src/ContentCard/index.test.js
@@ -4,7 +4,7 @@ import ContentCard from "./";
 
 const testId = "ndsContentCard";
 
-describe("Toggle", () => {
+describe("ContentCard", () => {
   it("renders without errors", () => {
     render(
       <ContentCard>

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -25,10 +25,16 @@ Error.propTypes = {
   error: PropTypes.string,
 };
 
+/**
+ * PRIVATE
+ *
+ * This component has no stories because it is only used internally by NDS.
+ * In a future release, this base Input component will be merged with TextInput.
+ */
 const Input = ({
   id,
   label,
-  icon,
+  startIconClass,
   disabled,
   multiline = false,
   decoration,
@@ -50,10 +56,14 @@ const Input = ({
   return (
     <div className={className} onClick={onClick} style={style}>
       <div className="nds-input-box">
-        {icon ? <div className={`nds-input-icon ${icon}`}></div> : ""}
+        {startIconClass ? (
+          <div className={`nds-input-icon ${startIconClass}`}></div>
+        ) : (
+          ""
+        )}
         <div
           className={`nds-input-column ${
-            !label || (icon && !multiline) ? "no-label" : ""
+            !label || (startIconClass && !multiline) ? "no-label" : ""
           }`}
         >
           {children}
@@ -69,8 +79,8 @@ const Input = ({
 Input.propTypes = {
   id: PropTypes.string,
   label: PropTypes.string,
-  /** full `narmi-icon-<shape>` className */
-  icon: PropTypes.node,
+  /** full `narmi-icon-<shape>` className for icon at start of input*/
+  startIconClass: PropTypes.node,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
   multiline: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -12,7 +12,8 @@ export const VALID_ICON_NAMES = iconSelection.icons.map(
  */
 const TextInput = (props) => {
   const {
-    icon,
+    icon, // DEPRECATED
+    startIcon,
     formatter,
     multiline,
     defaultValue,
@@ -20,6 +21,9 @@ const TextInput = (props) => {
     onBlur,
     ...nativeElementProps
   } = props;
+
+  // support deprecated `icon` prop as the startIcon until we remove it
+  const leftIcon = icon !== undefined ? icon : startIcon;
 
   const [inputValue, setInputValue] = useState(
     defaultValue ? defaultValue : ""
@@ -45,7 +49,7 @@ const TextInput = (props) => {
         ref.current?.focus();
       }}
       {...props}
-      icon={icon ? `narmi-icon-${icon}` : undefined}
+      startIconClass={leftIcon ? `narmi-icon-${leftIcon}` : undefined}
     >
       {multiline ? (
         <div
@@ -93,6 +97,8 @@ TextInput.propTypes = {
   /** function that formats the input value on blur */
   formatter: PropTypes.func,
   /** Name of Narmi icon to place at the start of the input box */
+  startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** DEPREACTED - use `startIcon` instead */
   icon: PropTypes.oneOf(VALID_ICON_NAMES),
 };
 

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -85,6 +85,7 @@ export default {
   argTypes: {
     onChange: { action: "change" },
     onBlur: { action: "blur" },
-    icon: { options: ["", ...VALID_ICON_NAMES] },
+    icon: { table: { disable: true } },
+    startIcon: { options: ["", ...VALID_ICON_NAMES] },
   },
 };


### PR DESCRIPTION
fixes #719 

Fixes some prop naming inconsistency in a non-breaking way.

- deprecate `type` in `ContentCard`; accepts `kind` instead
- deprecate `icon` in `TextInput`; accepts `startIcon` now (we will need to support an endIcon in the near future)

I have already filed follow up tickets for the next major release to remove deprecated props as part of future breaking changes.