### PR TITLE
fix(TextInput): prevent descenders in floating label from being cut off

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -104,6 +104,11 @@
     }
   }
 
+  input,
+  textarea {
+    background: transparent;
+  }
+
   input {
     color: var(--color-grey);
   }


### PR DESCRIPTION
fixes #766 

The white background is defined in the parent box of the input, so we can make the input itself transparent to prevent cutting off text in the floating label

<img width="361" alt="Screen Shot 2022-07-11 at 5 36 11 PM" src="https://user-images.githubusercontent.com/231252/178362828-9e46614c-d227-455f-87a0-e59098e1e585.png">

