### PR TITLE
fix(Dialog): add bottom spacing when no footer is passed in

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -100,7 +100,10 @@ const Dialog = ({
             </div>
             <div
               ref={contentRef}
-              className="nds-dialog-content nds-typography padding--top--xs"
+              className={cc([
+                "nds-dialog-content nds-typography padding--top--xs",
+                { "padding--bottom--l": !footer },
+              ])}
             >
               {children}
             </div>

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -102,7 +102,7 @@ const Dialog = ({
               ref={contentRef}
               className={cc([
                 "nds-dialog-content nds-typography padding--top--xs",
-                { "padding--bottom--l": !footer },
+                { "padding--bottom--xl": !footer },
               ])}
             >
               {children}


### PR DESCRIPTION
closes #1002 

As part of the NDS v3 release, we refactored some components in `banking` that were using the deprecated `Modal` component. The `Modal` component was providing some bottom spacing to the content area. In `Dialog`, the `footer` prop causes some bottom padding to be added.

**This PR will add some default bottom padding to `Dialog` when no `footer` prop is passed in.**

### Examples

After the change, `Dialog` usage without a footer will have bottom spacing

<img width="578" alt="Screen Shot 2023-08-18 at 3 20 46 PM" src="https://github.com/narmi/design_system/assets/231252/2fe9c2e0-b45e-407b-82a9-b6c1388ce91a">
<img width="590" alt="Screen Shot 2023-08-18 at 3 22 22 PM" src="https://github.com/narmi/design_system/assets/231252/e3ea7a6b-5d59-40f3-adaf-c3971fe4f431">
