### PR TITLE
fix(TextInput): add `aria-label` property as a11y fallback

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -76,6 +76,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
           ref={forwardedRef}
           type="text"
           required
+          aria-label={props.label}
           placeholder={props.label}
           data-testid={testId}
           {...nativeElementProps}


### PR DESCRIPTION
closes #821 
relates to: https://github.com/narmi/banking/issues/23322

- Add `aria-label` property to input element generated by `TextInput`

Our accessibility tool in Storybook did not find this violation, but different assistive technologies have different needs. Sometimes they will not be able to associate the `label` element we output to the `input` element, so this aria property ensures the label is _always_ readable, regardless of the position and visibility of the `label` element.

<img width="388" alt="Screen Shot 2022-10-11 at 5 04 19 PM" src="https://user-images.githubusercontent.com/231252/195198165-a528faa8-5050-4e20-a37b-ec4c7dbeb4a7.png">
