### PR TITLE
fix(Button)!: set default type attribute as 'button'

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -23,6 +23,7 @@ const Button = ({
   isLoading = false,
   disabled = false,
   kind = "primary",
+  type = "button",
   size = "m",
   startIcon = null,
   endIcon = null,
@@ -56,6 +57,7 @@ const Button = ({
       elementType={as}
       tabIndex={0}
       onClick={onClick}
+      type={type}
       {...otherProps}
       className={cc([
         "nds-typography",
@@ -114,6 +116,8 @@ Button.propTypes = {
   isLoading: PropTypes.bool,
   /** style of button to render */
   kind: PropTypes.oneOf(["primary", "secondary", "negative", "menu", "plain"]),
+  /** type attribute of button element */
+  type: PropTypes.oneOf(["submit", "button"]),
   /** size variant of button */
   size: PropTypes.oneOf(["xs", "s", "m", "l"]),
   /** Click callback, with event object passed as argument */


### PR DESCRIPTION
closes #946 

Set the `type` attribute default of the root element of `Button` to `button`.

This prevents the html default behavior of a `button` being a `submit` button, which will fire a submit event and register a click when a user presses the Enter key while within a `form` element.