### PR TITLE
feat(Pagination): enable fully controlled mode

### DIFF
--- a/src/Pagination/index.stories.js
+++ b/src/Pagination/index.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Pagination from "./";
 
 const Template = (args) => <Pagination {...args} />;
@@ -7,6 +7,40 @@ export const Overview = Template.bind({});
 Overview.args = {
   totalPages: 40,
   defaultSelectedPage: 3,
+};
+
+export const FullyControlled = () => {
+  const [selectedPage, setSelectedPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(40);
+
+  const handlePageChange = (page) => {
+    setSelectedPage(parseInt(page, 10));
+  };
+
+  return (
+    <>
+      <Pagination
+        totalPages={totalPages}
+        selectedPage={selectedPage}
+        onPageChange={handlePageChange}
+      />
+      <div className="padding--all border--top margin--top">
+        <label htmlFor="totalPages">Total pages</label>
+        <select
+          className="margin--left"
+          id="totalPages"
+          onChange={(e) => setTotalPages(parseInt(e.target.value), 10)}
+        >
+          <option value="1">1</option>
+          <option value="3">3</option>
+          <option value="25">25</option>
+          <option value="40" selected>
+            40
+          </option>
+        </select>
+      </div>
+    </>
+  );
 };
 
 export default {


### PR DESCRIPTION
closes #984 

Refactor `Pagination` to allow fully controlled selected page and total pages.

When the selected page becomes out of bounds (most likely because total pages change), we move selection back to the beginning. If the currently selected page is within bounds, we keep that page selected.

![Aug-02-2023 13-08-24](https://github.com/narmi/design_system/assets/231252/bbbaae61-82ff-43ca-9e00-4fd61a61f834)
