### PR TITLE
fix: update unshimmed legacy theme vars

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -132,12 +132,12 @@
 */
 .nds-plain-button {
   cursor: pointer;
-  color: RGB(var(--nds-primary-color));
+  color: var(--theme-primary);
   font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-default);
 
   &:hover {
-    color: RGB(var(--nds-primary-color));
+    color: var(--theme-primary);
     .nds-button-label {
       text-decoration: underline;
     }

--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -16,7 +16,7 @@
   &[data-hoverable="true"]:active,
   &[data-hoverable="true"]:hover,
   &[data-selected="true"] {
-    border: 1px solid RGB(var(--nds-primary-color));
+    border: 1px solid var(--theme-primary);
   }
 
   &[data-hoverable="true"]:active,
@@ -34,7 +34,7 @@
     display: flex;
 
     .nds-card-title {
-      color: RGB(var(--nds-primary-color));
+      color: var(--theme-primary);
       margin: 0;
       line-height: 28px;
 

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -30,8 +30,8 @@
 
   &.nds-checkbox--checked {
     .narmi-icon-check {
-      background-color: RGB(var(--nds-primary-color));
-      border: 1px solid RGB(var(--nds-primary-color));
+      background-color: var(--theme-primary);
+      border: 1px solid var(--theme-primary);
       &:after {
         display: block;
       }

--- a/src/DateInput/index.scss
+++ b/src/DateInput/index.scss
@@ -5,10 +5,9 @@ body {
   .flatpickr-calendar {
     margin-top: 20px;
     margin-left: -10px;
-    box-shadow: 2px 0 0 RGB(var(--nds-primary-color)),
-      -2px 0 0 RGB(var(--nds-primary-color)),
-      0 2px 0 RGB(var(--nds-primary-color)),
-      0 -2px 0 RGB(var(--nds-primary-color)), 0 3px 13px RGB(0 0 0 / 8%);
+    box-shadow: 2px 0 0 var(--theme-primary), -2px 0 0 var(--theme-primary),
+      0 2px 0 var(--theme-primary), 0 -2px 0 var(--theme-primary),
+      0 3px 13px RGB(0 0 0 / 8%);
 
     &:before,
     &:after {
@@ -32,7 +31,7 @@ body {
   }
 
   .flatpickr-current-month {
-    color: RGB(var(--nds-primary-color));
+    color: var(--theme-primary);
 
     span.cur-month {
       user-select: none;
@@ -187,7 +186,7 @@ body {
     }
 
     &:hover {
-      color: RGB(var(--nds-primary-color));
+      color: var(--theme-primary);
     }
 
     &:after {
@@ -195,7 +194,7 @@ body {
       font-family: "icomoon";
       top: -2px;
       font-size: 24px;
-      color: RGB(var(--nds-primary-color));
+      color: var(--theme-primary);
     }
   }
 

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -29,10 +29,10 @@
     align-items: center;
 
     &:focus-within {
-      border: 1px solid RGB(var(--nds-primary-color));
+      border: 1px solid var(--theme-primary);
 
       label {
-        color: RGB(var(--nds-primary-color));
+        color: var(--theme-primary);
         margin-bottom: -3px;
       }
     }

--- a/src/Modal/index.scss
+++ b/src/Modal/index.scss
@@ -103,5 +103,5 @@
 }
 
 hr.nds-hr {
-  border: 1px solid RGB(var(--nds-primary-color));
+  border: 1px solid var(--theme-primary);
 }

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -46,7 +46,7 @@
         height: 12px;
         transform: translate(-50%, -50%);
         border-radius: 50%;
-        background: RGB(var(--nds-primary-color));
+        background: var(--theme-primary);
       }
     }
 


### PR DESCRIPTION
fixes #731
fixes #732

Some NDS style values were being set to a legacy CSS custom property for the primary theme color. These get appropriately shimmed in `banking` and storybook, but third party consumers are missing the shim.

This PR replaces all the legacy vars with the correct `--theme` var from design tokens to resolve the problem of vanishing borders and unchecked radios.