### PR TITLE
fix(Select): cover deselection case in controlled mode

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -14,7 +14,7 @@ const noop = () => {};
  */
 export const isAction = (item) => {
   let result = false;
-  if (item) {
+  if (item && item.props) {
     result = "onSelect" in item.props;
   }
   return result;
@@ -80,7 +80,7 @@ const Select = ({
       if (isAction(selectedItem)) {
         selectedItem.props.onSelect();
       } else {
-        onChange(selectedItem.props.value);
+        onChange(selectedItem.props ? selectedItem.props.value : "");
       }
     },
   };
@@ -102,7 +102,7 @@ const Select = ({
     getItemProps,
   } = useSelect(downshiftOpts);
 
-  const hasSelectedItem = selectedItem !== undefined;
+  const hasSelectedItem = selectedItem !== undefined && selectedItem.props;
 
   return (
     <div className="nds-select" data-testid={testId}>

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -103,10 +103,10 @@ InAForm.parameters = {
 };
 
 export const Controlled = () => {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(null);
   return (
     <>
-      <Select label="Account" value={value} onChange={setValue}>
+      <Select label="Account" value={value} onChange={(v) => setValue(v)}>
         <Select.Item value="checking1234">Checking (1234)</Select.Item>
         <Select.Item value="savings4321">Savings (4321)</Select.Item>
       </Select>
@@ -115,7 +115,7 @@ export const Controlled = () => {
           label="Clear selection"
           kind="negative"
           onClick={() => {
-            setValue("");
+            setValue(null);
           }}
         />
       </div>

--- a/src/Select/index.test.js
+++ b/src/Select/index.test.js
@@ -11,6 +11,9 @@ describe("Select", () => {
   it("isAction: detects action items correctly", () => {
     expect(isAction(<Select.Item value="foo" />)).toBe(false);
     expect(isAction(<Select.Action onSelect={() => {}} />)).toBe(true);
+    expect(isAction(null)).toBe(false);
+    expect(isAction(undefined)).toBe(false);
+    expect(isAction("")).toBe(false);
   });
 
   it("getSelectedItemDisplay: only returns non-action items", () => {


### PR DESCRIPTION
fixes #793 

Fixes errors thrown when `value` is passed, but with a value of `undefined`, `null`, or `""`.

Basically, the component uses `value` to look for a matching `Select.Item` by its `value` prop. If the item is not found in children, the Selection should clear. There were a few places where the code assumed an item would always be present and have props.