### PR TITLE
Style/1044 combobox design feedback

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -141,7 +141,6 @@ const Combobox = ({
     Boolean(controlledInputValue)
   );
 
-  // TODO: state reducer
   const {
     isOpen,
     selectedItem,

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -137,7 +137,11 @@ const Combobox = ({
   }
 
   const [displayedItems, setDisplayedItems] = useState(items);
+  const [showClearButton, setShowClearButton] = useState(
+    Boolean(controlledInputValue)
+  );
 
+  // TODO: state reducer
   const {
     isOpen,
     selectedItem,
@@ -147,7 +151,6 @@ const Combobox = ({
     getItemProps,
     highlightedIndex,
     inputValue,
-    setInputValue,
     openMenu,
     reset,
   } = useCombobox({
@@ -180,6 +183,14 @@ const Combobox = ({
       }
       onChange(newSelection);
       onInputChange(newSelection);
+    },
+    onStateChange: ({ type }) => {
+      if (
+        type === useCombobox.stateChangeTypes.ItemClick ||
+        type === useCombobox.stateChangeTypes.InputChange
+      ) {
+        setShowClearButton(true);
+      }
     },
   });
 
@@ -296,11 +307,7 @@ const Combobox = ({
       // Reset filtered items every time user refocuses.
       // Subsequent changes in the input will re-filter the list.
       openMenu();
-      // If the user revisits the combobox after selecting an item,
-      // only show the selected item and clear the input. The list will
-      // be re-filtered as they type
       if (hasSelectedItem) {
-        setInputValue("");
         setDisplayedItems(items.filter(isSelectable));
       }
     }
@@ -331,6 +338,10 @@ const Combobox = ({
         <TextInput
           label={label}
           value={inputValue}
+          showClearButton={showClearButton}
+          onInputClear={() => {
+            reset(); // reset all downshift state when user clicks clear button
+          }}
           startIcon={icon}
           endContent={
             <span
@@ -342,15 +353,6 @@ const Combobox = ({
           {...getInputProps({
             onFocus: handleMenuOpen,
             onClick: handleMenuOpen,
-            onBlur: () => {
-              // If the user has selected an option, we should
-              // always set that as the value of the input.
-              if (hasSelectedItem) {
-                setInputValue(
-                  selectedItem.props.searchValue || selectedItem.props.value
-                );
-              }
-            },
           })}
         />
         {renderLayer(

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -332,7 +332,13 @@ const Combobox = ({
           label={label}
           value={inputValue}
           startIcon={icon}
-          endIcon={isOpen ? "chevron-up" : "chevron-down"}
+          endContent={
+            <span
+              className={`fontSize--l fontColor--primary narmi-icon-${
+                isOpen ? "chevron-up" : "chevron-down"
+              }`}
+            />
+          }
           {...getInputProps({
             onFocus: handleMenuOpen,
             onClick: handleMenuOpen,

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -296,7 +296,11 @@ const Combobox = ({
       // Reset filtered items every time user refocuses.
       // Subsequent changes in the input will re-filter the list.
       openMenu();
+      // If the user revisits the combobox after selecting an item,
+      // only show the selected item and clear the input. The list will
+      // be re-filtered as they type
       if (hasSelectedItem) {
+        setInputValue("");
         setDisplayedItems(items.filter(isSelectable));
       }
     }

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -91,9 +91,10 @@
   }
 
   .nds-category-icon {
+    font-size: 20px;
     position: absolute;
     right: var(--space-s);
     top: 50%;
-    transform: translateY(-50%);
+    transform: translate(-1px, -50%);
   }
 }

--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -48,13 +48,15 @@ const DropdownTrigger = React.forwardRef(
               {labelText}
             </label>
           )}
-          {displayValue && <span className="nds-dropdownTrigger-value">{displayValue}</span>}
+          {displayValue && (
+            <span className="nds-dropdownTrigger-value">{displayValue}</span>
+          )}
           {showOpenIndicator && (
             <span
               role="img"
               aria-label={isOpen ? "popup open" : "popup closed"}
               className={cc([
-                "nds-dropdownTrigger-chevron fontSize--l fontColor--secondary",
+                "nds-dropdownTrigger-chevron fontSize--l fontColor--primary",
                 `narmi-icon-chevron-${isOpen ? "up" : "down"}`,
               ])}
             />

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -46,15 +46,22 @@ const Input = ({
   ].join(" ");
 
   const endIconJsx = showClearButton ? (
-    <div
-      className={`nds-input-icon nds-input-close narmi-icon-x`}
+    <button
+      className={`button--reset nds-input-icon nds-input-close fontColor--primary`}
       onClick={clearInput}
-      role="button"
-      tabIndex="0"
+      onKeyUp={({ key }) => {
+        if (key === "Enter" || key === "Space") {
+          clearInput();
+        }
+      }}
       aria-label="Clear Input"
-    ></div>
+    >
+      <span className="narmi-icon-x" />
+    </button>
   ) : (
-    <div className={`nds-input-icon ${endIconClass}`}></div>
+    <div
+      className={`nds-input-icon nds-input-icon--faded ${endIconClass}`}
+    ></div>
   );
 
   return (
@@ -62,7 +69,9 @@ const Input = ({
       <div className="nds-input-box">
         {startContent && <div>{startContent}</div>}
         {startIconClass && (
-          <div className={`nds-input-icon ${startIconClass}`}></div>
+          <div
+            className={`nds-input-icon nds-input-icon--faded ${startIconClass}`}
+          ></div>
         )}
         <div
           className={`nds-input-column ${
@@ -88,6 +97,8 @@ Input.propTypes = {
   startIconClass: PropTypes.node,
   /** full `narmi-icon-<shape>` className for icon at end of input */
   endIconClass: PropTypes.node,
+  startContent: PropTypes.node,
+  endContent: PropTypes.node,
   showClearButton: PropTypes.bool,
   clearInput: PropTypes.func,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -21,8 +21,10 @@ By default, if neither `multiline` nor `icon` are provided, an overhanging label
 const Input = ({
   id,
   label,
+  startContent,
   startIconClass,
   endIconClass,
+  endContent,
   showClearButton,
   clearInput,
   disabled,
@@ -58,6 +60,7 @@ const Input = ({
   return (
     <div className={className} onClick={onClick} style={style}>
       <div className="nds-input-box">
+        {startContent && <div>{startContent}</div>}
         {startIconClass && (
           <div className={`nds-input-icon ${startIconClass}`}></div>
         )}
@@ -71,6 +74,7 @@ const Input = ({
           {!multiline ? <label htmlFor={id}>{label}</label> : ""}
         </div>
         {(endIconClass || showClearButton) && endIconJsx}
+        {endContent && <div>{endContent}</div>}
       </div>
       <Error error={error} />
     </div>

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -19,7 +19,7 @@
   font-size: 16px;
 
   .nds-input-box {
-    box-sizing: border-box;;
+    box-sizing: border-box;
     min-height: 48px;
     border: 1px solid var(--color-lightGrey);
     background: var(--color-white);
@@ -37,10 +37,6 @@
         color: var(--theme-primary);
         margin-bottom: -3px;
       }
-    }
-
-    .nds-input-close:hover {
-      cursor: pointer;
     }
   }
 
@@ -76,6 +72,9 @@
     display: flex;
     font-size: 1.25em;
     padding: 0 0.3em 0 0;
+  }
+
+  .nds-input-icon--faded {
     opacity: 0.5;
   }
 

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -70,9 +70,10 @@
   }
 
   .nds-category-icon {
+    font-size: 20px;
     position: absolute;
     right: var(--space-s);
     top: 50%;
-    transform: translateY(-50%);
+    transform: translate(1px, -50%);
   }
 }

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -14,6 +14,8 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
   const {
     startIcon,
     endIcon,
+    startContent,
+    endContent,
     showClearButton,
     formatter,
     multiline,
@@ -49,6 +51,8 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
   return (
     <Input
       {...props}
+      startContent={startContent}
+      endContent={endContent}
       startIconClass={startIcon ? `narmi-icon-${startIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
       showClearButton={showClearButton && inputValue}
@@ -110,6 +114,10 @@ TextInput.propTypes = {
   startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Name of Narmi icon to place at the end of the input box */
   endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** Accepts a JSX node to act as a custom `startIcon` */
+  startContent: PropTypes.node,
+  /** Accepts a JSX node to act as a custom `endIcon` */
+  endContent: PropTypes.node,
   /** Display an X at the end of label that clears input and calls onChange on click. Takes precedence over endIcon when input is not empty */
   showClearButton: PropTypes.bool,
   /** Text of error message to display under the input */

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -57,6 +57,12 @@ WithIcon.args = {
   startIcon: "search",
 };
 
+export const CustomStartAndEndContent = Template.bind({});
+CustomStartAndEndContent.args = {
+  label: "Search",
+  endContent: <button className="button--reset">clear</button>,
+};
+
 export const AsColorInput = () => {
   const [color, setColor] = useState("#915F6D");
   return (
@@ -103,20 +109,28 @@ export const DateTime = () => {
   const [dateTime, setDateTime] = useState(null);
   return (
     <>
-      <TextInput type="datetime-local" label="Start datetime" onChange={(e) => setDateTime(e.target.value)} />
-      <div className="margin--top--xxs" >Value: {dateTime}</div>
+      <TextInput
+        type="datetime-local"
+        label="Start datetime"
+        onChange={(e) => setDateTime(e.target.value)}
+      />
+      <div className="margin--top--xxs">Value: {dateTime}</div>
     </>
-  )
+  );
 };
 
 export const Time = () => {
   const [time, setTime] = useState(null);
   return (
     <>
-      <TextInput type="time" label="Start time" onChange={(e) => setTime(e.target.value)} />
-      <div className="margin--top--xxs" >Value: {time}</div>
+      <TextInput
+        type="time"
+        label="Start time"
+        onChange={(e) => setTime(e.target.value)}
+      />
+      <div className="margin--top--xxs">Value: {time}</div>
     </>
-  )
+  );
 };
 
 export default {


### PR DESCRIPTION
closes #1044 

After speaking with Hillary, we decided to try using a clear icon instead of auto-clearing the input on focus. The auto-clearing behavior had some technical issues and could lead to a bad UX for a user tabbing through the form (imagine tabbing back to correct an error and creating another error by mistake when focus moves through the Combobox)


## Changes

### TextInput and Input

- Add `startContent` and `endContent` for custom beginning and end icons/buttons in inputs
- Update the clear button and add an `onInputClear` callback

### DropdownTrigger, Select, and Combobox chevron icons

- Use `endContent` to create a darker chevron for dropdown indicators per design
- Update size and position of category summary chevrons to match

### Combobox

- Add clear icon that shows up when there is an input value. When the user clicks it, the downshift state is reset and the input is refocused for input.

## Screenshots
<img width="491" alt="Screenshot 2023-10-04 at 11 38 55 AM" src="https://github.com/narmi/design_system/assets/231252/e8ed0433-8f6a-4eb5-8349-19209a4afd2a">
<img width="396" alt="Screenshot 2023-10-04 at 11 33 57 AM" src="https://github.com/narmi/design_system/assets/231252/7d351db6-8215-414e-87f8-f50fd07b3e00">
<img width="1051" alt="Screenshot 2023-10-03 at 11 38 43 PM" src="https://github.com/narmi/design_system/assets/231252/13a33694-59aa-457f-a589-711d00b2cef4">
<img width="914" alt="Screenshot 2023-10-04 at 11 41 54 AM" src="https://github.com/narmi/design_system/assets/231252/6701640d-3a7a-42c6-ad7a-d55842adaa92">

![Oct-04-2023 16-29-23](https://github.com/narmi/design_system/assets/231252/615c8243-a7e7-4046-8d03-d32b67174813)

