### PR TITLE
feat(helper-classes): add xxl spacing size

### DIFF
--- a/src/helper-classes/spacing.scss
+++ b/src/helper-classes/spacing.scss
@@ -1,7 +1,7 @@
 /**
 * padding and margin helpers
 */
-$sizes: xxs, xs, s, m, l, xl;
+$sizes: xxs, xs, s, m, l, xl, xxl;
 
 @each $property in (padding, margin) {
   // all sides spacing (`<margin|padding>--all`)

--- a/src/helper-classes/spacing.stories.mdx
+++ b/src/helper-classes/spacing.stories.mdx
@@ -13,7 +13,7 @@ Adds standard margin amount for a given side or axis.
 
 Valid sides/axes are (`all`, `top`, `right`, `bottom`, `left`, `x`, `y`)
 
-Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
+Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`, `xxl`).
 
 <Story name="Margin">
   <ClassExample
@@ -30,7 +30,7 @@ Adds standard padding amount for a given side or axis.
 
 Valid sides/axes are (`all`, `top`, `right`, `bottom`, `left`, `x`, `y`)
 
-Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`).
+Valid amounts are (`xxs`, `xs`, `s`, `m`, `l`, `xl`, `xxl`).
 
 <Story name="Padding">
   <ClassExample

--- a/tokens/src/layout/space.json
+++ b/tokens/src/layout/space.json
@@ -7,6 +7,7 @@
       "m": { "value": "16px" },
       "l": { "value": "20px" },
       "xl": { "value": "40px" },
+      "xxl": { "value": "60px"},
       "default": { "value": "{layout.space.l.value}" }
     }
   }


### PR DESCRIPTION
Design specs sometimes ask for a spacing of `60px` which for now we hardcode or define as a var in the NDS consumer. It's come up often enough for me to think that it should be made part of the standard. 

