### PR TITLE
feat(TextInput): add startContent and endContent props for custom icons

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -352,7 +352,13 @@ const Combobox = ({
           label={label}
           value={inputValue}
           startIcon={icon}
-          endIcon={isOpen ? "chevron-up" : "chevron-down"}
+          endContent={
+            <span
+              className={`fontSize--l fontColor--primary narmi-icon-${
+                isOpen ? "chevron-up" : "chevron-down"
+              }`}
+            />
+          }
           {...getInputProps({
             onFocus: () => {
               if (hasSelectedItem) {

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -91,9 +91,10 @@
   }
 
   .nds-category-icon {
+    font-size: 20px;
     position: absolute;
     right: var(--space-s);
     top: 50%;
-    transform: translateY(-50%);
+    transform: translate(1px, -50%);
   }
 }

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -23,6 +23,8 @@ const Input = ({
   label,
   startIconClass,
   endIconClass,
+  startContent,
+  endContent,
   showClearButton,
   clearInput,
   disabled,
@@ -52,14 +54,19 @@ const Input = ({
       aria-label="Clear Input"
     ></div>
   ) : (
-    <div className={`nds-input-icon ${endIconClass}`}></div>
+    <div
+      className={`nds-input-icon nds-input-icon--faded ${endIconClass}`}
+    ></div>
   );
 
   return (
     <div className={className} onClick={onClick} style={style}>
       <div className="nds-input-box">
+        {startContent && <div>startContent</div>}
         {startIconClass && (
-          <div className={`nds-input-icon ${startIconClass}`}></div>
+          <div
+            className={`nds-input-icon nds-input-icon--faded ${startIconClass}`}
+          ></div>
         )}
         <div
           className={`nds-input-column ${
@@ -71,6 +78,7 @@ const Input = ({
           {!multiline ? <label htmlFor={id}>{label}</label> : ""}
         </div>
         {(endIconClass || showClearButton) && endIconJsx}
+        {endContent && <div>{endContent}</div>}
       </div>
       <Error error={error} />
     </div>
@@ -81,9 +89,13 @@ Input.propTypes = {
   id: PropTypes.string,
   label: PropTypes.string,
   /** full `narmi-icon-<shape>` className for icon at start of input */
-  startIconClass: PropTypes.node,
+  startIconClass: PropTypes.string,
   /** full `narmi-icon-<shape>` className for icon at end of input */
-  endIconClass: PropTypes.node,
+  endIconClass: PropTypes.string,
+  /** arbitrary JSX to place at the start of the input */
+  startContent: PropTypes.node,
+  /** arbitrary JSX to place at the end of the input */
+  endContent: PropTypes.node,
   showClearButton: PropTypes.bool,
   clearInput: PropTypes.func,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -76,7 +76,6 @@
     display: flex;
     font-size: 1.25em;
     padding: 0 0.3em 0 0;
-    opacity: 0.5;
   }
 
   label {
@@ -189,4 +188,8 @@ textarea::autofill {
     grid-column: 1 / 2;
     grid-row: 1 / 2;
   }
+}
+
+.nds-input-icon--faded {
+  opacity: 0.5;
 }

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -70,9 +70,10 @@
   }
 
   .nds-category-icon {
+    font-size: 20px;
     position: absolute;
     right: var(--space-s);
     top: 50%;
-    transform: translateY(-50%);
+    transform: translate(1px, -50%);
   }
 }

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -14,6 +14,8 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
   const {
     startIcon,
     endIcon,
+    startContent,
+    endContent,
     showClearButton,
     formatter,
     multiline,
@@ -51,6 +53,8 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
       {...props}
       startIconClass={startIcon ? `narmi-icon-${startIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
+      startContent={startContent}
+      endContent={endContent}
       showClearButton={showClearButton && inputValue}
       clearInput={_onClearInput}
     >
@@ -110,6 +114,10 @@ TextInput.propTypes = {
   startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Name of Narmi icon to place at the end of the input box */
   endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** JSX content slot at input start for custom buttons and icons  */
+  startContent: PropTypes.node,
+  /** JSX content slot at input end for custom buttons and icons  */
+  endContent: PropTypes.node,
   /** Display an X at the end of label that clears input and calls onChange on click. Takes precedence over endIcon when input is not empty */
   showClearButton: PropTypes.bool,
   /** Text of error message to display under the input */

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -57,6 +57,16 @@ WithIcon.args = {
   startIcon: "search",
 };
 
+export const CustomStartAndEndContent = Template.bind({});
+CustomStartAndEndContent.args = {
+  label: "Search",
+  endContent: (
+    <button className="button--reset">
+      <i className="narmi-icon-info" />
+    </button>
+  ),
+};
+
 export const AsColorInput = () => {
   const [color, setColor] = useState("#915F6D");
   return (
@@ -103,20 +113,28 @@ export const DateTime = () => {
   const [dateTime, setDateTime] = useState(null);
   return (
     <>
-      <TextInput type="datetime-local" label="Start datetime" onChange={(e) => setDateTime(e.target.value)} />
-      <div className="margin--top--xxs" >Value: {dateTime}</div>
+      <TextInput
+        type="datetime-local"
+        label="Start datetime"
+        onChange={(e) => setDateTime(e.target.value)}
+      />
+      <div className="margin--top--xxs">Value: {dateTime}</div>
     </>
-  )
+  );
 };
 
 export const Time = () => {
   const [time, setTime] = useState(null);
   return (
     <>
-      <TextInput type="time" label="Start time" onChange={(e) => setTime(e.target.value)} />
-      <div className="margin--top--xxs" >Value: {time}</div>
+      <TextInput
+        type="time"
+        label="Start time"
+        onChange={(e) => setTime(e.target.value)}
+      />
+      <div className="margin--top--xxs">Value: {time}</div>
     </>
-  )
+  );
 };
 
 export default {


### PR DESCRIPTION
closes #1044 

- Adds `startContent` and `endContent` to `TextInput`
- Add story for start and end content props in `TextInput`
- Update category chevron styling in `Select` and `Combobox`
- Update `Combobox` to use `endContent` to render a darker chevron

<img width="372" alt="Screenshot 2023-10-10 at 3 59 37 PM" src="https://github.com/narmi/design_system/assets/231252/fa750ed6-b0cc-4217-afd7-bdbd973174a2">
<img width="706" alt="Screenshot 2023-10-10 at 4 00 03 PM" src="https://github.com/narmi/design_system/assets/231252/40e4343f-1f16-42e8-ad13-e7bdc9f0b170">
