### PR TITLE
refactor(tokens): replace all legacy `--nds-` tokens with standard vars

### DIFF
--- a/src/Card/index.scss
+++ b/src/Card/index.scss
@@ -1,12 +1,11 @@
 .nds-card {
   width: 100%;
   height: 100%;
-  box-shadow: RGB(var(--nds-dropshadow-light));
   border-radius: 4px;
 
   padding: 20px;
-  background-color: RGB(var(--nds-white));
-  border: 1px solid RGB(var(--nds-lightest-grey));
+  background-color: var(--color-white);
+  border: 1px solid var(--color-lightGrey);
 
   &[data-hoverable="true"] {
     box-shadow: none;
@@ -21,7 +20,7 @@
 
   &[data-hoverable="true"]:active,
   &[data-selected="true"] {
-    background-color: RGBA(var(--nds-primary-color), var(--subdued-5-opacity));
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
   }
 
   @media (max-width: #{map.get($breakpoints, "s")}) {

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -46,7 +46,7 @@
     background-color: white;
     font-weight: bold;
     border-radius: 3px;
-    border: 1px solid RGB(var(--nds-lightest-grey));
+    border: 1px solid var(--color-lightGrey);
     color: white;
     font-size: 15px;
     text-align: center;

--- a/src/DateInput/index.scss
+++ b/src/DateInput/index.scss
@@ -27,7 +27,7 @@ body {
   }
 
   .flatpickr-month {
-    font-family: var(--nds-font-family);
+    font-family: var(--font-family-body);
   }
 
   .flatpickr-current-month {
@@ -72,7 +72,7 @@ body {
   }
 
   span.flatpickr-weekday {
-    font-family: var(--nds-font-family);
+    font-family: var(--font-family-body);
     font-weight: 400;
     user-select: none;
   }
@@ -81,8 +81,8 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--nds-black);
-    font-family: var(--nds-font-family);
+    color: var(--color-black);
+    font-family: var(--font-family-body);
     user-select: none;
   }
 
@@ -135,15 +135,12 @@ body {
   .flatpickr-day.today:hover {
     background-color: transparent;
     border-color: #e9e9e9;
-    color: var(--nds-black);
+    color: var(--color-black);
 
     &:before {
       position: absolute;
       content: "\A";
-      background-color: RGBA(
-        var(--nds-primary-color),
-        var(--subdued-20-opacity)
-      );
+      background-color: RGBA(var(--theme-rgb-primary), var(--alpha-20));
       border-radius: 40px;
       z-index: -1;
       height: 30px;
@@ -165,7 +162,7 @@ body {
   .flatpickr-day.flatpickr-day.endRange:focus {
     color: white;
     &:before {
-      background-color: RGBA(var(--nds-primary-color));
+      background-color: var(--theme-primary);
     }
   }
 

--- a/src/Dropdown/index.scss
+++ b/src/Dropdown/index.scss
@@ -52,7 +52,7 @@
       overflow: hidden;
       .nds-dropdown-children {
         border-radius: 4px;
-        border: 1px solid var(--nds-primary-color);
+        border: 1px solid var(--theme-primary);
         font-size: 16px;
         .nds-dropdown-item {
           padding-top: 5px;

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -5,7 +5,7 @@
   vertical-align: middle;
   font-weight: 400;
   line-height: normal;
-  font-family: var(--nds-font-family);
+  font-family: var(--font-family-body);
   border: none;
   outline: 0;
   padding: 0;
@@ -19,8 +19,8 @@
   font-size: 16px;
 
   .nds-input-box {
-    border: 1px solid RGB(var(--nds-lightest-grey));
-    background: RGB(var(--nds-white));
+    border: 1px solid var(--color-lightGrey);
+    background: var(--color-white);
     position: relative;
     width: 100%;
     padding: 7px 0.8em;
@@ -46,20 +46,20 @@
 
   &.disabled .nds-input-box {
     pointer-events: none;
-    background-color: RGB(var(--nds-smoke-grey));
+    background-color: var(--color-smokeGrey);
 
     input {
-      color: RGB(var(--nds-medium-grey));
+      color: var(--color-mediumGrey);
     }
   }
 
   &.error {
     .nds-input-box {
-      border: 1px solid RGB(var(--nds-red));
+      border: 1px solid var(--color-errorDark);
     }
 
     label {
-      color: RGB(var(--nds-red));
+      color: var(--color-errorDark);
     }
   }
 
@@ -77,10 +77,10 @@
   label {
     background: transparent;
     pointer-events: none;
-    font-family: var(--nds-font-family);
+    font-family: var(--font-family-body);
     font-weight: 400;
     font-size: 12px;
-    color: RGB(var(--nds-medium-grey));
+    color: var(--color-mediumGrey);
     line-height: 1.25;
     white-space: nowrap;
     overflow: hidden;
@@ -90,7 +90,7 @@
   .nds-input-error {
     font-size: 12px;
     font-weight: 400;
-    color: RGB(var(--nds-red));
+    color: var(--color-errorDark);
     width: 100%;
     display: flex;
     flex-flow: row nowrap;
@@ -105,12 +105,12 @@
   }
 
   input {
-    color: RGB(var(--nds-grey));
+    color: var(--color-grey);
   }
 
   textarea {
     @extend %shared-multiline-styles;
-    color: var(--nds-grey-text);
+    color: var(--color-grey);
     width: 100%;
     resize: none;
   }
@@ -126,7 +126,7 @@
     outline: 0;
     letter-spacing: 0;
     vertical-align: middle;
-    font-family: var(--nds-font-family);
+    font-family: var(--font-family-body);
     padding: 0;
     width: 100%;
     font-size: 16px;
@@ -156,7 +156,7 @@
   input,
   textarea {
     &::placeholder {
-      color: var(--nds-medium-grey);
+      color: var(--color-mediumGrey);
       font-weight: 400;
     }
   }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -39,7 +39,7 @@ const Modal = ({
         <div className="nds-modal-dismiss" onClick={setNotOpen}>
           <span
             className={"narmi-icon-x"}
-            style={{ fontSize: "20px", color: "rgb(var(--nds-black))" }}
+            style={{ fontSize: "20px", color: "var(--color-black)" }}
           />
         </div>
         {header ? (

--- a/src/Modal/index.scss
+++ b/src/Modal/index.scss
@@ -20,7 +20,7 @@
     display: none;
     z-index: 100;
     position: fixed;
-    background: RGB(var(--nds-white));
+    background: var(--color-white);
     border-radius: 8px;
     max-width: 500px;
   }
@@ -84,7 +84,7 @@
     padding: 0;
     background: none;
     & > .nds-details-container {
-      background: RGB(var(--nds-white));
+      background: var(--color-white);
     }
   }
 

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -33,7 +33,7 @@
       height: 20px;
       width: 20px;
       background-color: transparent;
-      border: 1px solid RGB(var(--nds-lightest-grey));
+      border: 1px solid var(--color-lightGrey);
       border-radius: 50%;
 
       &:after {

--- a/src/base-styles/typography.scss
+++ b/src/base-styles/typography.scss
@@ -47,7 +47,7 @@
     font-weight: var(--font-weight-bold);
     font-size: var(--font-size-xs);
     text-transform: uppercase;
-    color: var(--nds-black);
+    color: var(--color-black);
   }
 
   p {


### PR DESCRIPTION
fixes #749 

Replaces all usage of older `--nds-` CSS vars with standard vars from design tokens. This ensures nothing in NDS relies on the consumer to shim these properties.