### PR TITLE
refactor(Checkbox)!: use auto spacing between checkboxes

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -1,4 +1,4 @@
-// only apply top margin to a checkbox container
+// only apply top spacing to a checkbox container
 // that is preceeded by another checkbox container
 .nds-checkbox-container ~ .nds-checkbox-container {
   padding-top: var(--space-s);

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -1,20 +1,22 @@
-.nds-checkbox-container {
-  margin-bottom: var(--space-s);
+// only apply top margin to a checkbox container
+// that is preceeded by another checkbox container
+.nds-checkbox-container ~ .nds-checkbox-container {
+  padding-top: var(--space-s);
+}
 
-  .nds-checkbox {
+.nds-checkbox {
+  cursor: pointer;
+  font-size: var(--font-size-default);
+
+  input {
     cursor: pointer;
-    font-size: var(--font-size-default);
-
-    input {
-      cursor: pointer;
-      clip: rect(0 0 0 0);
-      clip-path: inset(50%);
-      height: 1px;
-      overflow: hidden;
-      position: absolute;
-      white-space: nowrap;
-      width: 1px;
-    }
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
   }
 }
 


### PR DESCRIPTION
closes #878 


**Targets `releases/v3`**

Instead of adding a margin to every checkbox container, which will create a spacing side effect with the element directly below the component, this PR makes checkbox spacing automatically appear between checkboxes based on if they directly follow each other in the DOM.

<img width="317" alt="Screen Shot 2023-06-26 at 4 39 46 PM" src="https://github.com/narmi/design_system/assets/231252/085d1417-d3c9-4cd6-ad26-db381c19f4d9">
