### PR TITLE
feat(Toggle): add `isActive` prop to `Toggle` (fully controlled)

### DIFF
--- a/src/Toggle/index.js
+++ b/src/Toggle/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 
@@ -7,16 +7,28 @@ import cc from "classcat";
  */
 const Toggle = ({
   defaultActive = false,
+  isActive,
   onChange = () => {},
   labelledBy,
   label,
   testId,
 }) => {
-  const [isActive, setIsActive] = useState(defaultActive);
+  const isControlled = isActive !== undefined;
+  const [isActiveInternal, setIsActiveInternal] = useState(
+    isControlled ? isActive : defaultActive || false
+  );
+
+  useEffect(() => {
+    if (isControlled) {
+      setIsActiveInternal(isActive);
+    }
+  }, [isActive]);
 
   const toggleActive = () => {
-    onChange(!isActive);
-    setIsActive(!isActive);
+    if (!isControlled) {
+      setIsActiveInternal(!isActiveInternal);
+    }
+    onChange(!isActiveInternal);
   };
 
   const buttonJsx = (
@@ -25,18 +37,20 @@ const Toggle = ({
         "resetButton",
         "nds-toggle",
         {
-          "nds-toggle--active": isActive,
+          "nds-toggle--active": isActiveInternal,
         },
       ])}
       type="button"
       role="switch"
-      aria-checked={isActive.toString()}
+      aria-checked={isActiveInternal.toString()}
       onClick={toggleActive}
       aria-labelledby={labelledBy}
       data-testid={testId}
     >
       <span className="nds-toggle-indicator elevation--low" />
-      <span className="nds-toggle-buttonText">{isActive ? "on" : "off"}</span>
+      <span className="nds-toggle-buttonText">
+        {isActiveInternal ? "on" : "off"}
+      </span>
     </button>
   );
 
@@ -58,6 +72,12 @@ Toggle.propTypes = {
   onChange: PropTypes.func,
   /** When set to `true`, the toggle will initially render as active */
   defaultActive: PropTypes.bool,
+  /**
+   * Sets active state of toggle; makes the component fully controlled.
+   * When using `isActive` you **must** use the `onChange` callback
+   * to update the active state of the toggle.
+   */
+  isActive: PropTypes.bool,
   /** Label element to render to the right of the toggle */
   label: PropTypes.string,
   /** ID of element that labels the toggle control (e.g. `my-label-element`)*/

--- a/src/Toggle/index.stories.js
+++ b/src/Toggle/index.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Toggle from "./";
 import Row from "../Row";
 
@@ -25,6 +25,23 @@ export const WithCustomLabel = () => (
   </div>
 );
 /* eslint-enable jsx-a11y/label-has-associated-control */
+
+export const FullyControlled = () => {
+  const [isActive, setIsActive] = useState(false);
+  return (
+    <>
+      <Toggle
+        label="Toggle state fully controlled"
+        isActive={isActive}
+        onChange={() => setIsActive((isActive) => !isActive)}
+      />
+      <hr />
+      <div className="alignChild--center--center">
+        <button onClick={() => setIsActive(false)}>Deactivate toggle</button>
+      </div>
+    </>
+  );
+};
 
 export default {
   title: "Components/Toggle",

--- a/src/Toggle/index.test.js
+++ b/src/Toggle/index.test.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import Toggle from "./";
 
@@ -20,5 +20,27 @@ describe("Toggle", () => {
     expect(handleChange).toHaveBeenLastCalledWith(true);
     fireEvent.click(screen.getByRole("switch"));
     expect(handleChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("acts as fully controlled component when `isActive` is passed", () => {
+    const ControlledToggleWithHandler = () => {
+      const [isActive, setIsActive] = useState(false);
+      return (
+        <>
+          <Toggle
+            label="Controlled Toggle"
+            isActive={isActive}
+            onChange={() => setIsActive((isActive) => !isActive)}
+          />
+          <button onClick={() => setIsActive(false)}>Reset</button>
+        </>
+      );
+    };
+    render(<ControlledToggleWithHandler />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
   });
 });


### PR DESCRIPTION
fixes #771 

Makes `Toggle` have a fully controlled mode via the new `isActive` prop.

<img width="1026" alt="Screen Shot 2022-07-06 at 1 49 22 PM" src="https://user-images.githubusercontent.com/231252/177613118-b5ec282a-fc56-4128-befc-d2b2b7eeacc3.png">

