### PR TITLE
fix(DropdownTrigger): use span instead of label

### DIFF
--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -43,9 +43,9 @@ const DropdownTrigger = React.forwardRef(
           {...otherProps}
         >
           {labelText && (
-            <label className="nds-dropdownTrigger-label" {...labelProps}>
+            <span className="nds-dropdownTrigger-label" {...labelProps}>
               {labelText}
-            </label>
+            </span>
           )}
           {displayValue && <span>{displayValue}</span>}
           {showOpenIndicator && (


### PR DESCRIPTION
closes https://github.com/narmi/design_system/issues/882

label's have a `for` and `id` attribute that we could take advantage here. I could try exploring that solution instead. I also saw that it was a common practice to wrap buttons and inputs with labels. However not all html components can be wrapped in a label tag. The easiest solution is using a span, not sure if this would break anything though