### PR TITLE
fix(docs): update popover stories to use type button

### DIFF
--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -19,7 +19,11 @@ const Template = (args) => (
 export const Overview = Template.bind({});
 Overview.args = {
   content: <div className="padding--all--m">📦 Any content</div>,
-  children: <Button type="secondary">Open Popover</Button>,
+  children: (
+    <Button type="button" kind="secondary">
+      Open Popover
+    </Button>
+  ),
 };
 Overview.argTypes = {
   content: { control: false },
@@ -27,8 +31,17 @@ Overview.argTypes = {
 
 export const Positioning = Template.bind({});
 Positioning.args = {
-  content: <div className="padding--all--m">Use <code>side</code> and <code>alignment</code> to set your preferred positioning</div>,
-  children: <Button type="secondary">Top / Start positioned Popover</Button>,
+  content: (
+    <div className="padding--all--m">
+      Use <code>side</code> and <code>alignment</code> to set your preferred
+      positioning
+    </div>
+  ),
+  children: (
+    <Button type="button" kind="secondary">
+      Top / Start positioned Popover
+    </Button>
+  ),
   side: "top",
   alignment: "start",
 };
@@ -38,7 +51,11 @@ Positioning.argTypes = {
 
 export const FocusManagement = Template.bind({});
 FocusManagement.args = {
-  children: <Button type="secondary">Click to show Popover</Button>,
+  children: (
+    <Button type="button" kind="secondary">
+      Click to show Popover
+    </Button>
+  ),
   content: (
     <div className="padding--all">
       Focus will be trapped to{" "}


### PR DESCRIPTION
closes #1007 

Update Popover stories to use correct props on the `Button` component passed in.

When an NDS `Button` is used as a trigger, it takes on `type="button"` by default. When in a form, it implicitly becomes `type="submit"`, which causes some unusual side effects with the Enter key opening the popover.

The docs now reflect how to best avoid this behavior by explicitly setting the button `type`