### PR TITLE
fix(LoadingShim): make loading visual smaller

### DIFF
--- a/src/LoadingShim/index.scss
+++ b/src/LoadingShim/index.scss
@@ -15,7 +15,7 @@
 }
 
 .nds-loadingShim-indicator {
-  width: 80px;
+  width: 60px;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
@@ -26,8 +26,8 @@
   transform: translateY(-40%);
 
   div {
-    width: 16px;
-    height: 16px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     background-color: var(--color-mediumGrey);
     transform: translateY(-80%);


### PR DESCRIPTION
closes #418 

### Before

<img width="930" alt="Screen Shot 2023-06-06 at 5 16 56 PM" src="https://github.com/narmi/design_system/assets/231252/a755122f-b4d5-41d1-8c42-da21ffae7c5d">


### After
<img width="914" alt="Screen Shot 2023-06-06 at 5 16 51 PM" src="https://github.com/narmi/design_system/assets/231252/abc899fa-8c83-4bf0-aeba-d7c2ffb93056">