### PR TITLE
fix(DatePicker): Android mobile datepicker doesn't like backspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "classcat": "^5.0.3",
         "downshift": "^6.1.7",
         "eslint-plugin-json": "^3.1.0",
-        "flatpickr": "^4.6.9",
+        "flatpickr": "^4.6.12",
         "raf-schd": "^4.0.3",
         "react-laag": "^2.0.3",
         "react-transition-group": "^4.4.5"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "classcat": "^5.0.3",
     "downshift": "^6.1.7",
     "eslint-plugin-json": "^3.1.0",
-    "flatpickr": "^4.6.9",
+    "flatpickr": "^4.6.12",
     "raf-schd": "^4.0.3",
     "react-laag": "^2.0.3",
     "react-transition-group": "^4.4.5"

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -19,6 +19,7 @@ const DateInput = ({
   defaultDate,
   onChange: onChangeProp = noop,
   useIsoOnChange = true,
+  disableMobile = false,
   testId,
   ...props
 }) => {
@@ -36,6 +37,7 @@ const DateInput = ({
     minDate,
     altInput,
     altFormat,
+    disableMobile,
     disable: disableDates,
     defaultDate,
     onChange: (flatpickrVal) => {
@@ -92,6 +94,8 @@ DateInput.propTypes = {
   dateFormat: PropTypes.string,
   /** If the `onChange` callback should pass the date string in ISO8601 format */
   useIsoOnChange: PropTypes.bool,
+  /** Disable mobile text inputs on mobile web */
+  disableMobile: PropTypes.bool,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };


### PR DESCRIPTION
Part of https://github.com/narmi/banking/issues/32271