### PR TITLE
fix(Checkbox): correct styling for hover and focus states

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -25,22 +25,6 @@
   align-items: center;
   padding-left: 28px;
 
-  &.nds-checkbox--focused {
-    .narmi-icon-check {
-      border: 2px solid var(--theme-primary);
-    }
-  }
-
-  &.nds-checkbox--checked {
-    .narmi-icon-check {
-      background-color: var(--theme-primary);
-      border: 1px solid var(--theme-primary);
-      &:after {
-        display: block;
-      }
-    }
-  }
-
   .narmi-icon-check {
     position: absolute;
     left: 0;
@@ -55,14 +39,33 @@
     text-align: center;
     line-height: 18px;
     box-sizing: content-box;
-    &:hover {
-      border: 2px solid var(--theme-primary);
-    }
     &:after {
       color: red;
     }
     &.error {
       border: 1px solid var(--color-errorDark);
+    }
+  }
+
+  // hover
+  .narmi-icon-check:hover {
+    border-color: var(--theme-primary);
+  }
+
+  // focused
+  &.nds-checkbox--focused .narmi-icon-check {
+    border-color: var(--theme-primary);
+    outline: 3px solid RGBA(var(--theme-rgb-primary), var(--alpha-10));
+  }
+
+  // checked
+  &.nds-checkbox--checked {
+    .narmi-icon-check {
+      background-color: var(--theme-primary);
+      border-color: var(--theme-primary);
+      &:after {
+        display: block;
+      }
     }
   }
 }


### PR DESCRIPTION
closes #850 

- Simplifies CSS for the `normal` variant of `Checkbox`
- Match borders to the figma designs for unchecked, checked, and hover
- Add a focus ring to a focused checkbox to make it easier to see which box is focused when they're already checked

### Second option focused, third option hovered
<img width="316" alt="Screen Shot 2022-11-21 at 2 21 23 PM" src="https://user-images.githubusercontent.com/231252/203142186-33e2a28a-2450-4935-99a0-7adaa65c4aff.png">

### Second option focused and hovered
<img width="316" alt="Screen Shot 2022-11-21 at 2 25 45 PM" src="https://user-images.githubusercontent.com/231252/203142187-7624c29c-763a-4ffa-a08d-f062c178cbc7.png">

