### PR TITLE
feat(Button): add `size` prop to support size variants

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -21,6 +21,7 @@ export const VALID_ICON_NAMES = iconSelection.icons.map(
 const Button = ({
   disabled = false,
   kind = "primary",
+  size = "m",
   startIcon = null,
   endIcon = null,
   testId,
@@ -58,6 +59,7 @@ const Button = ({
         "nds-typography",
         "nds-button",
         `nds-button--${kind}`,
+        `fontSize--${size}`,
         {
           resetButton: as === "button",
           "nds-button--disabled": disabled,
@@ -101,6 +103,8 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   /** style of button to render */
   kind: PropTypes.oneOf(["primary", "secondary", "negative", "menu", "plain"]),
+  /** size variant of button */
+  size: PropTypes.oneOf(["s", "m", "l"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
   /** Name of Narmi icon to place at the start of the label */

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -68,7 +68,7 @@
   text-align: left;
   color: var(--font-color-primary);
   display: block;
-  font-size: var(--font-size-l);
+  font-size: var(--font-size-l) !important;
 
   .nds-button-content {
     margin: 10px 0;
@@ -78,7 +78,7 @@
     margin: 0 12px;
     font-weight: var(--font-weight-semibold);
     display: inline-block;
-    font-size: var(--font-size-default);
+    font-size: var(--font-size-default) !important;
   }
 }
 
@@ -134,7 +134,6 @@
   cursor: pointer;
   color: var(--theme-primary);
   font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-default);
 
   &:hover {
     color: var(--theme-primary);

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -42,6 +42,20 @@ ConfirmAndCancel.parameters = {
   },
 };
 
+export const ButtonSizes = () => (
+  <Row alignItems="center">
+    <Row.Item shrink>
+      <Button kind="plain" label="Small Button" size="s" />
+    </Row.Item>
+    <Row.Item shrink>
+      <Button kind="plain" label="Medium Button" size="m" />
+    </Row.Item>
+    <Row.Item shrink>
+      <Button kind="plain" label="Large Button" size="l" />
+    </Row.Item>
+  </Row>
+);
+
 export default {
   title: "Components/Button",
   component: Button,

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -45,6 +45,24 @@ describe("Button", () => {
     expect(button).toHaveAttribute("disabled");
   });
 
+  it("has expected classes for `s` size", () => {
+    render(<Button label={LABEL} size="s" />);
+    const button = getButton();
+    expect(button).toHaveClass("fontSize--s");
+  });
+
+  it("has expected classes for `m` size", () => {
+    render(<Button label={LABEL} size="m" />);
+    const button = getButton();
+    expect(button).toHaveClass("fontSize--s");
+  });
+
+  it("has expected classes for `l` size", () => {
+    render(<Button label={LABEL} size="l" />);
+    const button = getButton();
+    expect(button).toHaveClass("fontSize--l");
+  });
+
   it("has expected classes for secondary button", () => {
     render(<Button label={LABEL} kind="secondary" />);
     const button = getButton();

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -54,7 +54,7 @@ describe("Button", () => {
   it("has expected classes for `m` size", () => {
     render(<Button label={LABEL} size="m" />);
     const button = getButton();
-    expect(button).toHaveClass("fontSize--s");
+    expect(button).toHaveClass("fontSize--m");
   });
 
   it("has expected classes for `l` size", () => {


### PR DESCRIPTION
fixes #779 

Adds `size` prop to `Button`.

<img width="604" alt="Screen Shot 2022-07-20 at 2 24 10 PM" src="https://user-images.githubusercontent.com/231252/180055341-8e0a3466-6f7d-4c84-8b54-4bb25479aa0f.png">

