### PR TITLE
refactor(Select): use portalled dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "2.46.3",
       "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
       "dependencies": {
-        "@charlietango/use-focus-trap": "^1.3.0",
         "classcat": "^5.0.3",
         "downshift": "^6.1.7",
         "eslint-plugin-json": "^3.1.0",
         "flatpickr": "^4.6.9",
         "raf-schd": "^4.0.3",
+        "react-focus-lock": "^2.9.4",
         "react-laag": "^2.0.3",
         "react-transition-group": "^4.4.5"
       },
@@ -2050,15 +2050,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "node_modules/@charlietango/use-focus-trap": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@charlietango/use-focus-trap/-/use-focus-trap-1.4.0.tgz",
-      "integrity": "sha512-M/t4N7UxJ8tRBP+u8xB77m49vugcaZ241x9Q92PTJaJUS3lAWTKC2itSebKMlIUyN1Xz7C1zz7cnOynPDeBdLA==",
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
@@ -11901,7 +11892,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -11913,7 +11904,7 @@
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
       "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11948,7 +11939,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -16968,6 +16959,11 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/detect-package-manager": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-2.0.1.tgz",
@@ -19143,6 +19139,17 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/follow-redirects": {
@@ -31954,6 +31961,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.1.tgz",
@@ -32029,6 +32047,28 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-inspector": {
@@ -36323,6 +36363,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-clipboard-copy": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/use-clipboard-copy/-/use-clipboard-copy-0.2.0.tgz",
@@ -36333,6 +36393,27 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util": {
@@ -39719,12 +39800,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@charlietango/use-focus-trap": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@charlietango/use-focus-trap/-/use-focus-trap-1.4.0.tgz",
-      "integrity": "sha512-M/t4N7UxJ8tRBP+u8xB77m49vugcaZ241x9Q92PTJaJUS3lAWTKC2itSebKMlIUyN1Xz7C1zz7cnOynPDeBdLA==",
-      "requires": {}
     },
     "@cnakazawa/watch": {
       "version": "1.0.4",
@@ -47306,7 +47381,7 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "devOptional": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -47318,7 +47393,7 @@
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
       "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -47353,7 +47428,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -51337,6 +51412,11 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "detect-package-manager": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-package-manager/-/detect-package-manager-2.0.1.tgz",
@@ -53085,6 +53165,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "follow-redirects": {
@@ -62638,6 +62726,14 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
+      }
+    },
     "react-docgen": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.4.1.tgz",
@@ -62699,6 +62795,19 @@
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
           "dev": true
         }
