### PR TITLE
fix(Select): prevent chevron from overlapping other open popovers

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -45,7 +45,15 @@
   right: var(--space-s);
   top: 50%;
   transform: translateY(-50%);
-  z-index: 999; /* appear above popovers per design */
+
+  // only overlap popovers if in an open state
+  &.narmi-icon-chevron-up {
+    z-index: 4;
+  }
+
+  &.narmi-icon-chevron-down {
+    z-index: 1;
+  }
 }
 
 .nds-dropdownTrigger-error {


### PR DESCRIPTION
closes #898 

Prevent the chevron in closed Select triggers from overlapping open Select popovers

<img width="329" alt="Screen Shot 2023-03-01 at 5 10 47 PM" src="https://user-images.githubusercontent.com/231252/222276944-370b0958-0651-4b4d-aa08-9f1b4119b38c.png">
<img width="310" alt="Screen Shot 2023-03-01 at 5 10 52 PM" src="https://user-images.githubusercontent.com/231252/222277066-365c94c9-06f1-45be-a943-2cd65398b656.png">

