### PR TITLE
feat(Alert): add Alert component

### DIFF
--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+import Row from "../Row";
+
+const noop = () => {};
+
+/**
+ * Inline system message, for a sepcific region of a page.
+ * The `isActive` prop is used to hide and show the Alert to ensure the Alert
+ * is always rendered in an [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
+ * for accessibility.
+ */
+const Alert = ({
+  isActive = false,
+  isDismissable = true,
+  onUserDismiss = noop,
+  kind = "info",
+  children,
+}) => {
+  const iconName = kind === "success" ? "check" : "info";
+
+  return (
+    <div aria-live="polite">
+      {isActive && (
+        <div
+          className={cc([
+            "nds-alert",
+            `nds-alert--${kind}`,
+            "rounded--all",
+            "padding--all",
+          ])}
+        >
+          <Row gapSize="s">
+            <Row.Item shrink>
+              <span className={`nds-alert-icon narmi-icon-${iconName}`} />
+            </Row.Item>
+            <Row.Item>{children}</Row.Item>
+            {isDismissable && (
+              <Row.Item shrink>
+                <button
+                  className="nds-alert-close resetButton"
+                  aria-label="close"
+                  onClick={onUserDismiss}
+                >
+                  <span className="narmi-icon-x"></span>
+                </button>
+              </Row.Item>
+            )}
+          </Row>
+        </div>
+      )}
+    </div>
+  );
+};
+
+Alert.propTypes = {
+  /** The alert is only visible when this prop is set to `true` */
+  isActive: PropTypes.bool,
+  /** Renders a dismiss button when `true` */
+  isDismissable: PropTypes.bool,
+  /** Callback for user dismissal actions */
+  onUserDismiss: PropTypes.func,
+  /** Variant of Alert to use */
+  kind: PropTypes.oneOf(["info", "error", "success"]),
+  /** Message content of the Alert */
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default Alert;

--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -1,0 +1,31 @@
+.nds-alert {
+  color: var(--font-color-primary);
+}
+
+.nds-alert-icon::before {
+  font-weight: bold;
+}
+
+.nds-alert--error {
+  background-color: var(--color-errorLight);
+
+  .nds-alert-icon::before {
+    color: var(--color-errorDark);
+  }
+}
+
+.nds-alert--info {
+  background-color: var(--color-warnLight);
+
+  .nds-alert-icon::before {
+    color: var(--color-warnDark);
+  }
+}
+
+.nds-alert--success {
+  background-color: var(--color-successLight);
+
+  .nds-alert-icon::before {
+    color: var(--color-successDark);
+  }
+}

--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -9,6 +9,12 @@
 .nds-alert--error {
   background-color: var(--color-errorLight);
 
+  // Rotating the info icon until we have a "!" icon
+  .nds-alert-icon {
+    display: inline-block;
+    transform: rotate(180deg);
+  }
+
   .nds-alert-icon::before {
     color: var(--color-errorDark);
   }

--- a/src/Alert/index.stories.js
+++ b/src/Alert/index.stories.js
@@ -50,6 +50,19 @@ ControllingVisibility.parameters = {
   },
 };
 
+export const WithoutDismiss = Template.bind({});
+WithoutDismiss.args = {
+  isActive: true,
+  kind: "error",
+  isDismissable: false,
+  children: (
+    <span>
+      The user can not dismiss this Alert when <code>isDismissable</code> is set
+      to <code>false</code>
+    </span>
+  ),
+};
+
 export default {
   title: "Components/Alert",
   component: Alert,

--- a/src/Alert/index.stories.js
+++ b/src/Alert/index.stories.js
@@ -1,0 +1,56 @@
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
+import React, { useState } from "react";
+import Alert from "./";
+
+const Template = (args) => <Alert {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  isActive: true,
+  children: (
+    <span>
+      I like turtles. Turtles are good. I like turtles. Turtles are good.
+    </span>
+  ),
+};
+
+export const ControllingVisibility = () => {
+  const [isActive, setIsActive] = useState(true);
+  return (
+    <>
+      <div className="margin--bottom">
+        <Alert
+          kind="success"
+          isActive={isActive}
+          onUserDismiss={() => {
+            setIsActive(false);
+          }}
+        >
+          You can dismiss this alert!
+        </Alert>
+      </div>
+      {!isActive && (
+        <button
+          onClick={() => {
+            setIsActive(true);
+          }}
+        >
+          Show alert again
+        </button>
+      )}
+    </>
+  );
+};
+ControllingVisibility.parameters = {
+  docs: {
+    description: {
+      story:
+        "Visibility of an alert should be controlled by the `isActive` prop instead of conditional rendering. This enables every `Alert` to be announced when it becomes active via an `aria-live` region.",
+    },
+  },
+};
+
+export default {
+  title: "Components/Alert",
+  component: Alert,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 require("./index.scss");
 
+import Alert from "./Alert";
 import Button from "./Button";
 import Checkbox from "./Checkbox";
 import ContentCard from "./ContentCard";
@@ -37,6 +38,7 @@ import formatNumber from "./formatters/formatNumber";
 import formatDate from "./formatters/formatDate";
 
 export {
+  Alert,
   Button,
   Checkbox,
   ContentCard,

--- a/src/index.scss
+++ b/src/index.scss
@@ -47,6 +47,7 @@
 @import "helper-classes/lists";
 
 // Components
+@import "Alert/";
 @import "RadioButtons/";
 @import "Input/";
 @import "DateInput/";


### PR DESCRIPTION
closes #1082 

Adds `Alert` component for rendering system messages within document flow. Has an `aria-live` region built in.

<img width="1046" alt="Screenshot 2023-11-13 at 6 28 59 PM" src="https://github.com/narmi/design_system/assets/231252/79b26713-1922-4684-bdf3-394e4f68405f">
