### PR TITLE
fix(TextInput): prevent global CSS from modifying input height

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -19,6 +19,8 @@
   font-size: 16px;
 
   .nds-input-box {
+    box-sizing: border-box;;
+    min-height: 48px;
     border: 1px solid var(--color-lightGrey);
     background: var(--color-white);
     position: relative;


### PR DESCRIPTION
fixes #812 

It looks like in some circumstances, inputs without a floating label were changing height once they have a value. This fix prevents the input from shrinking in height.