### PR TITLE
Add option for Tooltip component to be controlled with isOpen prop

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -15,26 +15,30 @@ const Tooltip = ({
   wrapperDisplay = "inline-flex",
   maxWidth = "400px",
   testId,
+  isOpen,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const isControlled = isOpen === true || isOpen === false;
+  const [open, setOpen] = useState(false);
   const delays = {
     open: 500,
     close: 100,
   };
   let activeTimer;
 
+  const shouldRenderTooltip = isControlled ? isOpen : open;
+
   const openPopover = () => {
     clearTimeout(activeTimer);
-    activeTimer = setTimeout(setIsOpen, delays.open, true);
+    activeTimer = setTimeout(setOpen, delays.open, true);
   };
 
   const closePopover = () => {
     clearTimeout(activeTimer);
-    activeTimer = setTimeout(setIsOpen, delays.close, false);
+    activeTimer = setTimeout(setOpen, delays.close, false);
   };
 
   const { renderLayer, triggerProps, layerProps, arrowProps } = useLayer({
-    isOpen,
+    isOpen: shouldRenderTooltip,
     onOutsideClick: closePopover,
     onDisappear: closePopover,
     auto: true,
@@ -63,7 +67,7 @@ const Tooltip = ({
       </div>
       {renderLayer(
         <>
-          {isOpen && (
+          {shouldRenderTooltip && (
             <div
               id="nds-tooltip"
               role="tooltip"
@@ -99,6 +103,9 @@ Tooltip.propTypes = {
   ]),
   /** Sets maximum width of tooltip */
   maxWidth: PropTypes.number,
+
+  /** If isOpen is set the component becomes a controlled component */
+  isOpen: PropTypes.bool,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -55,7 +55,7 @@ export const ControlledTooltip = () => {
 
   return (
     <div
-      onMouseLeave={(event) => {
+      onMouseLeave={() => {
         setIsOpen(false);
       }}
     >

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -81,7 +81,7 @@ ControlledTooltip.parameters = {
   docs: {
     description: {
       story:
-        "Tooltip can be used in a TextInput by composing an absolutely positioned narmi icon as the Tooltip trigger.",
+        "Tooltip can controlled to be open or closed by passing an optional isOpen property",
     },
   },
 };

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Tooltip from "./";
 import Button from "../Button";
 import TextInput from "../TextInput";
@@ -40,7 +40,44 @@ export const WithTextInput = () => (
     </div>
   </div>
 );
+
 WithTextInput.parameters = {
+  docs: {
+    description: {
+      story:
+        "Tooltip can be used in a TextInput by composing an absolutely positioned narmi icon as the Tooltip trigger.",
+    },
+  },
+};
+
+export const ControlledTooltip = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div
+      onMouseLeave={(event) => {
+        setIsOpen(false);
+      }}
+    >
+      <Tooltip
+        isOpen={isOpen}
+        text="Hover over anywhere else to close the tooltip."
+      >
+        Tooltip should be over me
+      </Tooltip>
+      <Button
+        style={{ marginLeft: 8 }}
+        onClick={() => {
+          setIsOpen((newIsOpen) => !newIsOpen);
+        }}
+      >
+        Click Me.
+      </Button>
+    </div>
+  );
+};
+
+ControlledTooltip.parameters = {
   docs: {
     description: {
       story:

--- a/src/Tooltip/index.test.js
+++ b/src/Tooltip/index.test.js
@@ -37,4 +37,28 @@ describe("Tooltip", () => {
     const tip = await screen.findByText(TIP_TEXT);
     expect(tip).toBeInTheDocument();
   });
+
+  it("renders tooltip when isOpen is set to true", () => {
+    render(
+      <Tooltip text={TIP_TEXT} isOpen={true}>
+        <p>{CHILD_TEXT}</p>
+      </Tooltip>
+    );
+
+    const tip = screen.getByText(TIP_TEXT);
+    expect(tip).toBeInTheDocument();
+  });
+
+  it("does not render tooltip when isOpen is false and trigger is focused", async () => {
+    render(
+      <Tooltip text={TIP_TEXT} isOpen={false}>
+        <p>{CHILD_TEXT}</p>
+      </Tooltip>
+    );
+    const trigger = getTrigger();
+    fireEvent.focus(trigger);
+    const tip = await screen.queryByText(TIP_TEXT);
+
+    expect(tip).toBeNull();
+  });
 });


### PR DESCRIPTION
This allows the `Tooltip` component to be a controlled component which is needed for https://github.com/narmi/banking/issues/33260.

A developer can pass an optional `isOpen` property to control if the `Tooltip` is open or not.