### PR TITLE
fix(Dialog): prevent mobile chrome from overlapping dialog footer

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -46,7 +46,8 @@
 
   // the modal dialog takes over the whole screen by default
   // (small veiwports)
-  height: 100vh;
+  height: 100vh; // fall back to 100vh for older mobile browsers
+  height: 100dvh; // prevents toolbar overlap in modern mobile browsers
   width: 100vw;
 
   // for tablet or larger, display the modal dialog as a floating box.


### PR DESCRIPTION
closes #1087 

CSS vocab:
```scss
property: value; // the pair is a "rule"
```

When a CSS ruleset has two different rules with the same property name, it will use the cascade (source order) to resolve the conflict. Browsers ignore rules that have properties or values they don't understand, so older browsers will just fall back to `100vh` in this case.