### PR TITLE
fix(ContentCard): thicken border of selected interactive card

### DIFF
--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -19,6 +19,9 @@
   }
   &:active,
   &[aria-pressed="true"] {
+    // use outline to prevent layout thrashing
+    // when the border is thickened in selected state
+    outline: 1px solid var(--theme-primary);
     &::before {
       content: "";
       position: absolute;


### PR DESCRIPTION
fixes #899 

Adds an extra pixel of thickness to selected cards, without increasing width or height

### Selected
<img width="518" alt="Screen Shot 2023-02-28 at 5 38 27 PM" src="https://user-images.githubusercontent.com/231252/221997894-7b8e41fa-ec97-440c-a330-11969aa2a215.png">

### Unselected
<img width="508" alt="Screen Shot 2023-02-28 at 5 38 32 PM" src="https://user-images.githubusercontent.com/231252/221997896-06b2d8c6-8215-408a-9f8a-1ec742f2a224.png">

### Unselected with hover
<img width="523" alt="Screen Shot 2023-02-28 at 5 38 24 PM" src="https://user-images.githubusercontent.com/231252/221997898-80a48ff8-6285-496e-98af-f648a8e4c97c.png">
