### PR TITLE
fix(icons): inline icon assets

### DIFF
--- a/src/icons/icons.css
+++ b/src/icons/icons.css
@@ -1,11 +1,11 @@
 @font-face {
   font-family: "icomoon";
-  src: url("./icomoon.eot?tsm2bw");
-  src: url("./icomoon.eot?tsm2bw#iefix")
-      format("embedded-opentype"),
-    url("./icomoon.ttf?tsm2bw") format("truetype"),
-    url("./icomoon.woff?tsm2bw") format("woff"),
-    url("./icomoon.svg?tsm2bw#icomoon") format("svg");
+  /*
+  * Because our webpack config inlines these resources as base64,
+  * we only include the `woff` format to reduce CSS file size.
+  * (this format works in all supported browsers)
+  */
+  src: url("./icomoon.woff?tsm2bw") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,9 +64,8 @@ module.exports = {
         ],
       },
       {
-        test: /icomoon.*\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
-        type: "asset/resource",
-        generator: { filename: "icons/[hash][ext][query]" },
+        test: /(icomoon).*\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        type: "asset/inline",
       },
       {
         test: /narmi-matiere.*\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,


### PR DESCRIPTION
fixes #741 
fixes #739 

- converts icon font file `url()` to inline base64
- load only the `woff` format for icon fonts to reduce CSS size (we don't support IE)

Next.js consumers were running into an issue in production builds where icon font files could not be loaded due to a CORS error. We can sidestep the issue by inlining the icon font until there is a more stable fix.

We will look for a better long-term solution in the follow a ticket: #746