### PR TITLE
feat(helper-casses): add theme color variants for fontColor and bgColor

### DIFF
--- a/src/helper-classes/background.scss
+++ b/src/helper-classes/background.scss
@@ -32,6 +32,19 @@
 }
 
 /**
+* Theme background colors
+*/
+.bgColor--theme--primary {
+  background-color: var(--theme-primary);
+}
+.bgColor--theme--secondary {
+  background-color: var(--theme-secondary);
+}
+.bgColor--theme--tertiary {
+  background-color: var(--theme-tertiary);
+}
+
+/**
 * Overlay scrims
 */
 .scrim--light {

--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -20,6 +20,19 @@
 }
 
 /**
+* theme colors
+*/
+.fontColor--theme--primary {
+  color: var(--theme-primary);
+}
+.fontColor--theme--secondary {
+  color: var(--theme-secondary);
+}
+.fontColor--theme--tertiary {
+  color: var(--theme-tertiary);
+}
+
+/**
 * helpers for setting font color to a standard "system" color
 */
 .fontColor--success {


### PR DESCRIPTION
fixes #750 

Adds theme color variants for font and background color helper classes.

(e.g. `fontColor--theme--primary`)