### PR TITLE
fix(focus traps): diable autofocus in Popover and Dialog

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -38,7 +38,6 @@ const Dialog = ({
   footer,
   width = "500px",
   testId,
-  hasAutoFocus = true,
 }) => {
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import React, { useRef, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
@@ -37,6 +38,7 @@ const Dialog = ({
   footer,
   width = "500px",
   testId,
+  hasAutoFocus = true,
 }) => {
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
@@ -76,7 +78,7 @@ const Dialog = ({
   const dialogJSX = (
     <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
       <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
-        <FocusLock>
+        <FocusLock autoFocus={false}>
           <div
             role="dialog"
             aria-labelledby="aria-dialog-label"

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-autofocus */
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useLayer } from "react-laag";
@@ -27,13 +28,16 @@ const Popover = ({
   closeOnContentClick = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const popoverContent = closeOnContentClick ? React.cloneElement(content, {
-    onClick: () => {
-      if (content.onClick) {
-        content.onClick();
-      } setIsOpen(false);
-    }
-  }) : content
+  const popoverContent = closeOnContentClick
+    ? React.cloneElement(content, {
+        onClick: () => {
+          if (content.onClick) {
+            content.onClick();
+          }
+          setIsOpen(false);
+        },
+      })
+    : content;
 
   const closePopover = () => {
     setIsOpen(false);
@@ -53,7 +57,7 @@ const Popover = ({
     if (key === "Escape" && isOpen) {
       setIsOpen(false);
     }
-  }
+  };
 
   const { renderLayer, triggerProps, triggerBounds, layerProps } = useLayer({
     isOpen,
@@ -107,9 +111,7 @@ const Popover = ({
               data-testid={testId}
             >
               <div tabIndex={-1}>
-                <FocusLock>
-                  {popoverContent}
-                </FocusLock>
+                <FocusLock autoFocus={false}>{popoverContent}</FocusLock>
               </div>
             </div>
           )}


### PR DESCRIPTION
Disables `autoFocus` feature of `FocusLock` everywhere in NDS it's used. Autofocusing the first element can lead to a frustrating experience for users, especially in regard to a11y