### PR TITLE
fix(Dialog): prevent width prop from overriding mobile viewport behavior

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -83,7 +83,7 @@ const Dialog = ({
             aria-labelledby="aria-dialog-label"
             aria-modal="true"
             className="nds-dialog"
-            style={{ width }}
+            style={{ "--dialog-preferred-width": width }}
             data-testid={testId}
           >
             <div

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -55,6 +55,7 @@
     border-radius: var(--border-radius-m);
     max-height: 80vh; // prevent modal from being taller than the shim content box
     min-width: 240px; // should be no narrower than this on larger viewports
+    width: var(--dialog-preferred-width);
   }
 }
 


### PR DESCRIPTION
## The problem

Identified by @xiexiewenting, the inline `width` style was overriding small viewport behavior because it's higher specificity.

Changing the prop or its default would be considered a breaking change, so we need a way to prevent the `width` prop from setting Dialog width at viewports "s" or smaller.

## The solution

Instead of directly setting the `width` style property on the Dialog element, we can instead set a _custom property_ that holds the value passed into the component.

This allows us to use CSS to decide when that property value should be used (only on screens larger than "s").


### Extra reading - Refresher on CSS Custom Properties

Despite having a `var()` function, CSS doesn't have variables. CSS has _custom properties_, which cascade like any other CSS property. Just like `font-size`, the value of a custom property gets inherited through the DOM tree unless it gets redefined somewhere on the way down.

The `var()` function is basically saying, "Use a variable value, based on the current value of this custom property in the cascade". 

`<div class="foo" style="--my-custom-property: blue" />` is more or less equivalent to:
```css
.foo {
   --my-custom-property: blue;
}
```

The value for `--my-custom-property` is only `blue` on DOM nodes matching the selector `.foo`, or if it's defined as an inline style on the element.