### PR TITLE
fix(Button): restrict hover underlines to text label

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -72,7 +72,9 @@ const Button = ({
               <Icon name={startIcon} />
             </Row.Item>
           )}
-          <Row.Item>{buttonLabel}</Row.Item>
+          <Row.Item>
+            <span className="nds-button-label">{buttonLabel}</span>
+          </Row.Item>
           {endIcon && (
             <Row.Item shrink>
               <Icon name={endIcon} />

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -94,7 +94,9 @@
 
   &:hover {
     color: var(--theme-secondary);
-    text-decoration: underline;
+    .nds-button-label {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -135,7 +137,9 @@
   font-size: var(--font-size-default);
 
   &:hover {
-    text-decoration: underline;
     color: RGB(var(--nds-primary-color));
+    .nds-button-label {
+      text-decoration: underline;
+    }
   }
 }


### PR DESCRIPTION
fixes #725 

Restricts text decoration effects to the label area of button (instead of extending to the icon areas, which looks weird)

<img width="142" alt="Screen Shot 2022-05-17 at 4 43 55 PM" src="https://user-images.githubusercontent.com/231252/168906915-776cfaee-fe36-49f2-93c0-2f41893aa605.png">
<img width="128" alt="Screen Shot 2022-05-17 at 4 44 01 PM" src="https://user-images.githubusercontent.com/231252/168906917-a9be2240-9c6e-4feb-be80-0030c23de903.png">

