### PR TITLE
fix(Combobox, Select): Fix Select and Combobox rendering in Dialogs

### DIFF
--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -12,7 +12,7 @@
   border-radius: var(--border-radius-default);
   max-height: 40vh;
   overflow-y: scroll;
-  z-index: 3;
+  z-index: 4;
 
   &--bottom {
     border-top: 1px solid var(--border-color-default);

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -1,7 +1,7 @@
 .nds-select-list {
   max-height: 50vh;
   overflow-y: auto;
-  z-index: 3;
+  z-index: 4;
 
   &:focus {
     outline: none;

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -262,9 +262,8 @@ export const InADialog = (args) => {
       >
         <div className="padding--y--s">
           <div>
-            The floating menu list will take up space in document flow, allowing
-            <code>Select</code> to expand the height of its content container if
-            there isn't enough room for the dropdown.
+            The floating menu list will render portaled near the bottom of the{" "}
+            {"<body>"} HTML element.
           </div>
           <div className="padding--y--l">
             <Select {...args} />


### PR DESCRIPTION
resolves: #1045

The `<div id="layers"></div>`, created by `react-laag`, is used alongside `downshift` to build our `Select` component. This `div` is appended to the end of the `body`. Meanwhile, the `Dialog` component also positions itself at the `body`'s end dynamically. As a result, the layers `div`, which has a `z-index` of `3`, precedes the `Dialog` in stacking order.

This PR bumps the `Select` and `Combobox` `z-index`es to 4.