### PR TITLE
feat(Dialog): add notification content slot

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -35,6 +35,7 @@ const Dialog = ({
   title,
   headerStyle = "bordered",
   children,
+  notification,
   footer,
   width = "500px",
   testId,
@@ -122,6 +123,11 @@ const Dialog = ({
                 </>
               )}
             </div>
+            {notification && (
+              <div className="nds-dialog-notification padding--y padding--x--xl">
+                {notification}
+              </div>
+            )}
             <div
               ref={contentRef}
               className={cc([
@@ -158,6 +164,8 @@ Dialog.propTypes = {
   children: PropTypes.node.isRequired,
   /** Heading in the top of the Dialog */
   title: PropTypes.string.isRequired,
+  /** Optional notification content to render pinned under the header */
+  notification: PropTypes.node,
   /** Contents of Dialog footer, typically reserved for action buttons */
   footer: PropTypes.node,
   /** Visual style for Dialog header */

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -101,7 +101,8 @@
 }
 
 .nds-dialog-header,
-.nds-dialog-footer {
+.nds-dialog-footer,
+.nds-dialog-notification {
   flex-basis: auto;
   flex-grow: 0;
   height: initial;

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Dialog from "./";
 import Button from "../Button";
 import Popover from "../Popover";
+import Alert from "../Alert";
 
 const BaseTemplate = (args) => <Dialog {...args} />;
 
@@ -173,11 +174,6 @@ FocusManagement.parameters = {
   },
 };
 
-export default {
-  title: "Components/Dialog",
-  component: Dialog,
-};
-
 export const PopoverDialog = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   return (
@@ -236,4 +232,20 @@ export const PopoverDialog = () => {
       </Dialog>
     </>
   );
+};
+
+export const WithNotification = InteractiveTemplate.bind({});
+WithNotification.args = {
+  title: "Dialog controlled by external state",
+  children: <div>Dialog content</div>,
+  notification: (
+    <Alert kind="error" isActive={true}>
+      This alert is pinned to the top of the dialog
+    </Alert>
+  ),
+};
+
+export default {
+  title: "Components/Dialog",
+  component: Dialog,
 };


### PR DESCRIPTION
closes #1098 

Adds a pinned content zone to Dialog near the header that can accept an `Alert` or any other JSX content