### PR TITLE
feat(Popover): add alignment prop for more position control

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -16,6 +16,7 @@ import useFocusTrap from "@charlietango/use-focus-trap";
  */
 const Popover = ({
   side = "bottom",
+  alignment = "center",
   content,
   children,
   wrapperDisplay = "inline-flex",
@@ -60,7 +61,7 @@ const Popover = ({
     onOutsideClick: closePopover,
     onDisappear: closePopover,
     auto: !disableAutoPlacement,
-    placement: `${side}-center`,
+    placement: `${side}-${alignment}`,
     preferX: "left",
     preferY: "bottom",
     container: document.body,
@@ -124,6 +125,8 @@ Popover.propTypes = {
   content: PropTypes.node.isRequired,
   /** Sets prefferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
+  /** Sets preferred alignment of the tooltip relative to the trigger */
+  alignment: PropTypes.oneOf(["start", "center", "end"]),
   /** CSS `display` value for the element that wraps the Tooltip children */
   wrapperDisplay: PropTypes.oneOf([
     "inline-flex",

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -19,9 +19,20 @@ const Template = (args) => (
 export const Overview = Template.bind({});
 Overview.args = {
   content: <div className="padding--all--m">📦 Any content</div>,
-  children: <Button type="secondary">Click to show Popover</Button>,
+  children: <Button type="secondary">Open Popover</Button>,
 };
 Overview.argTypes = {
+  content: { control: false },
+};
+
+export const Positioning = Template.bind({});
+Positioning.args = {
+  content: <div className="padding--all--m">Use <code>side</code> and <code>alignment</code> to set your preferred positioning</div>,
+  children: <Button type="secondary">Top / Start positioned Popover</Button>,
+  side: "top",
+  alignment: "start",
+};
+Positioning.argTypes = {
   content: { control: false },
 };
 


### PR DESCRIPTION
closes #935 

Adds `alignment` prop to `Popover`. This prop is passed through to the positioning engine to allow us to not only pick a side, but an _alignment_ for the popover.

### Example

`<Popover side="top" alignment="start" ...otherProps />`

<img width="591" alt="Screen Shot 2023-06-27 at 2 10 14 PM" src="https://github.com/narmi/design_system/assets/231252/96154269-bcdc-4ede-9abb-8e24a3efa8d4">
<img width="868" alt="Screen Shot 2023-06-27 at 2 10 23 PM" src="https://github.com/narmi/design_system/assets/231252/011209e8-3337-4763-bf8d-8c73e3a7ca13">
