### PR TITLE
fix(dist): add deprecations json to `dist/`

### DIFF
--- a/src/deprecations.json
+++ b/src/deprecations.json
@@ -1,0 +1,20 @@
+{
+  "cssCustomProperties": [
+    "--nds-black",
+    "--nds-grey",
+    "--nds-medium-grey",
+    "--nds-lightest-grey",
+    "--nds-smoke-grey",
+    "--nds-red",
+    "--nds-white",
+    "--nds-font-family",
+    "nds-header-font",
+    "subdued-20-opacity",
+    "subdued-10-opacity"
+  ],
+  "components": [
+    "Card",
+    "Dropdown",
+    "PlainButton"
+  ]
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@
 @import "../dist/tokens/css/rgbColors.css";
 
 // ⚠️ DEPRECATED ⚠️
+// (see `src/deprecations.json`)
 // These custom properties will be removed in a future release.
 // For now, they map to the equivalent value from NDS Tokens
 :root {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,10 @@ module.exports = {
           from: path.join(__dirname, "src/icons/"),
           to: path.resolve(__dirname, "dist/icons/"),
         },
+        {
+          from: path.join(__dirname, "src/deprecations.json"),
+          to: path.join(__dirname, "dist/deprecations.json"),
+        }
       ],
     }),
   ],


### PR DESCRIPTION
relates to https://github.com/narmi/banking/issues/15579

Adds a `deprecations.json` to `dist/` that lists important deprecations (things that will be removed in the next major version).

#### Why?

- a step toward a more automated deprecation strategy for NDS
- serves as a deprecation list for dangerfile rules in internal Narmi software