### PR TITLE
fix: minor styling tweaks for `Tabs` and `Dialog`

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -33,7 +33,7 @@
   // for tablet or larger, display the modal dialog as a floating box.
   @include atMediaUp("s") {
     height: auto;
-    border-radius: var(--border-radius-default);
+    border-radius: var(--border-radius-m);
     max-height: 100%; // prevent modal from being taller than the shim content box
     min-height: 240px; // prevent content area from collapsing to 0
     min-width: 240px; // should be no narrower than this on larger viewports

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -30,6 +30,6 @@
   }
 
   &--selected {
-    font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-bold);
   }
 }


### PR DESCRIPTION
fixes #758 

- Make selected tab have bold font weight
- Use 8px border radius on `Dialog`