+      }
+    },
+    "react-focus-lock": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
       }
     },
     "react-inspector": {
@@ -66103,6 +66212,14 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "use-clipboard-copy": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/use-clipboard-copy/-/use-clipboard-copy-0.2.0.tgz",
@@ -66110,6 +66227,15 @@
       "dev": true,
       "requires": {
         "clipboard-copy": "^3.0.0"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -98,12 +98,12 @@
   "author": "@narmi",
   "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
   "dependencies": {
-    "@charlietango/use-focus-trap": "^1.3.0",
     "classcat": "^5.0.3",
     "downshift": "^6.1.7",
     "eslint-plugin-json": "^3.1.0",
     "flatpickr": "^4.6.9",
     "raf-schd": "^4.0.3",
+    "react-focus-lock": "^2.9.4",
     "react-laag": "^2.0.3",
     "react-transition-group": "^4.4.5"
   },

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -2,10 +2,10 @@ import React, { useRef, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import rafSchd from "raf-schd";
-import useFocusTrap from "@charlietango/use-focus-trap";
 import cc from "classcat";
 import useLockBodyScroll from "./useLockBodyScroll";
 import { CSSTransition } from "react-transition-group";
+import FocusLock from "react-focus-lock";
 
 const noop = () => {};
 
@@ -41,7 +41,6 @@ const Dialog = ({
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
   const shimRef = useRef(null);
-  const focusTrapRef = useFocusTrap(isOpen);
   useLockBodyScroll(isOpen);
 
   // `rafSchd` uses `requestAnimationFrame` to schedule the state update
@@ -77,45 +76,47 @@ const Dialog = ({
   const dialogJSX = (
     <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
       <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
-        <div
-          role="dialog"
-          aria-labelledby="aria-dialog-label"
-          aria-modal="true"
-          className="nds-dialog"
-          style={{ width }}
-          ref={focusTrapRef}
-          data-testid={testId}
-        >
-          <div className={`nds-dialog-header nds-dialog-header--${headerStyle}`}>
-            <h4 id="aria-dialog-label">{title}</h4>
-            <button
-              className="resetButton nds-dialog-closeButton"
-              aria-label="close"
-              onClick={onUserDismiss}
-            >
-              <span className="narmi-icon-x"></span>
-            </button>
-          </div>
+        <FocusLock>
           <div
-            ref={contentRef}
-            className="nds-dialog-content nds-typography padding--top--xs"
+            role="dialog"
+            aria-labelledby="aria-dialog-label"
+            aria-modal="true"
+            className="nds-dialog"
+            style={{ width }}
+            data-testid={testId}
           >
-            {children}
-          </div>
-          {footer && (
             <div
-              className={cc([
-                "nds-dialog-footer",
-                { "nds-dialog-footer--overflowing": isContentOverflowing },
-              ])}
+              className={`nds-dialog-header nds-dialog-header--${headerStyle}`}
             >
-              {footer}
+              <h4 id="aria-dialog-label">{title}</h4>
+              <button
+                className="resetButton nds-dialog-closeButton"
+                aria-label="close"
+                onClick={onUserDismiss}
+              >
+                <span className="narmi-icon-x"></span>
+              </button>
             </div>
-          )}
-        </div>
+            <div
+              ref={contentRef}
+              className="nds-dialog-content nds-typography padding--top--xs"
+            >
+              {children}
+            </div>
+            {footer && (
+              <div
+                className={cc([
+                  "nds-dialog-footer",
+                  { "nds-dialog-footer--overflowing": isContentOverflowing },
+                ])}
+              >
+                {footer}
+              </div>
+            )}
+          </div>
+        </FocusLock>
       </div>
     </CSSTransition>
-
   );
   /* eslint-enable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
 

--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -36,6 +36,7 @@ const DropdownTrigger = React.forwardRef(
             {
               "nds-dropdownTrigger-button--hasValue": Boolean(displayValue),
               "nds-dropdownTrigger-button--hasError": Boolean(errorText),
+              "nds-dropdownTrigger-button--isActive": isOpen,
             },
           ])}
           aria-expanded={isOpen ? "true" : "false"}

--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -10,6 +10,7 @@
   text-align: left;
   border: 1px solid var(--border-color-default) !important;
 
+  &--isActive,
   &:focus {
     outline: none;
     border-color: var(--theme-primary) !important;

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useLayer } from "react-laag";
-import useFocusTrap from "@charlietango/use-focus-trap";
+import FocusLock from "react-focus-lock";
 
 /**
  * Generic Popover component. Renders a floating element that can contain any content,
@@ -26,7 +26,6 @@ const Popover = ({
   closeOnContentClick = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const focusTrapRef = useFocusTrap(isOpen);
   const popoverContent = closeOnContentClick ? React.cloneElement(content, {
     onClick: () => {
       if (content.onClick) {
@@ -106,8 +105,10 @@ const Popover = ({
               style={layerStyle}
               data-testid={testId}
             >
-              <div ref={focusTrapRef} tabIndex={-1}>
-                {popoverContent}
+              <div tabIndex={-1}>
+                <FocusLock>
+                  {popoverContent}
+                </FocusLock>
               </div>
             </div>
           )}

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -1,25 +1,24 @@
-.nds-select {
-  position: relative;
-}
-
 .nds-select-list {
-  visibility: hidden;
-  position: absolute;
-  z-index: 3;
-  border-color: var(--theme-primary) !important;
-  top: 0;
-  right: 0;
-  width: 100%;
   max-height: 60vh;
   overflow-y: auto;
+  z-index: 3;
 
   &:focus {
     outline: none;
   }
-}
 
-.nds-select-list--active {
-  visibility: visible;
+  &--active--top,
+  &--active--bottom {
+    border: 1px solid var(--theme-primary);
+  }
+
+  &--active--top {
+    border-bottom: 1px solid var(--border-color-default);
+  }
+
+  &--active--bottom {
+    border-top: 1px solid var(--border-color-default);
+  }
 }
 
 .nds-select-item {


### PR DESCRIPTION
closes #949 

- Replaces focus trap library with `react-focus-lock`, which is a better implementation that can follow portals
- Adds "active' state for dropdown trigger used in `Select`
- Replace static CSS positioning in `Select` with the `react-laag` positioning hook (also used in `Popover`)

### The `Select` now portals it's dropdown, allowing the menu control to overflow the `Dialog` container:
![select-in-dialog](https://github.com/narmi/design_system/assets/231252/3f276e99-61ff-4ab0-abbb-19c259f31897)

### The positioning engine (`react-laag`) now automatically flips between top/bottom to avoid getting cut off by viewport edges
![select-flip](https://github.com/narmi/design_system/assets/231252/fbd5ed0e-e2d2-4af5-86bb-214362011c53)

