### PR TITLE
fix(MenuButton): set default z-index for reach-ui portals

### DIFF
--- a/src/MenuButton/index.scss
+++ b/src/MenuButton/index.scss
@@ -36,7 +36,6 @@
 [data-reach-menu-popover] {
   display: block;
   position: absolute;
-  z-index: 3;
 }
 
 [data-reach-menu-popover][hidden] {

--- a/src/base-styles/reach-ui.scss
+++ b/src/base-styles/reach-ui.scss
@@ -1,0 +1,3 @@
+reach-portal * {
+  z-index: 4;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -35,6 +35,7 @@
 @import "base-styles/defaults";
 @import "base-styles/typography";
 @import "base-styles/grid";
+@import "base-styles/reach-ui"; // Reach-UI lib base styles
 
 // Helper classes
 @import "helper-classes/position";


### PR DESCRIPTION
fixes #1080


Components that use the ReachUI library for accessibility uses [their custom Portal component](https://reach.tech/portal) when portalling is needed. The ReachUI `Portal` component creates a custom element, `<reach-portal>` and appends it to `document.body`.

The problem is that the `reach-portal` is a different stacking context than `document.body`, where all other portalled elements in NDS are appended to.

This PR creates a global rule that sets the `reach-portal` to a z-index value that is high enough to resolve above the `document.body` stacking context.

In the future, we may want to consider refactoring all components to write to the `<reach-portal>` element instead by using the Reach `<Portal>` component.

<img width="527" alt="Screenshot 2023-11-16 at 4 03 36 PM" src="https://github.com/narmi/design_system/assets/231252/7d32dc76-9e38-421a-9caa-548d4260d527">


