### PR TITLE
fix(Select): enable typing in faux input before menu is open

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -157,13 +157,23 @@ const Select = ({
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;
-      if (type === "__menu_keydown_character__") {
+      let isOpen = changes.isOpen;
+
+      if (
+        type === "__menu_keydown_character__" ||
+        type === "__togglebutton_keydown_character__"
+      ) {
         const { inputValue } = changes;
         setUserInput(inputValue);
+        isOpen = true;
       } else {
         setUserInput(""); // reset input after any other event
       }
-      return changes;
+
+      return {
+        ...changes,
+        isOpen,
+      };
     },
   };
 


### PR DESCRIPTION
relates to: 
- https://github.com/narmi/banking/issues/35868

Add key event handling to menu trigger in addition to the menu. This allows users to tab to the field and begin typing before the menu is open. Typing anything with the trigger focused will open the menu.

Once an item is selected, we do not clear it from the display value, but the user may type in the background to autocomplete to another item. This mimics the behavior of a native `select` element.

![Aug-29-2023 15-10-40](https://github.com/narmi/design_system/assets/231252/76c671a6-3382-417a-af71-f6593460e22b)
