### PR TITLE
fix(row): set min-width on Row.Item

### DIFF
--- a/src/Row/index.scss
+++ b/src/Row/index.scss
@@ -13,6 +13,7 @@
   width: auto;
   height: 100%;
   min-height: 0;
+  min-width: 0;
 
   // The shrink variant shrink wraps the row item to content width
   &--shrink {


### PR DESCRIPTION
This allows content to overflow if it sets `overflow` and has no effect if the content has an intrinsic width (most other cases).

For https://github.com/narmi/banking/issues/38767

![image](https://github.com/narmi/design_system/assets/511342/19086ed7-3b55-4a3b-a5d4-b9ea8ef7b980)
