### PR TITLE
fix(Popover): check if SSR in useLayer options

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -67,7 +67,7 @@ const Popover = ({
     placement: `${side}-${alignment}`,
     preferX: "left",
     preferY: "bottom",
-    container: document.body,
+    container: document ? document.body : undefined,
     triggerOffset: offset,
   });
 


### PR DESCRIPTION
fixes #1011 

Avoid referencing document properties without checking if we're in SSR first