### PR TITLE
fix(Popover): use typeof for SSR check

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -67,7 +67,7 @@ const Popover = ({
     placement: `${side}-${alignment}`,
     preferX: "left",
     preferY: "bottom",
-    container: document ? document.body : undefined,
+    container: typeof document !== "undefined" ? document.body : undefined,
     triggerOffset: offset,
   });
 


### PR DESCRIPTION
relates to #1011 

Use `typeof` for undefined check