### PR TITLE
fix(TruncatedAccount): show full account name in `title` on hover

### DIFF
--- a/src/TruncatedAccount/index.js
+++ b/src/TruncatedAccount/index.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
  * The account name will truncate with ellipsis as needed to fit the space.
  */
 const TruncatedAccount = ({ name, lastFour }) => (
-  <span className="nds-truncatedAccount">
+  <span className="nds-truncatedAccount" title={`${name} - ${lastFour}`}>
     <span className="whiteSpace--truncate">{name}</span>
     {lastFour && (
       <span role="img" className="padding--x--xxs">


### PR DESCRIPTION
fixes #800 

Adds a `title` attribute with the full account name. Useful to users who navigate desktop web with a mouse