### PR TITLE
feat(typography): use real weight and italics instead of faux bolding…

### DIFF
--- a/src/base-styles/defaults.scss
+++ b/src/base-styles/defaults.scss
@@ -15,6 +15,7 @@ body {
   max-width: unset;
   background-color: var(--color-white);
   text-decoration-skip-ink: none;
+  font-synthesis: none; /* Prevent browser from using faux italics */
 }
 
 h1,

--- a/src/fonts/fonts.css
+++ b/src/fonts/fonts.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Mulish:wght@200..700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,200;0,400;0,600;0,700;1,200;1,400;1,600;1,700&display=swap");
 
 @font-face {
   font-family: "Narmi Matiere";


### PR DESCRIPTION
closes https://github.com/narmi/banking/issues/40039

We have been using faux italics in body type. This PR ensures the italic font variation setting from the variable font is enabled, and uses the `font-synthesis` property to prevent faux bolding and faux slanting.

lovely italic glyphs as the type designer intended (good):
<img width="679" alt="Screenshot 2024-01-17 at 7 00 16 PM" src="https://github.com/narmi/design_system/assets/231252/d18f22e4-c53d-44f7-82c9-a7ee501bd7b5">

the browser just applying a slant transform (bad):
<img width="680" alt="Screenshot 2024-01-17 at 7 00 22 PM" src="https://github.com/narmi/design_system/assets/231252/b423d5f1-6244-438e-af23-f6f3692aac59">
