### PR TITLE
refactor(TextInput)!: Remove deprecated 'icon' prop. Use 'startIcon' …

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -12,7 +12,6 @@ export const VALID_ICON_NAMES = iconSelection.icons.map(
  */
 const TextInput = React.forwardRef((props, forwardedRef) => {
   const {
-    icon, // DEPRECATED
     startIcon,
     endIcon,
     formatter,
@@ -23,9 +22,6 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     testId,
     ...nativeElementProps
   } = props;
-
-  // support deprecated `icon` prop as the startIcon until we remove it
-  const leftIcon = icon !== undefined ? icon : startIcon;
 
   const [inputValue, setInputValue] = useState(
     defaultValue ? defaultValue : ""
@@ -47,7 +43,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
   return (
     <Input
       {...props}
-      startIconClass={leftIcon ? `narmi-icon-${leftIcon}` : undefined}
+      startIconClass={startIcon ? `narmi-icon-${startIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
     >
       {multiline ? (
@@ -108,8 +104,6 @@ TextInput.propTypes = {
   endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Text of error message to display under the input */
   error: PropTypes.string,
-  /** DEPREACTED - use `startIcon` instead */
-  icon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -54,7 +54,7 @@ export const MultiLine = () => {
 export const WithIcon = Template.bind({});
 WithIcon.args = {
   label: "Search",
-  icon: "search",
+  startIcon: "search",
 };
 
 export const AsColorInput = () => {
@@ -88,7 +88,6 @@ export default {
   title: "Components/TextInput",
   component: TextInput,
   argTypes: {
-    icon: { table: { disable: true } },
     startIcon: { options: ["", ...VALID_ICON_NAMES] },
     endIcon: { options: ["", ...VALID_ICON_NAMES] },
   },


### PR DESCRIPTION
closes #721 

Removes deprecated `icon` prop from `TextInput`. Moving forward, we will need to use `startIcon` and `endIcon`.

Platform team will be responsible for updating existing usage in `banking` when NDS v3 is released.