### PR TITLE
feat(DateInput): add `disablePortal` for use inside popover

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -58,7 +58,6 @@ const DateInput = ({
 
   useEffect(() => {
     if (disablePortal) {
-      console.dir({ ...props });
       flatpickrOptions.static = true;
     }
     flatpickr(input.current, flatpickrOptions);

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -21,6 +21,7 @@ const DateInput = ({
   useIsoOnChange = true,
   disableMobile = false,
   testId,
+  disablePortal,
   ...props
 }) => {
   const input = useRef();
@@ -56,21 +57,26 @@ const DateInput = ({
   };
 
   useEffect(() => {
+    if (disablePortal) {
+      console.dir({ ...props });
+      flatpickrOptions.static = true;
+    }
     flatpickr(input.current, flatpickrOptions);
-  }, [flatpickrOptions, input]);
+  }, [flatpickrOptions, input, disablePortal]);
 
   return (
-    <Input {...props}>
-      <input
-        key={"nds-text"}
-        ref={input}
-        type="date"
-        required
-        placeholder={props.label}
-        data-testid={testId}
-        {...props}
-      />
-    </Input>
+    <div>
+      <Input {...props} label={props.label}>
+        <input
+          key={"nds-text"}
+          ref={input}
+          type="date"
+          required
+          data-testid={testId}
+          {...props}
+        />
+      </Input>
+    </div>
   );
 };
 DateInput.propTypes = {
@@ -101,6 +107,8 @@ DateInput.propTypes = {
   disableMobile: PropTypes.bool,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
+  /** When true, appends the calendar popup to the parent of the input instead of to document body */
+  disablePortal: PropTypes.bool,
 };
 DateInput.defaultProps = {
   onChange: () => {},

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -1,5 +1,6 @@
 import React from "react";
 import DateInput from "./";
+import Popover from "../Popover";
 
 // formats native date object to the format flatpickr expects
 const toFPString = (date, dayOffset = 0) => {
@@ -36,6 +37,43 @@ AltInput.parameters = {
     description: {
       story:
         "The `altInput` prop will make the input show a date in an alternat format defined by `altFormat`. See [flatpickr docs](https://flatpickr.js.org/formatting/) for formatting options.",
+    },
+  },
+};
+
+export const DisablePortal = () => {
+  const content = (
+    <div className="padding--all">
+      <div className="padding--bottom">
+        <DateInput label="Start Date" disablePortal={true} />
+      </div>
+      <div className="padding--bottom">
+        <DateInput label="End Date" disablePortal={true} />
+      </div>
+    </div>
+  );
+
+  return (
+    <div
+      style={{
+        height: "200px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <Popover content={content}>
+        <button>Click to show popover</button>
+      </Popover>
+    </div>
+  );
+};
+DisablePortal.parameters = {
+  docs: {
+    description: {
+      story:
+        "By default, `DateInput` appends to the document body. Most of the time, this is fine, but when using inside of another modal that uses 'click outside' behavior, it can be helpful to render the `DateInput` calendar in-place by passing `disablePortal={true}`",
     },
   },
 };


### PR DESCRIPTION
fixes #1010 

Adds `disablePortal` prop to `DateInput` to append the calendar _inside_ its parent instead of `document.body`. This is useful when we want to use a `DateInput` inside a `Popover`.

<img width="1066" alt="Screen Shot 2023-08-29 at 6 51 50 PM" src="https://github.com/narmi/design_system/assets/231252/43b40bcf-49ab-4fd8-ac54-58a9f772a2be">
<img width="501" alt="Screen Shot 2023-08-29 at 6 51 59 PM" src="https://github.com/narmi/design_system/assets/231252/a4e37624-787f-424f-bd5a-105f1a3142e1">

