### PR TITLE
build(ci): remove manual trigger from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,5 @@
 name: Release
 on:
-  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Only CI should run the release workflow. This removes the manual trigger for the workflow.