### PR TITLE
feat(Drawer): allow popovers within Drawer

### DIFF
--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -8,7 +8,7 @@
   overflow: auto;
   position: fixed;
   transition: transform var(--transition-speed) ease;
-  z-index: 1000;
+  z-index: 900;
   border: var(--border-size-s);
   border-color: var(--border-color-light);
   padding: var(--space-xxl);
@@ -64,13 +64,13 @@
   visibility: visible;
   opacity: 1;
   pointer-events: auto;
-  z-index: 990;
+  z-index: 890;
 }
 
 .navigation {
   background: transparent;
   transition: transform var(--transition-speed) ease;
-  z-index: 999; 
+  z-index: 899; 
 }
 .navigation--open--right {
   transform: translateX(-125px);

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Drawer from "./";
 import Button from "../Button";
+import Popover from "../Popover";
 
 const CONTENTS = [
   <>
@@ -170,6 +171,26 @@ ScrollingContentWithoutNavigation.parameters = {
         "The Drawer will render open or closed based on the isOpen prop passed in. Use the onUserDismiss callback to determine when to change the value of isOpen.",
     },
   },
+};
+
+export const ContentWithPopover = BaseTemplate.bind({});
+ContentWithPopover.args = {
+  showControls: false,
+  children: (
+    <div
+      style={{
+        height: "200px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Popover content={<div className="padding--all--m">📦 Any content</div>}>
+        <Button type="secondary">Click to show Popover</Button>
+      </Popover>
+    </div>
+  ),
 };
 
 export default {


### PR DESCRIPTION
The z-index in the Drawer was within the same range of Popover and other NDS elements that rely on the z-index to appear on top of other elements. This caused those elements to be unusable within the Drawer.

This PR decreases the z-index range for the Drawer, which allows elements like the Popover to be used within it.

https://user-images.githubusercontent.com/40327446/214100866-06c2e020-c5c6-42a9-a018-2179a22cc51e.mov




