### PR TITLE
fix(TextInput): fix placeholder color

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -141,16 +141,18 @@
       display: none;
     }
   }
+}
 
-  input,
-  textarea {
-    &:placeholder,
-    &:autofill {
-      background: transparent;
-      color: var(--color-mediumGrey);
-      font-weight: 400;
-    }
-  }
+input::placeholder,
+textarea::placeholder {
+  color: var(--color-mediumGrey);
+  font-weight: 400;
+}
+
+input::autofill,
+textarea::autofill {
+  background: transparent;
+  color: var(--color-mediumGrey);
 }
 
 .nds-input-multiline-grid {


### PR DESCRIPTION
Fixes https://github.com/narmi/banking/issues/30236

Fixes broken selector for input placeholders

**Before** (user agent default)
<img width="310" alt="Screen Shot 2023-04-04 at 4 44 42 PM" src="https://user-images.githubusercontent.com/231252/229916674-eac4b2e9-630d-4d41-86de-054e6ea310a6.png">

**After** (NDS medium grey)
<img width="296" alt="Screen Shot 2023-04-04 at 4 44 47 PM" src="https://user-images.githubusercontent.com/231252/229916677-c7356b96-a4df-4f29-8d1b-5981f0857d06.png">
