### PR TITLE
feat(numberFormat): add option to not show cents on currency

### DIFF
--- a/src/formatters/formatNumber.js
+++ b/src/formatters/formatNumber.js
@@ -15,7 +15,7 @@
  * @param {String} style format style (`currency` or `percent`)
  * @returns {String} number string formatted for display
  */
-const formatNumber = (input, style = "currency", signDisplay="auto") => {
+const formatNumber = (input, style = "currency", signDisplay = "auto", showCents = true) => {
   let number = parseFloat(input, 10);
   let formatterOpts = {
     style,
@@ -43,8 +43,8 @@ const formatNumber = (input, style = "currency", signDisplay="auto") => {
 
   if (style === "currency") {
     formatterOpts.currency = "USD";
-    formatterOpts.minimumFractionDigits = 2;
-    formatterOpts.maximumFractionDigits = 2;
+    formatterOpts.minimumFractionDigits = showCents ? 2 : 0;
+    formatterOpts.maximumFractionDigits = showCents ? 2 : 0;
   } else if (style === "percent") {
     formatterOpts.maximumFractionDigits = Number.isInteger(number) ? 0 : 2;
   }

--- a/src/formatters/formatNumber.test.js
+++ b/src/formatters/formatNumber.test.js
@@ -70,6 +70,21 @@ describe("formatNumber", () => {
       const expected = "$0.00";
       expect(actual).toEqual(expected);
     });
+    it("optionally hides cents for integer number", () => {
+      const actual = formatNumber(12, style, "auto", false);
+      const expected = "$12";
+      expect(actual).toEqual(expected);
+    });
+    it("optionally hides cents for float number, rounding up", () => {
+      const actual = formatNumber(12.5, style, "auto", false);
+      const expected = "$13";
+      expect(actual).toEqual(expected);
+    });
+    it("optionally hides cents for float number, rounding down", () => {
+      const actual = formatNumber(12.4, style, "auto", false);
+      const expected = "$12";
+      expect(actual).toEqual(expected);
+    });
   });
 
   describe("percent", () => {


### PR DESCRIPTION
Some designs call for not showing cents on currency (such as when displaying limits), so it would be useful to have this option in the NDS `numberFormat` method. 

Unfortunately, adding this means if I want to set the `showCents` option, I have to specify the `signDisplay`, even if I just want to use the default. Potential options include:

- allow for falsey value for `signDisplay`, which would mean use the default 
- refactor the optional params in this function to be a single param of object type