### PR TITLE
feat(RadioButtons): add `error` prop to support RadioButtons error state

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -19,9 +19,11 @@ const RadioButtons = ({
   kind = "normal",
   onChange = () => {},
   testId,
+  error,
   ...containerProps
 }) => {
   const isControlled = value !== undefined;
+  const hasError = error !== undefined && error.length > 0;
   const [checkedValue, setCheckedValue] = useState(
     isControlled ? value : initialValue
   );
@@ -62,6 +64,7 @@ const RadioButtons = ({
             {
               "nds-radiobuttons-option--checked": checkedValue == inputValue,
               "nds-radiobuttons-option--focused": focusedValue == inputValue,
+              "nds-radiobuttons-option--error": hasError,
               "padding--all rounded--all border--all": kind === "card",
             },
           ])}
@@ -86,6 +89,12 @@ const RadioButtons = ({
           />
         </label>
       ))}
+      {hasError && (
+        <div className="fontColor--error">
+          <span className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
+          {error}
+        </div>
+      )}
     </div>
   );
 };
@@ -111,6 +120,11 @@ RadioButtons.propTypes = {
    * `card` - display input and label as a toggleable card
    */
   kind: PropTypes.oneOf(["normal", "card"]),
+  /**
+   * Error message. When passed, the `error` prop will
+   * render the radio group in an error state.
+   */
+  error: PropTypes.string,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -56,6 +56,10 @@
       border: 2px solid var(--theme-primary);
     }
 
+    &.nds-radiobuttons-option--error .nds-radio {
+      border-color: var(--color-errorDark);
+    }
+
     &.nds-radiobuttons-option--checked .nds-radio {
       background-color: transparent;
 
@@ -88,6 +92,10 @@
     &.nds-radiobuttons-option--focused,
     &.nds-radiobuttons-option--checked {
       border-color: var(--theme-primary);
+    }
+
+    &.nds-radiobuttons-option--error {
+      border-color: var(--color-errorDark);
     }
 
     &.nds-radiobuttons-option--checked {

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -35,6 +35,17 @@ export const Example = () => {
   );
 };
 
+export const ErrorState = Template.bind({});
+ErrorState.args = {
+  options: {
+    OptionA: "A",
+    OptionB: "B",
+    OptionC: "C",
+  },
+  name: "options",
+  error: "Selection required",
+};
+
 export const FullyControlled = () => {
   const [value, setValue] = useState("blue");
   return (


### PR DESCRIPTION
fixes #775 

Adds `error` prop to `RadioButtons`

<img width="920" alt="Screen Shot 2022-07-20 at 6 08 15 PM" src="https://user-images.githubusercontent.com/231252/180091086-7a40c258-542d-4e33-a886-f32e9dbae45d.png">

