### PR TITLE
fix(DropdownTrigger): set explicit text color for value

### DIFF
--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -47,7 +47,7 @@ const DropdownTrigger = React.forwardRef(
               {labelText}
             </label>
           )}
-          {displayValue && <span>{displayValue}</span>}
+          {displayValue && <span className="nds-dropdownTrigger-value">{displayValue}</span>}
           {showOpenIndicator && (
             <span
               role="img"

--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -24,6 +24,10 @@
   color: var(--color-mediumGrey);
 }
 
+.nds-dropdownTrigger-value {
+  color: var(--font-color-primary);
+}
+
 // float the label to top like a text input
 // when there's a value to display
 .nds-dropdownTrigger-button--hasValue {


### PR DESCRIPTION
closes #907 

Prevents selected value in `DropdownTrigger` from showing as blue in iOS 

See also: <https://developer.apple.com/forums/thread/690529>