### PR TITLE
feat(Select): add getTypeaheadString prop for custom typeahead behavior

### DIFF
--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -136,6 +136,43 @@ CustomTypeahead.parameters = {
   },
 };
 
+export const ChangingTypeaheadBehavior = Template.bind({});
+ChangingTypeaheadBehavior.args = {
+  label: "Select an Industry",
+  getTypeaheadString: (userInput, selectItem) => {
+    console.info({ userInput });
+    console.info({ selectItem });
+
+    let searchString =
+      selectItem.props.searchValue || selectItem.props.value || "";
+
+    // user is searching by code
+    if (/\d/.test(userInput)) {
+      searchString = selectItem.props.value;
+    }
+
+    return searchString;
+  },
+  children: [
+    { name: "Agriculture", code: "12345" },
+    { name: "Manufacturing", code: "55555" },
+    { name: "Logistics", code: "32144" },
+    { name: "Hospitality", code: "22147" },
+  ].map(({ name, code }) => (
+    <Select.Item value={code} searchValue={name}>
+      {name} - {code}
+    </Select.Item>
+  )),
+};
+ChangingTypeaheadBehavior.parameters = {
+  docs: {
+    description: {
+      story:
+        "You may provide a function to the `getTypeaheadString` prop to customize which item props/data should be used for autocomplete. In this example, we autocomplete on `value` when the user input is numeric, and autocomplete on `searchValue` (name) when the input is alpha",
+    },
+  },
+};
+
 export const InAForm = () => {
   const [inputValue, setInputValue] = useState("");
   return (


### PR DESCRIPTION
closes #989 

Enables custom typeahead behavior via the `getTypeaheadString` function prop.

