### PR TITLE
fix(Tag): prevent label overflow

### DIFF
--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
-import Row from "../Row";
 
 const noop = () => {};
 
@@ -20,24 +19,20 @@ const Tag = ({
       className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}
       data-testid={testId}
     >
-      <Row alignItems="center" gapSize="xxs">
-        <Row.Item shrink>{label}</Row.Item>
-        {kind === "dismissible" && (
-          <Row.Item shrink>
-            <span
-              className="narmi-icon-x"
-              role="button"
-              tabIndex={0}
-              onClick={onDismiss}
-              onKeyUp={({ key }) => {
-                if (key === "Enter" || key == " ") {
-                  onDismiss();
-                }
-              }}
-            />
-          </Row.Item>
-        )}
-      </Row>
+      <div className="whiteSpace--truncate">{label}</div>
+      {kind === "dismissible" && (
+        <div
+          className="narmi-icon-x margin--left--xs"
+          role="button"
+          tabIndex={0}
+          onClick={onDismiss}
+          onKeyUp={({ key }) => {
+            if (key === "Enter" || key == " ") {
+              onDismiss();
+            }
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/Tag/index.scss
+++ b/src/Tag/index.scss
@@ -2,9 +2,11 @@
   padding: 0 var(--space-s);
   border-radius: 16px;
   display: inline-flex;
+  justify-content: flex-start;
   align-items: center;
   font-size: var(--font-size-xs);
   height: 23px;
+  max-width: 100%;
   .narmi-icon-x {
     cursor: pointer;
     display: inline-block;


### PR DESCRIPTION
Fixes issue where label text could overflow the Tag.

Now the tag will grow as large as the parent container allows, and truncate the label text with ellipsis after that.

<img width="912" alt="Screenshot 2023-10-25 at 5 12 09 PM" src="https://github.com/narmi/design_system/assets/231252/33c35a99-695d-493d-b40b-de923ead59b8">
