### PR TITLE
docs(TextInput): add example of hide/show password

### DIFF
--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import TextInput, { VALID_ICON_NAMES } from "./";
+import Button from "../Button";
 
 const Template = (args) => <TextInput {...args} />;
 
@@ -133,6 +134,27 @@ export const Time = () => {
         onChange={(e) => setTime(e.target.value)}
       />
       <div className="margin--top--xxs">Value: {time}</div>
+    </>
+  );
+};
+
+export const PasswordShowHide = () => {
+  const [showInputVal, setShowInputVal] = useState(false);
+  return (
+    <>
+      <TextInput
+        type={showInputVal ? "text" : "password"}
+        label="Password"
+        endContent={
+          <Button
+            kind="plain"
+            label={showInputVal ? "Hide" : "Show"}
+            onClick={() => {
+              setShowInputVal((curr) => !curr);
+            }}
+          />
+        }
+      />
     </>
   );
 };


### PR DESCRIPTION
closes #824 

Adds storybook story to show how to build a password input with show/hide feature

<img width="330" alt="Screenshot 2024-01-18 at 5 41 43 PM" src="https://github.com/narmi/design_system/assets/231252/36c66797-1d5e-42ee-86c5-460bb4b7e9ab">
<img width="336" alt="Screenshot 2024-01-18 at 5 41 50 PM" src="https://github.com/narmi/design_system/assets/231252/5cb3debf-9d7e-49c2-b9bd-808dac348755">
