### PR TITLE
fix(DateInput): use TextInput component instead of native input directly

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import Input from "../Input";
+import TextInput from "../TextInput";
 import { english } from "flatpickr/dist/l10n/default";
 import flatpickr from "flatpickr";
 
@@ -64,18 +64,17 @@ const DateInput = ({
   }, [flatpickrOptions, input, disablePortal]);
 
   return (
-    <div>
-      <Input {...props} label={props.label}>
-        <input
-          key={"nds-text"}
-          ref={input}
-          type="date"
-          required
-          data-testid={testId}
-          {...props}
-        />
-      </Input>
-    </div>
+    <>
+      <TextInput
+        {...props}
+        label={props.label}
+        ref={input}
+        type="date"
+        required
+        data-testid={testId}
+        {...props}
+      />
+    </>
   );
 };
 DateInput.propTypes = {

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -45,10 +45,18 @@ export const DisablePortal = () => {
   const content = (
     <div className="padding--all">
       <div className="padding--bottom">
-        <DateInput label="Start Date" disablePortal={true} />
+        <DateInput
+          label="Start Date"
+          placeholder="YYYY-MM-DD"
+          disablePortal={true}
+        />
       </div>
       <div className="padding--bottom">
-        <DateInput label="End Date" disablePortal={true} />
+        <DateInput
+          label="End Date"
+          placeholder="YYYY-MM-DD"
+          disablePortal={true}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
fixes #1038 

Convert `input` to `TextInput` to ensure stable label rendering behavior