### PR TITLE
docs(storybook): set actions and children control settings globally

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,8 +14,12 @@ export const parameters = {
     page: () => <Layout />,
     theme: docs,
   },
+  actions: {
+    argTypesRegex: "^on[A-Z].*",
+  },
   controls: {
     sort: "requiredFirst",
+    exclude: /children/,
     matchers: {
       color: /(background|color)$/i,
     },

--- a/src/Button/index.stories.js
+++ b/src/Button/index.stories.js
@@ -60,8 +60,6 @@ export default {
   title: "Components/Button",
   component: Button,
   argTypes: {
-    onClick: { action: "clicked" },
-    children: { control: false },
     startIcon: { options: ["", ...VALID_ICON_NAMES] },
     endIcon: { options: ["", ...VALID_ICON_NAMES] },
   },

--- a/src/Card/index.stories.js
+++ b/src/Card/index.stories.js
@@ -243,7 +243,4 @@ export const Form = () => {
 export default {
   title: "Components/Card",
   component: Card,
-  argTypes: {
-    children: { control: false },
-  },
 };

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -55,7 +55,4 @@ AsCard.parameters = {
 export default {
   title: "Components/Checkbox",
   component: Checkbox,
-  argTypes: {
-    onChange: { action: "change" },
-  },
 };

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -97,9 +97,6 @@ export default {
   component: Combobox,
   subcomponents: { ComboboxItem, ComboboxHeading },
   argTypes: {
-    children: { control: false },
-    onChange: { action: "Combobox change" },
-    onInputChange: { action: "Combobox input change" },
+    icon: { options: ["", ...VALID_ICON_NAMES] },
   },
-  icon: { options: ["", ...VALID_ICON_NAMES] },
 };

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -56,7 +56,5 @@ export default {
   component: ContentCard,
   argTypes: {
     type: { table: { disable: true } },
-    onClick: { action: "clicked (only fires for `interactive` type)" },
-    children: { control: false },
   },
 };

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -43,7 +43,4 @@ AltInput.parameters = {
 export default {
   title: "Components/DateInput",
   component: DateInput,
-  argTypes: {
-    onChange: { action: "change" },
-  },
 };

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -137,10 +137,6 @@ FocusManagement.parameters = {
 export default {
   title: "Components/Dialog",
   component: Dialog,
-  argTypes: {
-    children: { control: false },
-    onUserDismiss: { action: "user dismiss" },
-  },
   parameters: {
     docs: {
       page: DialogLayout,
@@ -160,21 +156,42 @@ export const PopoverDialog = () => {
         }
         `}
       </style>
-      <Popover closeOnContentClick content={
-        <div className="popover-content">
-          <div tabIndex="0" role="button" onClick={() => { setIsDialogOpen(true) }} onKeyDown={() => { }}>
-            Open Modal
+      <Popover
+        closeOnContentClick
+        content={
+          <div className="popover-content">
+            <div
+              tabIndex="0"
+              role="button"
+              onClick={() => {
+                setIsDialogOpen(true);
+              }}
+              onKeyDown={() => {}}
+            >
+              Open Modal
+            </div>
+            <div
+              tabIndex="0"
+              role="button"
+              onClick={() => {}}
+              onKeyDown={() => {}}
+            >
+              Does Nothing
+            </div>
           </div>
-          <div tabIndex="0" role="button" onClick={() => { }} onKeyDown={() => { }}>
-            Does Nothing
-          </div>
-        </div>
-      }>
+        }
+      >
         <span className="narmi-icon-more-horizontal"></span>
       </Popover>
       <Dialog isOpen={isDialogOpen} title={`Remove account`}>
-        <Button onClick={() => { setIsDialogOpen(false) }}>Close</Button>
+        <Button
+          onClick={() => {
+            setIsDialogOpen(false);
+          }}
+        >
+          Close
+        </Button>
       </Dialog>
     </>
   );
-}
+};

--- a/src/Dropdown/index.stories.js
+++ b/src/Dropdown/index.stories.js
@@ -123,9 +123,4 @@ export const NewMemberDropDown = () => {
 export default {
   title: "Components/Dropdown",
   component: Dropdown,
-  argTypes: {
-    children: { control: false },
-    onChange: { action: "change" },
-    onClose: { action: "close" },
-  },
 };

--- a/src/LoadingShim/index.stories.js
+++ b/src/LoadingShim/index.stories.js
@@ -27,7 +27,4 @@ Overview.args = {
 export default {
   title: "Components/LoadingShim",
   component: LoadingShim,
-  argTypes: {
-    children: { control: false },
-  },
 };

--- a/src/Pagination/index.stories.js
+++ b/src/Pagination/index.stories.js
@@ -12,7 +12,4 @@ Overview.args = {
 export default {
   title: "Components/Pagination",
   component: Pagination,
-  argTypes: {
-    onPageChange: { action: "page change" },
-  },
 };

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -45,7 +45,4 @@ FocusManagement.args = {
 export default {
   title: "Components/Popover",
   component: Popover,
-  argTypes: {
-    children: { control: false },
-  },
 };

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -106,7 +106,4 @@ AsCard.parameters = {
 export default {
   title: "Components/RadioButtons",
   component: RadioButtons,
-  artTypes: {
-    onChange: { action: "change" },
-  },
 };

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -187,7 +187,4 @@ export default {
   title: "Components/Row",
   component: Row,
   subcomponents: { RowItem },
-  argTypes: {
-    children: { control: false },
-  },
 };

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -174,6 +174,5 @@ export default {
   subcomponents: { SelectItem, SelectAction },
   argTypes: {
     children: { control: false },
-    onChange: { action: "Select change" },
   },
 };

--- a/src/SeparatorList/index.stories.js
+++ b/src/SeparatorList/index.stories.js
@@ -40,7 +40,4 @@ AsBreadcrumbs.parameters = {
 export default {
   title: "Components/SeparatorList",
   component: SeparatorList,
-  argTypes: {
-    items: { control: false },
-  },
 };

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -125,7 +125,4 @@ export default {
   title: "Components/Tabs",
   component: Tabs,
   subcomponents: { TabsList, TabsTab, TabsPanel },
-  argTypes: {
-    onTabChange: { action: "tab change" },
-  },
 };

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -83,8 +83,6 @@ export default {
   title: "Components/TextInput",
   component: TextInput,
   argTypes: {
-    onChange: { action: "change" },
-    onBlur: { action: "blur" },
     icon: { table: { disable: true } },
     startIcon: { options: ["", ...VALID_ICON_NAMES] },
     endIcon: { options: ["", ...VALID_ICON_NAMES] },

--- a/src/Toggle/index.stories.js
+++ b/src/Toggle/index.stories.js
@@ -46,8 +46,4 @@ export const FullyControlled = () => {
 export default {
   title: "Components/Toggle",
   component: Toggle,
-  argTypes: {
-    children: { table: { disable: true } },
-    onChange: { action: "clicked" },
-  },
 };

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -52,7 +52,4 @@ WithTextInput.parameters = {
 export default {
   title: "Components/Tooltip",
   component: Tooltip,
-  argTypes: {
-    children: { control: false },
-  },
 };


### PR DESCRIPTION
fixes #791 

Moves some story-level configuration to the global config file:
- Actions should fire on any prop starting with `on`
- Controls for `children` prop should always be disabled in the props tables