### PR TITLE
feat(helper-classes): add rotation helpers

### DIFF
--- a/src/helper-classes/position.scss
+++ b/src/helper-classes/position.scss
@@ -25,3 +25,16 @@ $yAlign: (
     }
   }
 }
+
+/**
+* Rotation
+* `rotate--<degrees>`
+*/
+$degrees: (45, 90, 180, 225, 270, 315);
+
+@each $deg in $degrees {
+  .rotate--#{$deg} {
+    transform: rotate(#{$deg}deg);
+    transform-origin: center;
+  }
+}

--- a/src/helper-classes/position.stories.mdx
+++ b/src/helper-classes/position.stories.mdx
@@ -1,5 +1,5 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs";
-import { alignChild } from "dist/docs/classManifest";
+import { Meta, Story } from "@storybook/addon-docs";
+import { alignChild, rotate } from "dist/docs/classManifest";
 import ClassExample from "helpers/ClassExample";
 
 <Meta title="Style/Helper Classes/Position" />
@@ -18,6 +18,31 @@ Aligns children of element using flexbox. Useful for quick center alignment.
       style={{ width: "120px", height: "120px", outline: "1px solid hotpink" }}
     >
       <div className="bgColor--cactus fontColor--white">Child</div>
+    </div>
+  </ClassExample>
+</Story>
+
+# Rotation
+
+<Story name="Rotation">
+  <ClassExample
+    signature="rotate--<degrees number>"
+    classCategory={rotate}
+    hideBorder
+  >
+    <div
+      className="bgColor--moss"
+      style={{
+        width: "60px",
+        height: "60px",
+        textAlign: "center",
+        verticalAlign: "bottom",
+        justifyContent: "center",
+        alignItems: "center",
+        display: "flex",
+      }}
+    >
+      <span className="fontColor--white fontSize--heading0">旋</span>
     </div>
   </ClassExample>
 </Story>


### PR DESCRIPTION
Adds rotation helper classes you can use on any element. Built for rotating icons, but it may come in handy for other things.

<img width="761" alt="Screenshot 2024-01-30 at 7 21 45 PM" src="https://github.com/narmi/design_system/assets/231252/90d3194c-6e65-4ee0-ac9d-c23312316747">
