### PR TITLE
fix(TextInput): ensure autofill styling doesn't overlap floating label

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -160,7 +160,9 @@
 
   input,
   textarea {
-    &::placeholder {
+    &:placeholder,
+    &:autofill {
+      background: transparent;
       color: var(--color-mediumGrey);
       font-weight: 400;
     }


### PR DESCRIPTION
closes https://github.com/narmi/banking/issues/20407


The form styling issue we saw on an iphone 11 / iOS 15 was due to default styling of browser autofill. This change ensures that no background is placed behind an autofill value, preventing an autofilled value from covering up the floating label of TextInput.

Also applies to any component that uses TextInput (like DateInput)