### PR TITLE
fix(DropdownTrigger): remove z-index on chevron-down

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -60,10 +60,6 @@
   &.narmi-icon-chevron-up {
     z-index: 4;
   }
-
-  &.narmi-icon-chevron-down {
-    z-index: 1;
-  }
 }
 
 .nds-dropdownTrigger-error {


### PR DESCRIPTION
resolves https://github.com/narmi/banking/issues/34975

This issue only occurs when `Select` is used and is resolved by removing the z-index. Confirmed via storybook at the expected behavior of the chevron-down in the select box is maintained.   
![Screen Shot 2023-08-23 at 10 57 52 AM](https://github.com/narmi/design_system/assets/25830081/7967c8d1-009a-4458-b15b-518763ada7a8)
