### PR TITLE
fix(Checkbox): fix top alignment for multiline labels

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -35,12 +35,12 @@ const Checkbox = ({
         {children}
       </a>
     );
-  }
+  };
 
   LinkRenderer.propTypes = {
     href: PropTypes.string.isRequired,
     children: PropTypes.array.isRequired,
-  }
+  };
 
   useEffect(() => {
     if (isControlled) {
@@ -64,7 +64,7 @@ const Checkbox = ({
   };
 
   return (
-    <div className="nds-checkbox-container">
+    <div className={`nds-checkbox-container nds-checkbox-container--${kind}`}>
       <label
         className={cc([
           `nds-checkbox nds-checkbox--${kind}`,
@@ -72,20 +72,19 @@ const Checkbox = ({
           {
             "nds-checkbox--checked": isChecked,
             "nds-checkbox--focused": isFocused,
-            "padding--all rounded--all border--all": isCard,
+            "padding--y--xl padding--x rounded--all border--all": isCard,
           },
         ])}
       >
-        {markdownLabel &&
-          <ReactMarkdown components={{ a: LinkRenderer }}>
-            {markdownLabel}
-          </ReactMarkdown>
-        }
-        {!markdownLabel &&
-          <p>
-            {label}
-          </p>
-        }
+        <span className={cc(["narmi-icon-check", { error: !!error }])}></span>
+        <div className="nds-checkbox-label">
+          {markdownLabel && (
+            <ReactMarkdown components={{ a: LinkRenderer }}>
+              {markdownLabel}
+            </ReactMarkdown>
+          )}
+          {!markdownLabel && <>{label}</>}
+        </div>
         <input
           onFocus={handleFocus}
           onBlur={handleBlur}
@@ -100,12 +99,6 @@ const Checkbox = ({
           type="checkbox"
           aria-label={label}
         />
-        <span
-          className={cc([
-            "narmi-icon-check",
-            { "error": !!error },
-          ])}
-        ></span>
       </label>
       <Error marginTop="xs" error={error} />
     </div>

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -4,6 +4,11 @@
   padding-top: var(--space-s);
 }
 
+// normal checkboxes git a bit of extra spacing
+.nds-checkbox-container--normal ~ .nds-checkbox-container--normal {
+  margin-top: var(--space-default);
+}
+
 .nds-checkbox {
   cursor: pointer;
   font-size: var(--font-size-default);
@@ -28,14 +33,18 @@
   display: flex;
   width: fit-content;
   position: relative;
-  align-items: center;
-  padding-left: 28px;
+  align-items: flex-start;
+  gap: var(--space-s);
 
   .narmi-icon-check {
-    position: absolute;
-    left: 0;
     height: 18px;
     width: 18px;
+
+    // - prevent this flex item from shrinking to checkmark width
+    // - visually align checkbox icon baseline with label baseline
+    flex-shrink: 0;
+    transform: translateY(1px);
+
     background-color: white;
     font-weight: bold;
     border-radius: 3px;
@@ -79,11 +88,16 @@
 .nds-checkbox--card {
   position: relative;
   display: flex;
+  flex-direction: row-reverse; // check should render on the right side
   align-items: center;
   justify-content: space-between;
   background-color: var(--color-white);
   color: var(--color-primary);
   font-weight: var(--font-weight-bold) !important;
+
+  .nds-checkbox-label {
+    flex-grow: 1;
+  }
 
   .narmi-icon-check {
     display: none;
@@ -101,7 +115,6 @@
 
   &.nds-checkbox--checked {
     .narmi-icon-check {
-      margin-left: var(--space-default);
       display: inline-flex;
       align-items: center;
       justify-content: center;

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -9,6 +9,13 @@
   margin-top: var(--space-default);
 }
 
+// reset paragraph spacing in markdown labels
+.nds-checkbox-label p {
+  margin: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
+}
+
 .nds-checkbox {
   cursor: pointer;
   font-size: var(--font-size-default);
@@ -97,9 +104,6 @@
 
   .nds-checkbox-label {
     flex-grow: 1;
-    p {
-      margin: 0;
-    }
   }
 
   .narmi-icon-check {

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -97,6 +97,9 @@
 
   .nds-checkbox-label {
     flex-grow: 1;
+    p {
+      margin: 0;
+    }
   }
 
   .narmi-icon-check {


### PR DESCRIPTION
closes #895 

- Move spacing responsibility from `p` tag to stable containers (it wasn't working when a `markdownLabel` was passed anyway)
- Use document flow positioning for the checkbox check that gets rendered instead of absolute positioning
- Align the checkbox to the top and line up the check icon baseline with the text baseline