### PR TITLE
fix(TextInput): Fix start content property for text input

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -62,7 +62,7 @@ const Input = ({
   return (
     <div className={className} onClick={onClick} style={style}>
       <div className="nds-input-box">
-        {startContent && <div>startContent</div>}
+        {startContent && <div>{startContent}</div>}
         {startIconClass && (
           <div
             className={`nds-input-icon nds-input-icon--faded ${startIconClass}`}


### PR DESCRIPTION
Currently the `startContent` property for text inputs is not rendering correctly because the variable not wrapped in `{}` 
![image](https://github.com/narmi/design_system/assets/32401210/a9abd2b0-f958-4a8f-bbe9-76190544ed35)
Returning:
```
<div>startContent</div>
```
