### PR TITLE
feat(Combobox): add categories feature 

### DIFF
--- a/src/Combobox/ComboboxCategory.js
+++ b/src/Combobox/ComboboxCategory.js
@@ -6,6 +6,7 @@ const ComboboxCategory = ({ children }) => <>{children}</>;
 ComboboxCategory.displayName = "Combobox.Category";
 
 ComboboxCategory.propTypes = {
+  label: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),

--- a/src/Combobox/ComboboxCategory.js
+++ b/src/Combobox/ComboboxCategory.js
@@ -1,0 +1,15 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ComboboxCategory = ({ children }) => <>{children}</>;
+
+ComboboxCategory.displayName = "Combobox.Category";
+
+ComboboxCategory.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default ComboboxCategory;

--- a/src/Combobox/ComboboxItem.js
+++ b/src/Combobox/ComboboxItem.js
@@ -15,7 +15,7 @@ ComboboxItem.propTypes = {
    */
   value: PropTypes.string.isRequired,
   /**
-   * Custom typeahead string. By default typeahead uses `value`.
+   * Custom typeahead string. By default, typeahead uses `value`.
    * Use this prop to pass in a custom string you'd like the user to search
    * against when using typeahead.
    */

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -80,6 +80,17 @@ export const getVisibleChildrenByCategory = (
 };
 
 /**
+ * @param {Array} items all selectable Combobox.Item children
+ * @param {String} inputValue lowercase value of input
+ * @returns {Array} Combobox.Item children, filtered by the input value
+ */
+export const defaultFilterItemsByInput = (items, inputValue) =>
+  items.filter((item) => {
+    const query = item.props.searchValue || item.props.value;
+    return query.toLowerCase().startsWith(inputValue);
+  });
+
+/**
  * Autocomplete input component following the accessible
  * [ARIA combobox pattern](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role).
  *
@@ -94,6 +105,7 @@ const Combobox = ({
   onChange = noop,
   onInputChange = noop,
   inputValue: controlledInputValue,
+  filterItemsByInput = defaultFilterItemsByInput,
   children,
   disableFiltering = false,
   errorText,
@@ -145,10 +157,10 @@ const Combobox = ({
       // Typeahead behavior - we adjust the list of available options passed
       // into `useCombobox` by filtering the initial items list from input value
       if (!disableFiltering) {
-        const filteredItems = items.filter(isSelectable).filter((item) => {
-          const query = item.props.searchValue || item.props.value;
-          return query.toLowerCase().startsWith(inputValue.toLowerCase());
-        });
+        const filteredItems = filterItemsByInput(
+          items.filter(isSelectable),
+          inputValue.toLowerCase()
+        );
         setDisplayedItems(filteredItems);
       }
 
@@ -377,6 +389,12 @@ Combobox.propTypes = {
    * as the user types.
    */
   disableFiltering: PropTypes.bool,
+  /**
+   * Optionally pass a function to customize filtering behavior
+   *
+   * Signature: `(items, inputValue) => [...filteredItems]`
+   */
+  filterItemsByInput: PropTypes.func,
   /**
    * Error message.
    * When passed, this will cause the input to render in error state.

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -50,7 +50,7 @@ export const shouldOpenCategory = (
     result = categoryValues.includes(highlightedValue);
   }
 
-  // user is actively filtering; open all categories and show suggestions
+  // user is actively filtering; default all categories to open
   if (typeof inputValue === "string" && inputValue.length > 0) {
     result = true;
   }

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -182,6 +182,7 @@ const Combobox = ({
       snap: true,
       placement: "bottom-start",
       possiblePlacements: ["top-start", "bottom-start"],
+      preferY: "bottom",
       triggerOffset: -3,
       containerOffset: 16,
     });

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -291,6 +291,17 @@ const Combobox = ({
     ) : null;
   };
 
+  const handleMenuOpen = () => {
+    if (!isOpen) {
+      // Reset filtered items every time user refocuses.
+      // Subsequent changes in the input will re-filter the list.
+      openMenu();
+      if (hasSelectedItem) {
+        setDisplayedItems(items.filter(isSelectable));
+      }
+    }
+  };
+
   // It is possible that a consumer may have nothing to pass to `children`.
   // For example, if an API response hasn't completed to load in the autocomplete
   // options. In that case, Cobmobox should render a normal TextInput.
@@ -319,16 +330,8 @@ const Combobox = ({
         startIcon={icon}
         endIcon={isOpen ? "chevron-up" : "chevron-down"}
         {...getInputProps({
-          onFocus: () => {
-            if (!isOpen) {
-              openMenu();
-            }
-          },
-          onClick: () => {
-            if (!isOpen) {
-              openMenu();
-            }
-          },
+          onFocus: handleMenuOpen,
+          onClick: handleMenuOpen,
           onBlur: () => {
             // If the user has selected an option, we should
             // always set that as the value of the input.

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -57,3 +57,39 @@
     transform: translateY(-50%);
   }
 }
+
+.nds-combobox-category {
+  list-style: none;
+
+  .narmi-icon-chevron-up {
+    display: none;
+  }
+
+  &[open] {
+    .narmi-icon-chevron-down {
+      display: none;
+    }
+    .narmi-icon-chevron-up {
+      display: block;
+    }
+  }
+
+  summary {
+    outline: none;
+    display: flex;
+    cursor: pointer;
+    position: relative;
+    min-height: var(--space-xl);
+
+    span {
+      align-self: center;
+    }
+  }
+
+  .nds-category-icon {
+    position: absolute;
+    right: var(--space-s);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -81,6 +81,10 @@
     position: relative;
     min-height: var(--space-xl);
 
+    &:hover {
+      background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+    }
+
     span {
       align-self: center;
     }

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -193,6 +193,39 @@ WithCategories.parameters = {
   },
 };
 
+export const CustomFiltering = Template.bind({});
+CustomFiltering.args = {
+  id: "customFiltering",
+  label: "Transfer to",
+  children: [
+    <Combobox.Item searchValue="Main Checking - 67289" value="checking2">
+      Main Checking - 67289
+    </Combobox.Item>,
+    <Combobox.Item searchValue="Joint Checking - 14857" value="checking3">
+      Joint Checking - 14857
+    </Combobox.Item>,
+    <Combobox.Item searchValue="Business Checking - 11234" value="checking1">
+      Business Checking - 11234
+    </Combobox.Item>,
+    <Combobox.Item searchValue="Business Checking - 62947" value="savings1">
+      Business Savings - 62947
+    </Combobox.Item>,
+  ],
+  filterItemsByInput: (items, inputVal) =>
+    items.filter((item) => {
+      const query = (item.props.searchValue || item.props.value).toLowerCase();
+      return query.includes(inputVal);
+    }),
+};
+CustomFiltering.parameters = {
+  docs: {
+    description: {
+      story:
+        "In this example, a custom `filterItemsByInput` function is used to enable search by either account name OR first four.",
+    },
+  },
+};
+
 export default {
   title: "Components/Combobox",
   component: Combobox,

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -83,7 +83,7 @@ NoChildren.parameters = {
 };
 
 export const FullyControlled = () => {
-  const [inputValue, setInputValue] = useState("Initial Value");
+  const [inputValue, setInputValue] = useState("");
   return (
     <div>
       <Combobox
@@ -148,6 +148,49 @@ export const InADialog = () => {
       </Dialog>
     </>
   );
+};
+
+export const WithCategories = Template.bind({});
+WithCategories.args = {
+  id: "withCategories",
+  label: "Transfer to",
+  children: [
+    <Combobox.Category label="Checking">
+      <Combobox.Item searchValue="Business Checking" value="checking1">
+        Business Checking - 11234
+      </Combobox.Item>
+      <Combobox.Item searchValue="Main Checking" value="checking2">
+        Main Checking - 13989
+      </Combobox.Item>
+      <Combobox.Item searchValue="Joint Checking" value="checking3">
+        Joint Checking - 14857
+      </Combobox.Item>
+    </Combobox.Category>,
+    <Combobox.Category label="Savings">
+      <Combobox.Item searchValue="Business Checking" value="savings1">
+        Business Savings - 13938
+      </Combobox.Item>
+      <Combobox.Item searchValue="Main Savings" value="savings2">
+        Main Savings - 48274
+      </Combobox.Item>
+      <Combobox.Item searchValue="Joint Savings" value="savings3">
+        Joint Savings - 48284
+      </Combobox.Item>
+    </Combobox.Category>,
+    <Combobox.Category label="External Accounts">
+      <Combobox.Item value="Sasha">Sasha - 84839</Combobox.Item>
+      <Combobox.Item value="Joan">Joan - 36183</Combobox.Item>
+      <Combobox.Item value="Benoit">Benoit - 53261</Combobox.Item>
+    </Combobox.Category>,
+  ],
+};
+WithCategories.parameters = {
+  docs: {
+    description: {
+      story:
+        "You may group `Combobox.Item` elements by category with `Combobox.Category`. When using categories, you **must** make all direct children of `Combobox` a `Combobox.Category`; no orphan items are allowed when using categories.",
+    },
+  },
 };
 
 export default {

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -81,7 +81,7 @@ WithCategories.args = {
   id: "withCategories",
   label: "Select an Icon",
   children: [
-    <Select.Category label="Transportation">
+    <Select.Category label="Transportation" key="transport">
       <Select.Item value="truck">
         <span className="narmi-icon-truck padding--right--xs" /> Truck
       </Select.Item>
@@ -92,7 +92,7 @@ WithCategories.args = {
         <span className="narmi-icon-car-outline padding--right--xs" /> Car
       </Select.Item>
     </Select.Category>,
-    <Select.Category label="Art">
+    <Select.Category label="Art" key="art">
       <Select.Item value="film">
         <span className="narmi-icon-film padding--right--xs" /> Film
       </Select.Item>

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -81,7 +81,7 @@ WithCategories.args = {
   id: "withCategories",
   label: "Select an Icon",
   children: [
-    <Select.Category label="Transportation" key="transport">
+    <Select.Category label="Transportation">
       <Select.Item value="truck">
         <span className="narmi-icon-truck padding--right--xs" /> Truck
       </Select.Item>
@@ -92,7 +92,7 @@ WithCategories.args = {
         <span className="narmi-icon-car-outline padding--right--xs" /> Car
       </Select.Item>
     </Select.Category>,
-    <Select.Category label="Art" key="art">
+    <Select.Category label="Art">
       <Select.Item value="film">
         <span className="narmi-icon-film padding--right--xs" /> Film
       </Select.Item>


### PR DESCRIPTION
closes #1018 

**blocked by: https://github.com/narmi/design_system/pull/1023**

Adds `Combobox.Category` support, similar to the category feature in `Select`.

## How it works

When categories are passed into `Combobox`, we extract all the children as a flat list, [similar to `Select`](https://github.com/narmi/design_system/blob/a6f155ba42c9d1edb087b326b35b582487be78c1/src/Select/index.js#L129). This allows the downshift `useCombobox` hook to ignore categories and behave the same as a basic Combobox.

Categories are used to nest items inside `details` elements when rendering, [similar to how it works in `Select`](https://github.com/narmi/design_system/blob/a6f155ba42c9d1edb087b326b35b582487be78c1/src/Select/index.js#L282).

### Category rendering rules

A category is only rendered when:
- It has at least one item that has not been filtered out by the typeahead behavior

A category is only opened when:
- User clicks on the category name
- Highlight via mouse or keyboard nav moves onto an item included in the category
- When items are being filtered, so users can see the category names _and_ the suggestions while filtering

## Demo
![Sep-08-2023 17-35-19](https://github.com/narmi/design_system/assets/231252/49553e2b-a4b7-42a0-ac53-4b54274d0218)



