### PR TITLE
refactor(ContentCard)!: remove deprecated `type` prop

### DIFF
--- a/src/ContentCard/index.js
+++ b/src/ContentCard/index.js
@@ -6,7 +6,6 @@ import cc from "classcat";
  * Narmi style content containers, with support for rendering as an interactive button.
  */
 const ContentCard = ({
-  type, // DEPRECATED
   kind = "plain",
   paddingSize = "l",
   onClick = () => {},
@@ -14,8 +13,7 @@ const ContentCard = ({
   children,
   testId,
 }) => {
-  const variant = type !== undefined ? type : kind; // support deprecated prop
-  const isInteractive = variant === "interactive";
+  const isInteractive = kind === "interactive";
 
   return (
     <div
@@ -35,7 +33,7 @@ const ContentCard = ({
       }
       className={cc([
         "nds-contentCard",
-        `nds-contentCard--${variant}`,
+        `nds-contentCard--${kind}`,
         `padding--all--${paddingSize}`,
         "rounded--all bgColor--white",
         { "button--reset": isInteractive },
@@ -68,8 +66,6 @@ ContentCard.propTypes = {
    * `interactive`: rounded rect with border, hover styles, and click handler
    */
   kind: PropTypes.oneOf(["plain", "elevated", "interactive"]),
-  /** DEPRECATED - use `kind` instead. This will be removed in a future release */
-  type: PropTypes.oneOf(["plain", "elevated", "interactive"]),
   /**
    * Only valid for `interactive` card type.
    * Callback for card click event.

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -28,7 +28,7 @@ export const SelectableCard = () => {
 
   return (
     <ContentCard
-      type="interactive"
+      kind="interactive"
       onClick={handleClick}
       isSelected={isCardSelected}
     >
@@ -46,7 +46,7 @@ SelectableCard.parameters = {
   docs: {
     description: {
       story:
-        "Cards of type `interactive` support a selected state that can be controlled with the `isSelected` prop.",
+        "Cards of kind `interactive` support a selected state that can be controlled with the `isSelected` prop.",
     },
   },
 };


### PR DESCRIPTION
closes #720

Removes deprecated `type` prop from `ContentCard`. Use `kind` moving forward.

**Targets `release/v3` branch**