### PR TITLE
feat(Combobox): add `inputValue` prop to enable fully controlled input

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -39,6 +39,7 @@ const Combobox = ({
   label,
   onChange = noop,
   onInputChange = noop,
+  inputValue: controlledInputValue,
   children,
   disableFiltering = false,
   errorText,
@@ -70,6 +71,7 @@ const Combobox = ({
     reset,
   } = useCombobox({
     items: displayedItems,
+    inputValue: controlledInputValue,
     itemToString: (item) => item.props.value,
     onInputValueChange: ({ inputValue }) => {
       // Typeahead behavior - we adjust the list of available options passed
@@ -98,10 +100,9 @@ const Combobox = ({
         newSelection = selectedItem.props.value;
       }
       onChange(newSelection);
+      onInputChange(newSelection);
     },
   });
-
-  const hasSelectedItem = !!selectedItem;
 
   // It is possible that a consumer may have nothing to pass to `children`.
   // For example, if an API response hasn't completed to load in the autocomplete
@@ -113,9 +114,12 @@ const Combobox = ({
         label={label}
         startIcon={icon}
         onChange={onInputChange}
+        value={inputValue}
       />
     );
   }
+
+  const hasSelectedItem = !!selectedItem;
 
   return (
     <div
@@ -214,6 +218,12 @@ Combobox.propTypes = {
   label: PropTypes.string.isRequired,
   /** Change callback. Called when an item is selected, with the `value` of the selected item */
   onChange: PropTypes.func,
+  /**
+   * Sets value of the input in a controlled manner.
+   * When using the `inputValue` prop, you **must** update it via the
+   * `onInputChange` handler.
+   */
+  inputValue: PropTypes.string,
   /** Input change callback. Called whenever the user updates the value of the input. */
   onInputChange: PropTypes.func,
   /**

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
-import React from "react";
+import React, { useState } from "react";
 import Combobox, { VALID_ICON_NAMES } from "./";
 import ComboboxItem from "./ComboboxItem";
 import ComboboxHeading from "./ComboboxHeading";
@@ -52,6 +52,42 @@ NoChildren.parameters = {
     description: {
       story:
         "If no children are passed, the `Combobox` will render a plain input",
+    },
+  },
+};
+
+export const FullyControlled = () => {
+  const [inputValue, setInputValue] = useState("Initial Value");
+  return (
+    <div>
+      <Combobox
+        label="Select Account"
+        inputValue={inputValue}
+        onInputChange={(val) => setInputValue(val)}
+      >
+        <Combobox.Heading text="Checking" />
+        <Combobox.Item value="Primary Checking - 4567" />
+        <Combobox.Item value="Secondary Checking - 9876" />
+        <Combobox.Heading text="Savings" />
+        <Combobox.Item value="Primary Savings - 1234" />
+        <Combobox.Item value="Cheese Fund - 5432" />
+      </Combobox>
+      <button
+        className="margin--top"
+        onClick={() => {
+          setInputValue("");
+        }}
+      >
+        Clear input value
+      </button>
+    </div>
+  );
+};
+FullyControlled.parameters = {
+  docs: {
+    description: {
+      story:
+        "To fully control the value input, use `inputValue` and `onInputChange`.",
     },
   },
 };

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -99,4 +99,17 @@ describe("Combobox", () => {
     fireEvent.blur(input);
     expect(screen.getByDisplayValue("New York")).toBeInTheDocument();
   });
+
+  it("should not update input value in uncontrolled manner when `inputValue` is passed", () => {
+    const value = "Initial value unhandled by parent state";
+    render(
+      <Combobox label={LABEL} inputValue={value}>
+        {CHILDREN}
+      </Combobox>
+    );
+    const input = screen.getByPlaceholderText(LABEL);
+    expect(screen.getByDisplayValue(value)).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "New value" } });
+    expect(screen.getByDisplayValue(value)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
fixes #778 

Allows the input inside `Combobox` to be fully controlled. Addresses an issue Grasshopper found where the input was blank after rerendering in their application.

<img width="919" alt="Screen Shot 2022-07-20 at 4 39 31 PM" src="https://user-images.githubusercontent.com/231252/180077546-6db7ee79-d3bd-4713-8709-2937006b1f33.png">

