### PR TITLE
feat(Select): add category grouping feature

### DIFF
--- a/src/Select/SelectCategory.js
+++ b/src/Select/SelectCategory.js
@@ -1,0 +1,19 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+import React from "react";
+import PropTypes from "prop-types";
+
+const SelectCategory = ({ children }) => {
+  return <>{children}</>;
+};
+
+SelectCategory.displayName = "Select.Category";
+
+SelectCategory.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default SelectCategory;

--- a/src/Select/SelectItem.js
+++ b/src/Select/SelectItem.js
@@ -14,6 +14,12 @@ SelectItem.propTypes = {
    * value starting with `n`.
    */
   value: PropTypes.string.isRequired,
+  /**
+   * Custom typeahead string. By default typeahead uses `value`.
+   * Use this prop to pass in a custom string you'd like the user to search
+   * against when using typeahead.
+   */
+  searchValue: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -11,9 +11,6 @@ import SelectCategory from "./SelectCategory";
 
 const noop = () => {};
 
-// TODO: open category if current selection is in it
-// TODO: update tests
-
 /**
  * @param {Object} item a Select.Item or Select.Action component
  * @returns {Boolean} true if the item is a Select.Action
@@ -202,6 +199,17 @@ const Select = ({
     );
   };
 
+  const getDetailsProps = (categoryChildren) => {
+    let detailsExtraProps = {};
+    if (
+      isHighlightedInCategory(highlightedIndex, categoryChildren, items) ||
+      isSelectedItemInCategory(selectedItem, categoryChildren)
+    ) {
+      detailsExtraProps.open = true;
+    }
+    return detailsExtraProps;
+  };
+
   return (
     <div className="nds-select" data-testid={testId}>
       <DropdownTrigger
@@ -239,20 +247,17 @@ const Select = ({
               <details
                 key={label}
                 className="nds-select-category"
-                open={
-                  isHighlightedInCategory(
-                    highlightedIndex,
-                    categoryChildren,
-                    items
-                  ) || isSelectedItemInCategory(selectedItem, categoryChildren)
-                }
+                {...getDetailsProps(categoryChildren)} // controls open state
               >
                 <summary className="fontWeight--bold alignChild--left--center padding--x--s padding--y-xs">
-                  <span>{label}</span>
+                  <span id={`select-category-${label}`}>{label}</span>
                   <span className="nds-category-icon narmi-icon-chevron-down" />
                   <span className="nds-category-icon narmi-icon-chevron-up" />
                 </summary>
-                <ul className="list--reset">
+                <ul
+                  className="list--reset"
+                  aria-labelledby={`select-category-${label}`}
+                >
                   {categoryChildren.map((item) => renderItem(item, items))}
                 </ul>
               </details>

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React from "react";
 import PropTypes from "prop-types";
 import { useSelect } from "downshift";
@@ -6,8 +7,12 @@ import cc from "classcat";
 import DropdownTrigger from "../DropdownTrigger";
 import SelectItem from "./SelectItem";
 import SelectAction from "./SelectAction";
+import SelectCategory from "./SelectCategory";
 
 const noop = () => {};
+
+// TODO: open category if current selection is in it
+// TODO: update tests
 
 /**
  * @param {Object} item a Select.Item or Select.Action component
@@ -51,6 +56,45 @@ export const getItemByValue = (value, items) => {
 };
 
 /**
+ * @param {Object} item an item from `items`
+ * @param {array} items downshift index `items`
+ * @returns {Number} index of item
+ */
+export const getItemIndex = ({ props }, items) => {
+  const values = items.map(({ props }) => props.value);
+  return values.indexOf(props.value);
+};
+
+/**
+ * @param {Object} highlightedIndex index of currently highlight item
+ * @param {Array} categoryChildren child items in a given category
+ * @param {Array} items downshift `items`
+ * @returns {Boolean} if the provided item is in the category
+ */
+export const isHighlightedInCategory = (
+  highlightedIndex,
+  categoryChildren,
+  items
+) => {
+  if (highlightedIndex < 0) return false;
+  const highlightedValue = items[highlightedIndex].props.value;
+  const categoryValues = categoryChildren.map((child) => child.props.value);
+  return categoryValues.includes(highlightedValue);
+};
+
+/**
+ * @param {Object} selectedItem
+ * @param {Array} categoryChildren child items in a given category
+ * @returns {Boolean} if the selected item is in the given cagetory children
+ */
+export const isSelectedItemInCategory = (selectedItem, categoryChildren) => {
+  if (!selectedItem) return false;
+  const selectedValue = selectedItem.props.value;
+  const categoryValues = categoryChildren.map((child) => child.props.value);
+  return categoryValues.includes(selectedValue);
+};
+
+/**
  * Accessible custom select control for giving users the ability to select one option from a list of options.
  * `Select` also supports the ability to pass in a `<Select.Action>` that acts as an option that only triggers a side effect.
  * Typeahead is enabled based on the `value` prop of `<Select.Item>` elements passed in.
@@ -66,10 +110,23 @@ const Select = ({
   errorText,
   testId,
 }) => {
-  // The menu should only render children that have `value` or `onSelect` prop
-  const items = React.Children.toArray(children).filter(
-    ({ props }) => "value" in props || "onSelect" in props
-  );
+  let items = [];
+  let categories = [];
+
+  const allChildren = React.Children.toArray(children);
+
+  // If categories are being used, extract items from categories
+  if (allChildren.some(({ type }) => type.displayName === "Select.Category")) {
+    items = allChildren.flatMap(({ props }) =>
+      React.Children.toArray(props.children)
+    );
+    categories = allChildren.map(({ props }) => ({
+      label: props.label,
+      categoryChildren: React.Children.toArray(props.children),
+    }));
+  } else {
+    items = allChildren;
+  }
 
   const downshiftOpts = {
     id: id || `nds-select-${label}`,
@@ -104,6 +161,7 @@ const Select = ({
     getItemProps,
   } = useSelect(downshiftOpts);
 
+  const hasCategories = categories.length > 0;
   const hasSelectedItem = selectedItem !== undefined && selectedItem.props;
   const showMenu = isOpen && items.length > 0;
 
@@ -119,6 +177,31 @@ const Select = ({
       possiblePlacements: ["top-start", "bottom-start"],
     });
 
+  const renderItem = (item, items) => {
+    const index = getItemIndex(item, items);
+    return (
+      <li
+        key={`item-${index}`}
+        className={cc([
+          "nds-select-item",
+          "alignChild--left--center padding--x--s padding--y--xs",
+          {
+            "nds-select-item--highlighted": highlightedIndex === index,
+            "rounded--top": index === 0,
+            "rounded--bottom": index === items.length - 1,
+            "nds-select-item--hasGutter": hasSelectedItem || hasCategories,
+          },
+        ])}
+        {...getItemProps({ item, index })}
+      >
+        {hasSelectedItem && selectedItem.props.value === item.props.value && (
+          <span className="narmi-icon-check fontSize--l fontWeight--bold" />
+        )}
+        {item}
+      </li>
+    );
+  };
+
   return (
     <div className="nds-select" data-testid={testId}>
       <DropdownTrigger
@@ -130,14 +213,13 @@ const Select = ({
         {...getToggleButtonProps(triggerProps)}
         style={{
           ...triggerProps.style,
-
         }}
       />
       {renderLayer(
-        <ul
+        <div
           className={cc([
             "nds-select-list",
-            "list--reset bgColor--white",
+            "bgColor--white",
             {
               "rounded--bottom": layerSide === "bottom",
               "rounded--top": layerSide === "top",
@@ -152,30 +234,35 @@ const Select = ({
           }}
         >
           {showMenu &&
-            items.map((item, index) => (
-              <li
-                key={`${item}${index}`}
-                className={cc([
-                  "nds-select-item",
-                  "alignChild--left--center padding--x--s padding--y--xs",
-                  {
-                    "nds-select-item--highlighted": highlightedIndex === index,
-                    "rounded--top": index === 0,
-                    "rounded--bottom": index === items.length - 1,
-                    // make a left gutter for the checkmark if any item selected
-                    "nds-select-item--hasGutter": hasSelectedItem,
-                  },
-                ])}
-                {...getItemProps({ item, index })}
+            hasCategories &&
+            categories.map(({ label, categoryChildren }) => (
+              <details
+                key={label}
+                className="nds-select-category"
+                open={
+                  isHighlightedInCategory(
+                    highlightedIndex,
+                    categoryChildren,
+                    items
+                  ) || isSelectedItemInCategory(selectedItem, categoryChildren)
+                }
               >
-                {hasSelectedItem &&
-                  selectedItem.props.value === item.props.value && (
-                    <span className="narmi-icon-check fontSize--l fontWeight--bold" />
-                  )}
-                {item}
-              </li>
+                <summary className="fontWeight--bold alignChild--left--center padding--x--s padding--y-xs">
+                  <span>{label}</span>
+                  <span className="nds-category-icon narmi-icon-chevron-down" />
+                  <span className="nds-category-icon narmi-icon-chevron-up" />
+                </summary>
+                <ul className="list--reset">
+                  {categoryChildren.map((item) => renderItem(item, items))}
+                </ul>
+              </details>
             ))}
-        </ul>
+          {showMenu && !hasCategories && (
+            <ul className="list--reset">
+              {items.map((item) => renderItem(item, items))}
+            </ul>
+          )}
+        </div>
       )}
     </div>
   );
@@ -217,4 +304,5 @@ Select.propTypes = {
 
 Select.Item = SelectItem;
 Select.Action = SelectAction;
+Select.Category = SelectCategory;
 export default Select;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -130,7 +130,7 @@ const Select = ({
     items,
     initialSelectedItem: defaultValue && getItemByValue(defaultValue, items),
     initialIsOpen: defaultOpen,
-    itemToString: (item) => item.props.value || item.props.children, // typeahead string
+    itemToString: (item) => item.props.searchValue || item.props.value, // typeahead string
     onSelectedItemChange: ({ selectedItem }) => {
       // for Select.Action items, we only fire the side effect
       if (isAction(selectedItem)) {

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -22,6 +22,7 @@
 }
 
 .nds-select-item {
+  box-sizing: border-box;
   cursor: pointer;
   position: relative;
   min-height: var(--space-xl);
@@ -38,5 +39,40 @@
     top: 50%;
     transform: translateY(-50%);
     color: var(--theme-primary);
+  }
+}
+
+.nds-select-category {
+  list-style: none;
+
+  .narmi-icon-chevron-up {
+    display: none;
+  }
+
+  &[open] {
+    .narmi-icon-chevron-down {
+      display: none;
+    }
+    .narmi-icon-chevron-up {
+      display: block;
+    }
+  }
+
+  summary {
+    display: flex;
+    cursor: pointer;
+    position: relative;
+    min-height: var(--space-xl);
+
+    span {
+      align-self: center;
+    }
+  }
+
+  .nds-category-icon {
+    position: absolute;
+    right: var(--space-s);
+    top: 50%;
+    transform: translateY(-50%);
   }
 }

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -73,6 +73,46 @@ WithAction.parameters = {
   },
 };
 
+export const WithCategories = Template.bind({});
+WithCategories.args = {
+  label: "Select an Icon",
+  children: [
+    <Select.Category label="Transportation">
+      <Select.Item value="truck">
+        <span className="narmi-icon-truck padding--right--xs" /> Truck
+      </Select.Item>
+      <Select.Item value="anchor">
+        <span className="narmi-icon-anchor padding--right--xs" /> Anchor
+      </Select.Item>
+      <Select.Item value="car-outline">
+        <span className="narmi-icon-car-outline padding--right--xs" /> Car
+      </Select.Item>
+    </Select.Category>,
+    <Select.Category label="Art">
+      <Select.Item value="film">
+        <span className="narmi-icon-film padding--right--xs" /> Film
+      </Select.Item>
+      <Select.Item value="aperture">
+        <span className="narmi-icon-aperture padding--right--xs" /> Aperture
+      </Select.Item>
+      <Select.Item value="pen">
+        <span className="narmi-icon-pen-tool padding--right--xs" /> Pen
+      </Select.Item>
+      <Select.Item value="blob">
+        <span className="narmi-icon-blob padding--right--xs" /> Blob
+      </Select.Item>
+    </Select.Category>,
+  ],
+};
+WithCategories.parameters = {
+  docs: {
+    description: {
+      story:
+        "You may group `Select.Item` elements by category with `Select.Category`. When using categories, you **must** make all direct children of `Select` a `Select.Category`; no orphan items are allowed when using categories.",
+    },
+  },
+};
+
 export const InAForm = () => {
   const [inputValue, setInputValue] = useState("");
   return (
@@ -107,7 +147,12 @@ export const Controlled = () => {
   const [value, setValue] = useState(null);
   return (
     <>
-      <Select id="controlled-product-field" label="Account" value={value} onChange={(v) => setValue(v)}>
+      <Select
+        id="controlled-product-field"
+        label="Account"
+        value={value}
+        onChange={(v) => setValue(v)}
+      >
         <Select.Item value="checking1234">Checking (1234)</Select.Item>
         <Select.Item value="savings4321">Savings (4321)</Select.Item>
       </Select>
@@ -175,19 +220,20 @@ export const OneItem = () => {
       <Select.Item value="checking1234">Checking (1234)</Select.Item>
     </Select>
   );
-}
+};
 
 export const OneAction = () => {
   return (
     <Select label="Account">
-      <Select.Action onSelect={()=>{}}>
+      <Select.Action onSelect={() => {}}>
         <span className="fontColor--pine fontWeight--bold">
-          <span className="narmi-icon-plus padding--right--xs" /> Add new account
+          <span className="narmi-icon-plus padding--right--xs" /> Add new
+          account
         </span>
       </Select.Action>
     </Select>
   );
-}
+};
 
 export default {
   title: "Components/Select",

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -113,6 +113,29 @@ WithCategories.parameters = {
   },
 };
 
+export const CustomTypeahead = Template.bind({});
+CustomTypeahead.args = {
+  label: "Select an Industry",
+  children: [
+    { name: "Agriculture", code: 12345 },
+    { name: "Manufacturing", code: 55555 },
+    { name: "Logistics", code: 32144 },
+    { name: "Hospitality", code: 22147 },
+  ].map(({ name, code }) => (
+    <Select.Item value={code} searchValue={name}>
+      {name}
+    </Select.Item>
+  )),
+};
+CustomTypeahead.parameters = {
+  docs: {
+    description: {
+      story:
+        "By default, typeahead highlights items based on `value`. You may pass a `searchValue` to customize the string users search against when using typeahead. In this example, the value is a numeric code, but we'd like the user to filter on industry namej",
+    },
+  },
+};
+
 export const InAForm = () => {
   const [inputValue, setInputValue] = useState("");
   return (

--- a/src/Select/index.test.js
+++ b/src/Select/index.test.js
@@ -1,6 +1,33 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import Select, { isAction, getSelectedItemDisplay, getItemByValue } from "./";
+import Select, {
+  isAction,
+  getSelectedItemDisplay,
+  getItemByValue,
+  getItemIndex,
+  isHighlightedInCategory,
+  isSelectedItemInCategory,
+} from "./";
+
+const MOCK_ITEMS = [
+  <Select.Item key=".0" value="uno">
+    one
+  </Select.Item>,
+  <Select.Item key=".1" value="dos">
+    two
+  </Select.Item>,
+  <Select.Item key=".2" value="tres">
+    three
+  </Select.Item>,
+  <Select.Item key=".3" value="quatro">
+    four
+  </Select.Item>,
+];
+
+const MOCK_CATEGORIES = [
+  { label: "Below Two", categoryChildren: [...MOCK_ITEMS].slice(0, 2) },
+  { label: "Above Two", categoryChildren: [...MOCK_ITEMS].slice(2, 2) },
+];
 
 describe("Select", () => {
   /**
@@ -35,9 +62,41 @@ describe("Select", () => {
     );
   });
 
+  it("getItemIndex: gets expected index of item by its value", () => {
+    const item = (
+      <Select.Item key=".2" value="tres">
+        three
+      </Select.Item>
+    );
+    expect(getItemIndex(item, MOCK_ITEMS)).toBe(2);
+  });
+
+  it("isHighlightedInCategory: correctly determines which category a highlighted item is in", () => {
+    const firstCategoryChildren = MOCK_CATEGORIES[0].categoryChildren;
+    expect(isHighlightedInCategory(-1, firstCategoryChildren, MOCK_ITEMS)).toBe(
+      false
+    ); // no item highlighted
+    expect(isHighlightedInCategory(1, firstCategoryChildren, MOCK_ITEMS)).toBe(
+      true
+    ); // second item is in first category
+    expect(isHighlightedInCategory(3, firstCategoryChildren, MOCK_ITEMS)).toBe(
+      false
+    ); // fourth item is NOT in first category
+  });
+
+  it("isSelectedItemInCategory: correctly determines if the selected item is in a given category", () => {
+    const firstCategoryChildren = MOCK_CATEGORIES[0].categoryChildren;
+    expect(isSelectedItemInCategory(MOCK_ITEMS[3], firstCategoryChildren)).toBe(
+      false
+    );
+    expect(isSelectedItemInCategory(MOCK_ITEMS[0], firstCategoryChildren)).toBe(
+      true
+    );
+  });
+
   it("renders as expected with basic props", () => {
     render(
-      <Select label="Account Type">
+      <Select id="accountField" label="Account Type">
         <Select.Item value="checking"></Select.Item>
         <Select.Item value="savings"></Select.Item>
       </Select>
@@ -94,7 +153,7 @@ describe("Select", () => {
     const handleChange = jest.fn();
     const sideEffect = jest.fn();
     render(
-      <Select label="Account Type" onChange={handleChange}>
+      <Select id="accountField" label="Account Type" onChange={handleChange}>
         <Select.Item value="checking">Checking</Select.Item>
         <Select.Item value="savings">Savings</Select.Item>
         <Select.Action onSelect={sideEffect}>Action</Select.Action>

--- a/src/base-styles/reset.scss
+++ b/src/base-styles/reset.scss
@@ -83,6 +83,12 @@ details {
 }
 summary {
   display: list-item;
+  padding-left: 0;
+  background-image: none;
+  -webkit-appearance: none;
+}
+details summary::-webkit-details-marker {
+  display: none;
 }
 
 // Normalize horizontal rule


### PR DESCRIPTION
closes #936 

Adds a `Select.Category` grouping element for select items.

The actual select items are treated by downshift as a flat list of items, but the component has some helpers to determine which items are in which category so we can open and close the disclosures as the highlight/selection moves through them.

Also made some markup changes to ensure we're not invalidly nesting list items directly inside a `details` element.

### How does this work?

The opening and closing disclosures for the categories use the [native `details` html element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details). This behaves in an uncontrolled manner, but if certain conditions are met (highlighted item is in category or selected item is in category), we force it open using its `open` attribute.

### How do I review this?

Aside from looking at the code, run the branch locally. Does the select behave in the way you expect it to?



------

<img width="1067" alt="Screen Shot 2023-07-27 at 5 16 04 PM" src="https://github.com/narmi/design_system/assets/231252/6c7fc289-1689-4735-a8fb-3424667aaf83">



![Jul-27-2023 17-27-53](https://github.com/narmi/design_system/assets/231252/912368c6-3e4e-48ff-a40a-22a59b4ef95f)

