### PR TITLE
feat(Dialog): add `banner` header style

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -42,6 +42,7 @@ const Dialog = ({
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
   const shimRef = useRef(null);
+  const isBanner = headerStyle === "banner";
   useLockBodyScroll(isOpen);
 
   // `rafSchd` uses `requestAnimationFrame` to schedule the state update
@@ -72,6 +73,20 @@ const Dialog = ({
     }
   };
 
+  const closeButtonJSX = (
+    <button
+      className={cc([
+        "resetButton",
+        "nds-dialog-closeButton",
+        { "nds-dialog-closeButton--banner": isBanner },
+      ])}
+      aria-label="close"
+      onClick={onUserDismiss}
+    >
+      <span className="narmi-icon-x"></span>
+    </button>
+  );
+
   // the shim has events for mouse users only; does not require a role
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
@@ -89,14 +104,23 @@ const Dialog = ({
             <div
               className={`nds-dialog-header nds-dialog-header--${headerStyle}`}
             >
-              <h4 id="aria-dialog-label">{title}</h4>
-              <button
-                className="resetButton nds-dialog-closeButton"
-                aria-label="close"
-                onClick={onUserDismiss}
-              >
-                <span className="narmi-icon-x"></span>
-              </button>
+              {isBanner ? (
+                <div className="margin--y--s">
+                  <div
+                    className="padding--y--xxs"
+                    id="aria-dialog-label"
+                    style={{ textAlign: "center" }}
+                  >
+                    {title}
+                  </div>
+                  {closeButtonJSX}
+                </div>
+              ) : (
+                <>
+                  <h4 id="aria-dialog-label">{title}</h4>
+                  {closeButtonJSX}
+                </>
+              )}
             </div>
             <div
               ref={contentRef}
@@ -137,7 +161,7 @@ Dialog.propTypes = {
   /** Contents of Dialog footer, typically reserved for action buttons */
   footer: PropTypes.node,
   /** Visual style for Dialog header */
-  headerStyle: PropTypes.oneOf(["bordered", "plain"]),
+  headerStyle: PropTypes.oneOf(["bordered", "plain", "banner"]),
   /** Controls open/close state of the modal. Use the `onUserDismiss` callback to update. */
   isOpen: PropTypes.bool,
   /**

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -77,12 +77,26 @@
   border-bottom: var(--border-size-m) solid var(--theme-primary);
 }
 
+.nds-dialog-header--banner {
+  background-color: var(--theme-primary);
+  color: white;
+  margin: 0 0;
+  padding: 0 var(--space-s) 0 var(--space-s);
+  @include atMediaUp("s") {
+    border-radius: var(--border-radius-m) var(--border-radius-m) 0 0;
+  }
+}
+
 .nds-dialog-closeButton {
   position: absolute;
   font-size: var(--font-size-l) !important;
   color: var(--font-color-primary);
   right: var(--space-m);
   top: var(--space-m);
+}
+
+.nds-dialog-closeButton--banner {
+  color: white !important;
 }
 
 .nds-dialog-header,

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -70,6 +70,45 @@ UsingWithState.parameters = {
     },
   },
 };
+export const BannerType = InteractiveTemplate.bind({});
+BannerType.args = {
+  title:
+    "This shows how the `title` will look like for the banner header style",
+  headerStyle: "banner",
+  width: "800px",
+  children: (
+    <>
+      <h4 className="margin--top--l">Lorem ipsum</h4>
+      <p>
+        Lorem ipsum dolor sit amet. Ea fugiat dolore quo possimus adipisci est
+        ipsum libero ab dolores minima ut facere rerum? Aut vitae sint ut nemo
+        nisi ut tempore voluptas. Eum adipisci quasi eum praesentium libero est
+        quidem consequatur At voluptatum debitis et laborum ducimus aut eaque
+        eligendi.
+      </p>
+      <p>
+        Ut alias eligendi ut dolorem eius rem consectetur ullam et natus nihil.
+        Et maiores dolores hic nesciunt quibusdam ut laboriosam earum qui quas
+        sapiente in molestiae accusantium.
+      </p>
+      <p>
+        Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+        eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+        voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt qui
+        sequi placeat. Non voluptatem molestiae et explicabo voluptas ut facilis
+        quia?
+      </p>
+    </>
+  ),
+};
+BannerType.parameters = {
+  docs: {
+    description: {
+      story:
+        "Works the same way as above, but its title is a banner instead. Note that the width might need to be set to be larger than the default depending on the length of title.",
+    },
+  },
+};
 
 export const ScrollingContent = InteractiveTemplate.bind({});
 ScrollingContent.args = {


### PR DESCRIPTION
Adds banner as a header style, which looks like this:

![image](https://github.com/narmi/design_system/assets/40327446/b109296d-a15f-4751-a94d-cb151df229f0)

https://github.com/narmi/design_system/assets/40327446/0a5dd878-2c5f-4a22-8509-4cf152b31335

For now, the color for text and the `x` icon is hardcoded to white, following the logic on Button.
