### PR TITLE
fix(Tooltip): allow SSR by using default `container` option of `useLayer`

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -43,7 +43,6 @@ const Tooltip = ({
     preferY: "top",
     triggerOffset: 12,
     arrowOffset: 12,
-    container: document.body,
   });
 
   return (


### PR DESCRIPTION
fixes #801 

Allows `Tooltip` to render server side without errors by removing the `container` option from the `useLayer` hook. As it turns out `document.body` is the default container it attaches to and we do not need to specify this option.