### PR TITLE
feat: add  prop to all components

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -23,6 +23,7 @@ const Button = ({
   kind = "primary",
   startIcon = null,
   endIcon = null,
+  testId,
   children,
   label,
   onClick = () => {},
@@ -63,7 +64,7 @@ const Button = ({
         },
       ])}
       disabled={isButtonElement && disabled ? true : undefined}
-      data-testid="nds-button"
+      data-testid={testId || "nds-button"}
     >
       <div className="nds-button-content">
         <Row gapSize="s" alignItems="center">
@@ -106,6 +107,8 @@ Button.propTypes = {
   startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Name of Narmi icon to place at the end of the label */
   endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
   /**
    * **⚠️ DEPRECATED**
    *

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -15,6 +15,7 @@ const Checkbox = ({
   checked,
   value,
   kind = "normal",
+  testId,
   ...rest
 }) => {
   const isControlled = checked !== undefined;
@@ -68,6 +69,7 @@ const Checkbox = ({
           name={name}
           id={id}
           value={value}
+          data-testid={testId}
           {...rest}
           type="checkbox"
         />
@@ -97,6 +99,8 @@ Checkbox.propTypes = {
   checked: PropTypes.bool,
   /** Sets the `value` attribute of the `input` */
   value: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
   /**
    * `normal` - visually matche a checkbox input
    *

--- a/src/ContentCard/index.js
+++ b/src/ContentCard/index.js
@@ -12,13 +12,14 @@ const ContentCard = ({
   onClick = () => {},
   isSelected = false,
   children,
+  testId,
 }) => {
   const variant = type !== undefined ? type : kind; // support deprecated prop
   const isInteractive = variant === "interactive";
 
   return (
     <div
-      data-testid="ndsContentCard"
+      data-testid={testId || "ndsContentCard"}
       role={isInteractive ? "button" : undefined}
       tabIndex={isInteractive ? "0" : undefined}
       aria-pressed={isInteractive ? isSelected : undefined}
@@ -97,6 +98,8 @@ ContentCard.propTypes = {
    * Renders card in visually selected state with appropriate attributes.
    */
   isSelected: PropTypes.bool,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default ContentCard;

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -18,6 +18,7 @@ const DateInput = ({
   altFormat,
   defaultDate,
   onChange: onChangeProp = noop,
+  testId,
   ...props
 }) => {
   const input = useRef();
@@ -59,6 +60,7 @@ const DateInput = ({
         type="date"
         required
         placeholder={props.label}
+        data-testid={testId}
         {...props}
       />
     </Input>
@@ -86,6 +88,8 @@ DateInput.propTypes = {
   defaultDate: PropTypes.string,
   /** Changes date format used in input. See [flatpickr docs](https://flatpickr.js.org/formatting/) for formatting options */
   dateFormat: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 DateInput.defaultProps = {
   onChange: () => {},

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -35,6 +35,7 @@ const Dialog = ({
   children,
   footer,
   width = "500px",
+  testId,
 }) => {
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
@@ -81,6 +82,7 @@ const Dialog = ({
         className="nds-dialog"
         style={{ width }}
         ref={focusTrapRef}
+        data-testid={testId}
       >
         <div className={`nds-dialog-header nds-dialog-header--${headerStyle}`}>
           <h4 id="aria-dialog-label">{title}</h4>
@@ -137,6 +139,8 @@ Dialog.propTypes = {
    * Use the full CSS value with the unit (e.g. "400px")
    */
   width: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Dialog;

--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -20,6 +20,7 @@ const DropdownTrigger = React.forwardRef(
       displayValue,
       errorText,
       minWidth = "auto",
+      testId,
       ...otherProps
     },
     ref
@@ -28,7 +29,7 @@ const DropdownTrigger = React.forwardRef(
       <div className="nds-dropdownTrigger" style={{ minWidth }}>
         <button
           ref={ref}
-          data-testid="dropdownTriggerButton"
+          data-testid={testId || "dropdownTriggerButton"}
           className={cc([
             "nds-dropdownTrigger-button button--reset padding--x--s",
             "bgColor--white rounded--all",
@@ -92,6 +93,8 @@ DropdownTrigger.propTypes = {
    * Use the full CSS value with the unit (e.g. "400px")
    */
   minWidth: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default DropdownTrigger;

--- a/src/LoadingShim/index.js
+++ b/src/LoadingShim/index.js
@@ -5,9 +5,9 @@ import PropTypes from "prop-types";
  * Used to wrap a block of loadable content. When `isLoading` is set to true,
  * the content area will have an overlay and loading animation.
  */
-const LoadingShim = ({ isLoading = false, children }) => (
+const LoadingShim = ({ isLoading = false, children, testId }) => (
   <div
-    data-testid="nds-loadingshim"
+    data-testid={testId || "nds-loadingshim"}
     aria-live="polite"
     aria-busy={isLoading.toString()}
     style={{ position: "relative" }}
@@ -34,6 +34,8 @@ LoadingShim.propTypes = {
   children: PropTypes.node.isRequired,
   /** When `true`, the loading shim appears over child content */
   isLoading: PropTypes.bool,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default LoadingShim;

--- a/src/LoadingSkeleton/index.js
+++ b/src/LoadingSkeleton/index.js
@@ -14,9 +14,10 @@ const LoadingSkeleton = ({
   lines = 3,
   showTitle = false,
   size = "medium",
+  testId,
 }) => {
   return isLoading ? (
-    <div className="nds-loading-skeleton">
+    <div className="nds-loading-skeleton" data-testid={testId}>
       {content === "paragraph" && (
         <>
           {showTitle && <div className="nds-line-block header" />}
@@ -53,6 +54,8 @@ LoadingSkeleton.propTypes = {
    * The size of the skeletal header text.
    */
   size: PropTypes.oneOf(["small", "medium", "large"]),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default LoadingSkeleton;

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -70,6 +70,7 @@ const Pagination = ({
   onPageChange = noop,
   totalPages = 1,
   defaultSelectedPage = 1,
+  testId,
 }) => {
   // no jokers allowed 🤡
   // - default to first page if default selected page is out of bounds
@@ -110,7 +111,7 @@ const Pagination = ({
   };
 
   const pagination = (
-    <div className="nds-typography nds-pagination">
+    <div className="nds-typography nds-pagination" data-testid={testId}>
       <nav aria-label="pagination">
         <Row gapSize="xxs" alignItems="center" as="ul">
           <Row.Item as="li" shrink>
@@ -264,6 +265,8 @@ Pagination.propTypes = {
    * Invoked with selected page number as the argument.
    */
   onPageChange: PropTypes.func,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Pagination;

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -22,6 +22,7 @@ const Popover = ({
   offset = 2,
   disableAutoPlacement = false,
   matchTriggerWidth = false,
+  testId,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const focusTrapRef = useFocusTrap(isOpen);
@@ -94,6 +95,7 @@ const Popover = ({
               {...layerProps}
               className="nds-typography nds-popover rounded--all bgColor--white"
               style={layerStyle}
+              data-testid={testId}
             >
               <div ref={focusTrapRef} tabIndex={-1}>
                 {content}
@@ -131,6 +133,8 @@ Popover.propTypes = {
    * always be placed on the given `side` prop.
    */
   disableAutoPlacement: PropTypes.bool,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Popover;

--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -18,6 +18,7 @@ const RadioButtons = ({
   value,
   kind = "normal",
   onChange = () => {},
+  testId,
   ...containerProps
 }) => {
   const isControlled = value !== undefined;
@@ -51,6 +52,7 @@ const RadioButtons = ({
     <div
       className={`nds-radiobuttons nds-radiobuttons--${kind}`}
       onChange={handleChange}
+      data-testid={testId}
       {...containerProps}
     >
       {Object.entries(options).map(([label, inputValue]) => (
@@ -109,6 +111,8 @@ RadioButtons.propTypes = {
    * `card` - display input and label as a toggleable card
    */
   kind: PropTypes.oneOf(["normal", "card"]),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default RadioButtons;

--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -7,10 +7,11 @@ import AsElement from "../util/AsElement";
  * Child component of `Row`.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
  */
-const RowItem = ({ shrink = false, as = "div", children }) => (
+const RowItem = ({ shrink = false, as = "div", children, testId }) => (
   <AsElement
     elementType={as}
     className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}
+    data-testid={testId}
   >
     {children}
   </AsElement>
@@ -28,6 +29,8 @@ RowItem.propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default RowItem;

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -31,11 +31,13 @@ const Row = ({
   gapSize = "l",
   as = "div",
   children,
+  testId,
 }) => (
   <AsElement
     elementType={as}
     className="nds-row"
     style={_getRowStyle(alignItems, justifyContent, gapSize)}
+    data-testid={testId}
   >
     {children}
   </AsElement>
@@ -56,6 +58,8 @@ Row.propTypes = {
   as: PropTypes.oneOf(["div", "ul"]),
   /** Children must be of type `Row.Item` */
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 Row.Item = RowItem;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -62,6 +62,7 @@ const Select = ({
   defaultValue,
   defaultOpen = false,
   errorText,
+  testId,
 }) => {
   // The menu should only render children that have `value` or `onSelect` prop
   const items = React.Children.toArray(
@@ -104,7 +105,7 @@ const Select = ({
   const hasSelectedItem = selectedItem !== undefined;
 
   return (
-    <div className="nds-select">
+    <div className="nds-select" data-testid={testId}>
       <DropdownTrigger
         isOpen={isOpen}
         labelText={label}
@@ -178,6 +179,8 @@ Select.propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 Select.Item = SelectItem;

--- a/src/SeparatorList/index.js
+++ b/src/SeparatorList/index.js
@@ -4,8 +4,11 @@ import PropTypes from "prop-types";
 /**
  * Takes a list of elements and places a visual separator between items.
  */
-const SeparatorList = ({ separator = "|", items = [] }) => (
-  <ul className="list--reset nds-typography nds-separatorList">
+const SeparatorList = ({ separator = "|", items = [], testId }) => (
+  <ul
+    className="list--reset nds-typography nds-separatorList"
+    data-testid={testId}
+  >
     {items.map((item, i) => {
       const itemProps = {};
       if (i !== items.length - 1) {
@@ -29,6 +32,8 @@ SeparatorList.propTypes = {
    * Character to use as separator between items
    */
   separator: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default SeparatorList;

--- a/src/Tabs/TabsPanel.js
+++ b/src/Tabs/TabsPanel.js
@@ -2,7 +2,7 @@ import React, { useEffect, useContext } from "react";
 import PropTypes from "prop-types";
 import TabsContext from "./context";
 
-const TabsPanel = ({ children, tabId }) => {
+const TabsPanel = ({ children, tabId, testId }) => {
   const { currentIndex, tabIds, hasPanels, setHasPanels } =
     useContext(TabsContext);
   const selectedId = tabIds[currentIndex];
@@ -21,6 +21,7 @@ const TabsPanel = ({ children, tabId }) => {
       id={`${tabId}-tabpanel`}
       aria-labelledby={`${tabId}-tab`}
       hidden={tabId !== selectedId ? true : undefined}
+      data-testid={testId}
     >
       {children}
     </div>
@@ -32,6 +33,8 @@ TabsPanel.propTypes = {
   children: PropTypes.node.isRequired,
   /** String ID used to link the `Tabs.Panel` to a `Tabs.Tab` */
   tabId: PropTypes.string.isRequired,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 TabsPanel.displayName = "Tabs.Panel";

--- a/src/Tabs/TabsTab.js
+++ b/src/Tabs/TabsTab.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import TabsContext from "./context";
 import cc from "classcat";
 
-const TabsTab = ({ label, tabId }) => {
+const TabsTab = ({ label, tabId, testId }) => {
   const { currentIndex, tabIds, hasPanels, changeTabs } =
     useContext(TabsContext);
   const isSelected = tabId === tabIds[currentIndex];
@@ -31,6 +31,7 @@ const TabsTab = ({ label, tabId }) => {
         id={`${tabId}-tab`}
         tabIndex={hasPanels ? "-1" : "0"}
         onClick={() => changeTabs(tabId)}
+        data-testid={testId}
       >
         {label}
       </button>
@@ -43,6 +44,8 @@ TabsTab.propTypes = {
   label: PropTypes.string.isRequired,
   /** String ID used to link the `Tabs.Tab` to a `Tabs.Panel` */
   tabId: PropTypes.string.isRequired,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 TabsTab.displayName = "Tabs.Tab";

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -21,6 +21,7 @@ const Tabs = ({
   selectedIndex = null,
   onTabChange = noop,
   hasBorder = true,
+  testId,
 }) => {
   const [tabIds, setTabIds] = useState([]);
   const [hasPanels, setHasPanels] = useState(false);
@@ -48,7 +49,10 @@ const Tabs = ({
         changeTabs,
       }}
     >
-      <div className={cc(["nds-tabs", { "nds-tabs--bordered": hasBorder }])}>
+      <div
+        className={cc(["nds-tabs", { "nds-tabs--bordered": hasBorder }])}
+        data-testid={testId}
+      >
         {children}
       </div>
     </TabsContext.Provider>
@@ -75,6 +79,8 @@ Tabs.propTypes = {
   onTabChange: PropTypes.func,
   /** Shows bottom border when `true` */
   hasBorder: PropTypes.bool,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 Tabs.List = TabsList;

--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -13,9 +13,13 @@ const Tag = ({
   kind = "subdued", // outline, subdued, x-tag (cactus400) #7fbc5b; #7FBC5B oneof
   onDismiss = noop,
   label,
+  testId,
 }) => {
   return (
-    <div className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}>
+    <div
+      className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}
+      data-testid={testId}
+    >
       <Row alignItems="center" gapSize="xxs">
         <Row.Item shrink>{label}</Row.Item>
         {kind === "dismissible" && (
@@ -39,10 +43,17 @@ const Tag = ({
 };
 
 Tag.propTypes = {
-  disableAutoPlacement: PropTypes.bool,
+  /** Variant of Tag */
   kind: PropTypes.oneOf(["subdued", "dismissible", "outline"]),
+  /**
+   * Callback for user dismissal action
+   * (only applicable for `dismissable` kind)
+   */
   onDismiss: PropTypes.func,
+  /** Label text of tag */
   label: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Tag;

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -19,6 +19,7 @@ const TextInput = (props) => {
     defaultValue,
     onChange,
     onBlur,
+    testId,
     ...nativeElementProps
   } = props;
 
@@ -64,6 +65,7 @@ const TextInput = (props) => {
             onChange={_onChange}
             onBlur={_onBlur}
             required
+            data-testid={testId}
             {...nativeElementProps}
           />
         </div>
@@ -77,6 +79,7 @@ const TextInput = (props) => {
           type="text"
           required
           placeholder={props.label}
+          data-testid={testId}
           {...nativeElementProps}
         />
       )}
@@ -100,6 +103,8 @@ TextInput.propTypes = {
   startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** DEPREACTED - use `startIcon` instead */
   icon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 TextInput.defaultProps = {

--- a/src/Toggle/index.js
+++ b/src/Toggle/index.js
@@ -10,6 +10,7 @@ const Toggle = ({
   onChange = () => {},
   labelledBy,
   label,
+  testId,
 }) => {
   const [isActive, setIsActive] = useState(defaultActive);
 
@@ -32,6 +33,7 @@ const Toggle = ({
       aria-checked={isActive.toString()}
       onClick={toggleActive}
       aria-labelledby={labelledBy}
+      data-testid={testId}
     >
       <span className="nds-toggle-indicator elevation--low" />
       <span className="nds-toggle-buttonText">{isActive ? "on" : "off"}</span>
@@ -60,6 +62,8 @@ Toggle.propTypes = {
   label: PropTypes.string,
   /** ID of element that labels the toggle control (e.g. `my-label-element`)*/
   labelledBy: PropTypes.string,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Toggle;

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -14,6 +14,7 @@ const Tooltip = ({
   children,
   wrapperDisplay = "inline-flex",
   maxWidth = "400px",
+  testId,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const delays = {
@@ -70,6 +71,7 @@ const Tooltip = ({
               className="nds-typography nds-tooltip elevation--middle"
               {...layerProps}
               style={{ maxWidth: maxWidth, ...layerProps.style }}
+              data-testid={testId}
             >
               {text}
               <Arrow {...arrowProps} />
@@ -98,6 +100,8 @@ Tooltip.propTypes = {
   ]),
   /** Sets maximum width of tooltip */
   maxWidth: PropTypes.number,
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
 };
 
 export default Tooltip;


### PR DESCRIPTION
fixes #709 

Adds dedicated `testId` prop to all components.

Not all components spread props, so an explicit, documented prop is used for the sake of API consistency across all components.

Older hard-coded test ids will still be present unless the consumer passes a `testId` override.