### PR TITLE
fix(MenuButton): prevent popover from closing before selection callback

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -72,12 +72,22 @@ const MenuButton = ({
       (item) => labelToItemId(item.props.label) === itemId
     );
     selectedItem.props.onSelect();
+    closePopover();
   };
 
   return (
     <MenuTrigger
       isOpen={isOpen}
-      onOpenChange={setIsOpen}
+      onOpenChange={(o) => {
+        /**
+         * We only need to use MenuTrigger to manage when
+         * the popover opens. Closing the popover is managed
+         * by `useLayer`
+         */
+        if (o) {
+          setIsOpen(true);
+        }
+      }}
       data-testid={testId}
       className="nds-menubutton"
     >


### PR DESCRIPTION
Fixes this issue reported by @JohnathanWeisner 


![edit-wire-recipient-not-opening (1)](https://github.com/narmi/design_system/assets/231252/613d5d31-3512-494c-b3fc-db4652873af0)
