### PR TITLE
style(font): Line height for smallText should be 1.25

### DIFF
--- a/tokens/src/font/lineHeight.json
+++ b/tokens/src/font/lineHeight.json
@@ -1,7 +1,7 @@
 {
   "font": {
     "lineHeight": {
-      "smallText": { "value": "1.6" },
+      "smallText": { "value": "1.25" },
       "bodyText": { "value": "1.25" },
       "bigText": { "value": "1.1" },
       "default": { "value": "{font.lineHeight.bodyText.value}" }


### PR DESCRIPTION
for narmi/banking#26643

For the comment: line height on fine print is too big. should follow NDS and be 1.25

**Before:**
![Screenshot 2023-01-19 at 3 07 13 PM](https://user-images.githubusercontent.com/50111807/213548717-c9b64ff1-a2e9-499c-8b4c-b13e0cb1d8a5.png)


**After:**
![Screenshot 2023-01-19 at 3 06 46 PM](https://user-images.githubusercontent.com/50111807/213548622-aa14b447-f8f8-4011-ad32-10e20f417c27.png)
