### PR TITLE
fix(TextInput): make clearInput call onChange

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -44,6 +44,10 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     }
     setInputValue(e.target.value);
   }
+  function _onClearInput(e) {
+    _onChange(e);
+    setInputValue("");
+  }
 
   return (
     <Input
@@ -51,7 +55,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
       startIconClass={leftIcon ? `narmi-icon-${leftIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
       showClearButton={showClearButton && inputValue}
-      clearInput={() => setInputValue("")}
+      clearInput={_onClearInput}
     >
       {multiline ? (
         <div
@@ -109,7 +113,7 @@ TextInput.propTypes = {
   startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Name of Narmi icon to place at the end of the input box */
   endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
-  /** Display an X at the end of label that clears input on click. Takes precedence over endIcon when input is not empty */
+  /** Display an X at the end of label that clears input and calls onChange on click. Takes precedence over endIcon when input is not empty */
   showClearButton: PropTypes.bool,
   /** Text of error message to display under the input */
   error: PropTypes.string,

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -88,6 +88,17 @@ export const WithClearInputIcon = () => {
   return <TextInput showClearButton />;
 };
 
+export const WithClearInputIconAndOnChange = () => {
+  const [text, setText] = useState("");
+
+  return (
+    <>
+      <TextInput onChange={(e) => setText(e.target.value)} showClearButton />
+      <div>Your text is: {text}</div>
+    </>
+  );
+};
+
 export default {
   title: "Components/TextInput",
   component: TextInput,


### PR DESCRIPTION
Without this, TextInput fields that have an onChange won't have it triggered when the input is cleared:


https://github.com/narmi/design_system/assets/40327446/a8989951-8db7-4d5c-999c-821fe111ca13


However, it should, since it should be the same thing as manually deleting the text. Example:

https://github.com/narmi/design_system/assets/40327446/3024635e-3727-48ac-b330-086ba57e6598

