### PR TITLE
feat(Checkbox): add error prop to display error beneath checkbox

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -14,6 +14,7 @@ const Checkbox = ({
   defaultChecked,
   checked,
   value,
+  error,
   kind = "normal",
   testId,
   ...rest
@@ -47,7 +48,7 @@ const Checkbox = ({
   };
 
   return (
-    <>
+    <div className="nds-checkbox-container">
       <label
         className={cc([
           "nds-typograhy",
@@ -75,7 +76,13 @@ const Checkbox = ({
         />
         <span className="narmi-icon-check"></span>
       </label>
-    </>
+      {error &&
+        <div className="fontColor--error margin--top--xs">
+          <span className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
+          {error}
+        </div>
+      }
+    </div>
   );
 };
 
@@ -99,6 +106,8 @@ Checkbox.propTypes = {
   checked: PropTypes.bool,
   /** Sets the `value` attribute of the `input` */
   value: PropTypes.string,
+  /** Text of error message to display under the checkbox */
+  error: PropTypes.string,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
   /**

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -1,17 +1,20 @@
-.nds-checkbox {
-  cursor: pointer;
+.nds-checkbox-container {
   margin-bottom: var(--space-s);
-  font-size: var(--font-size-default);
 
-  input {
+  .nds-checkbox {
     cursor: pointer;
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+    font-size: var(--font-size-default);
+
+    input {
+      cursor: pointer;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      height: 1px;
+      overflow: hidden;
+      position: absolute;
+      white-space: nowrap;
+      width: 1px;
+    }
   }
 }
 


### PR DESCRIPTION
Changed the fragment to a `div` to add the `.nds-checkbox-container` classname. This is because there is a margin beneath `.nds-checkbox` label, but if an error is displayed beneath that label, we want that margin below the error. 

![image](https://user-images.githubusercontent.com/4285085/197698259-ddec8f74-c08b-4144-8ebd-8ae742fb3d92.png)
