### PR TITLE
fix(DropdownTrigger): set `type` attribute on button element

### DIFF
--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -39,6 +39,7 @@ const DropdownTrigger = React.forwardRef(
             },
           ])}
           aria-expanded={isOpen ? "true" : "false"}
+          type="button"
           {...otherProps}
         >
           {labelText && (


### PR DESCRIPTION
The `button` element in the DropdownTrigger component does not have a `type` specified, which means that when it is a child of a `form`, it will submit the form. This PR sets the `type` to `button` to prevent this behavior.