### PR TITLE
fix(Dialog): remove min-height of dialog

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -54,7 +54,6 @@
     height: auto;
     border-radius: var(--border-radius-m);
     max-height: 100%; // prevent modal from being taller than the shim content box
-    min-height: 240px; // prevent content area from collapsing to 0
     min-width: 240px; // should be no narrower than this on larger viewports
   }
 }


### PR DESCRIPTION
fixes #862 

Ensure space between content and footer area is consistent by removing min-height.

### Before
<img width="595" alt="Screen Shot 2023-03-09 at 6 55 52 PM" src="https://user-images.githubusercontent.com/231252/224187930-98a61686-0eb1-4f7f-a8d0-107d6670c684.png">


### After
<img width="582" alt="Screen Shot 2023-03-09 at 6 55 25 PM" src="https://user-images.githubusercontent.com/231252/224187949-9bb6d1cf-8fa0-4ce5-8f47-2bfa39838ffe.png">


