### PR TITLE
fix(base-styles): skip ink on text underline globally

### DIFF
--- a/src/base-styles/defaults.scss
+++ b/src/base-styles/defaults.scss
@@ -14,6 +14,7 @@ body {
   color: var(--font-color-primary);
   max-width: unset;
   background-color: var(--color-white);
+  text-decoration-skip-ink: none;
 }
 
 h1,


### PR DESCRIPTION
fixes #921 

Changes underline text decoration behavior globally so that "ink" (descenders) don't interrupt the underline.

**This will not add underlines to any elements.** This rule only changes the style of an underline when that text decoration property is present.

(per design: <https://www.notion.so/narmi/First-IB-Design-QA-f751c057241e4031a9e9db636c2a6dba?pvs=4#1eded13c12904981995592ead26a5ee4>)

### Before
<img width="356" alt="Screen Shot 2023-03-28 at 3 00 41 PM" src="https://user-images.githubusercontent.com/231252/228341297-1c247d81-1c69-4d50-8839-aa01c83ab7b3.png">

### After
<img width="355" alt="Screen Shot 2023-03-28 at 3 00 48 PM" src="https://user-images.githubusercontent.com/231252/228341296-951978ea-49b4-4cec-be8c-111560eaeff8.png">
