### PR TITLE
fix(Select): use correct state change types in state reducer

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -160,8 +160,8 @@ const Select = ({
       let isOpen = changes.isOpen;
 
       if (
-        type === "__menu_keydown_character__" ||
-        type === "__togglebutton_keydown_character__"
+        type === useSelect.stateChangeTypes.MenuKeyDownCharacter ||
+        type === useSelect.stateChangeTypes.ToggleButtonKeyDownCharacter
       ) {
         const { inputValue } = changes;
         setUserInput(inputValue);


### PR DESCRIPTION
**tl;dr** the state reducer in Select didn't work in prod builds. This makes it work in prod builds.

We were hard coding the string value of state change types from the `useSelect` downshift hook. It works fine in dev, but these strings are subject to change in prod builds, so we must instead use the references provided by `useSelect.stateChangeTypes`