### PR TITLE
fix(FormSection): update styling to better suit design use case

### DIFF
--- a/src/FormSection/index.js
+++ b/src/FormSection/index.js
@@ -6,18 +6,18 @@ import Row from "../Row";
  * A sectioning element for forms that renders a label and line above the section
  */
 const FormSection = ({ title, children }) => (
-  <div className="nds-formSection padding--bottom">
+  <div className="nds-formSection fontFamily--body">
     <Row alignItems="center" gapSize="xs">
       <Row.Item shrink>
-        <h3 className="fontColor--secondary fontSize--xs">{title}</h3>
+        <h3 className="fontColor--secondary fontSize--xs fontFamily--body">{title}</h3>
       </Row.Item>
       <Row.Item>
-        <div style={{ width: "100%", height: "var(--space-l)" }}>
+        <div style={{ width: "100%", height: "var(--space-m)" }}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             version="1.1"
             xmlnsXlink="http://www.w3.org/1999/xlink"
-            height="var(--space-l)"
+            height="var(--space-m)"
             width="100%"
           >
             <line
@@ -32,9 +32,7 @@ const FormSection = ({ title, children }) => (
         </div>
       </Row.Item>
     </Row>
-    <div className="padding--top">
-      {children}
-    </div>
+    {children}
   </div>
 );
 


### PR DESCRIPTION
For https://github.com/narmi/banking/issues/28841

I thought we used this component elsewhere in `banking`, but that I can see we just want to use it in CAO, as per the ticket above. This PR removes the padding surrounding the component, reduces the height of the component to 16px (`size--m`), and ensures the font is `body` instead of the default `header` of the `h3` element.

