### PR TITLE
feat: Support React 18 consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,8 +85,8 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "^16 || ^17",
-        "react-dom": "^16 || ^17"
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "dev": "tmux new-session \"npm i && npm run watch\"\\; split-window 'npm run storybook'"
   },
   "peerDependencies": {
-    "react": "^16 || ^17",
-    "react-dom": "^16 || ^17"
+    "react": "^16 || ^17 || ^18",
+    "react-dom": "^16 || ^17 || ^18"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",


### PR DESCRIPTION
closes #845 

Verified working in a latest NextJs consumer (which uses React 18).

In source, NDS still uses React 16. The built files in _dist_ may be used by React 18 consumers. This allows third party developers to use the latest version of their favorite framework with NDS.

Upgrading _source_ in NDS to React 18 is a much bigger lift we can do later.