### PR TITLE
fix(MenuButton): use hover effect on icon trigger when menu is open

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -37,7 +37,10 @@ const MenuButton = ({
             className={cc([
               "nds-menubutton-trigger",
               "button--reset",
-              { "nds-menubutton-trigger--useHoverEffect": !trigger },
+              {
+                "nds-menubutton-trigger--useCssHover": !trigger,
+                "nds-menubutton-trigger--hovered": !trigger && isExpanded,
+              },
             ])}
           >
             <Row gapSize="xxs">

--- a/src/MenuButton/index.scss
+++ b/src/MenuButton/index.scss
@@ -1,15 +1,24 @@
+%trigger-hover {
+  color: var(--theme-primary);
+  background-color: rgba(var(--theme-rgb-primary), var(--alpha-5));
+  text-decoration: none;
+}
+
 .nds-menubutton-trigger {
   color: var(--font-color-secondary);
   border-radius: var(--border-radius-s);
 
-  &--useHoverEffect {
+  &--useCssHover {
     &:focus button,
     &:hover,
     &:active {
-      color: var(--theme-primary);
-      background-color: rgba(var(--theme-rgb-primary), var(--alpha-5));
-      text-decoration: none;
+      @extend %trigger-hover;
     }
+  }
+
+  // forces hover effect when menu is open
+  &--hovered {
+    @extend %trigger-hover;
   }
 }
 
@@ -27,7 +36,7 @@
 [data-reach-menu-popover] {
   display: block;
   position: absolute;
-  z-index: 2;
+  z-index: 3;
 }
 
 [data-reach-menu-popover][hidden] {


### PR DESCRIPTION
closes #1078

Show hover effect on icon trigger when the menu in `MenuButton` is open.
This does not apply to cases where a custom `trigger` is passed in, which is okay because we have the option to show the standard up/down chevron dropdown indicator in custom triggers.

<img width="189" alt="Screenshot 2023-11-13 at 12 01 40 PM" src="https://github.com/narmi/design_system/assets/231252/fb366c4a-7fd6-4b53-95ba-279218d5899e">
