### PR TITLE
feat(icons): inline icon font asset

### DIFF
--- a/src/icons/style.css
+++ b/src/icons/style.css
@@ -1,10 +1,6 @@
 @font-face {
   font-family: 'icomoon';
-  src:
-    url('fonts/icomoon.woff2?ookznz') format('woff2'),
-    url('fonts/icomoon.ttf?ookznz') format('truetype'),
-    url('fonts/icomoon.woff?ookznz') format('woff'),
-    url('fonts/icomoon.svg?ookznz#icomoon') format('svg');
+  src: url('fonts/icomoon.woff?ookznz') format('woff');
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = {
       },
       {
         test: /(icomoon).*\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
-        type: "asset/resource",
+        type: "asset/inline",
       },
       {
         test: /narmi-matiere.*\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,


### PR DESCRIPTION
Fixes issue where prod builds of Nextjs were not fetching icomoon font assets correctly, resulting in CORS errors.

This webpack change causes the `woff` referenced in `src/icons/style.css` to be inlined as base64, working around the fetch entirely until we solve this problem in a more long term way.