### PR TITLE
feat(checkbox): add indeterminate state property

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -1,5 +1,5 @@
 // https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_custom_checkbox
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import Error from "../Error";
@@ -16,6 +16,7 @@ const Checkbox = ({
   name,
   defaultChecked,
   checked,
+  indeterminate,
   value,
   error,
   kind = "normal",
@@ -28,6 +29,7 @@ const Checkbox = ({
   );
   const [isFocused, setIsFocused] = useState(false);
   const isCard = kind === "card";
+  const inputRef = useRef(null);
 
   const LinkRenderer = ({ href, children }) => {
     return (
@@ -47,6 +49,12 @@ const Checkbox = ({
       setIsChecked(checked);
     }
   }, [checked]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = indeterminate;
+    }
+  }, [indeterminate, inputRef]);
 
   const handleChange = (e) => {
     if (!isControlled) {
@@ -71,12 +79,18 @@ const Checkbox = ({
           "fontWeight--default",
           {
             "nds-checkbox--checked": isChecked,
+            "nds-checkbox--indeterminate": indeterminate,
             "nds-checkbox--focused": isFocused,
             "padding--y--xl padding--x rounded--all border--all": isCard,
           },
         ])}
       >
-        <span className={cc(["narmi-icon-check", { error: !!error }])}></span>
+        <span
+          className={cc([
+            indeterminate ? "narmi-icon-minus" : "narmi-icon-check",
+            { error: !!error },
+          ])}
+        ></span>
         <div className="nds-checkbox-label">
           {markdownLabel && (
             <ReactMarkdown components={{ a: LinkRenderer }}>
@@ -98,6 +112,7 @@ const Checkbox = ({
           {...rest}
           type="checkbox"
           aria-label={label}
+          ref={inputRef}
         />
       </label>
       <Error marginTop="xs" error={error} />
@@ -125,6 +140,8 @@ Checkbox.propTypes = {
   defaultChecked: PropTypes.bool,
   /** Sets the checkbox checked value */
   checked: PropTypes.bool,
+  /** Sets the checkbox indeterminate value */
+  indeterminate: PropTypes.bool,
   /** Sets the `value` attribute of the `input` */
   value: PropTypes.string,
   /** Text of error message to display under the checkbox */

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -43,7 +43,7 @@
   align-items: flex-start;
   gap: var(--space-s);
 
-  .narmi-icon-check {
+  .narmi-icon-check, .narmi-icon-minus {
     height: 18px;
     width: 18px;
 
@@ -70,24 +70,22 @@
   }
 
   // hover
-  .narmi-icon-check:hover {
+  .narmi-icon-check:hover, .narmi-icon-minus:hover {
     border-color: var(--theme-primary);
   }
 
   // focused
-  &.nds-checkbox--focused .narmi-icon-check {
+  &.nds-checkbox--focused .narmi-icon-check, &.nds-checkbox--focused .narmi-icon-minus {
     border-color: var(--theme-primary);
     outline: 3px solid RGBA(var(--theme-rgb-primary), var(--alpha-10));
   }
 
   // checked
-  &.nds-checkbox--checked {
-    .narmi-icon-check {
-      background-color: var(--theme-primary);
-      border-color: var(--theme-primary);
-      &:after {
-        display: block;
-      }
+  &.nds-checkbox--checked .narmi-icon-check, .narmi-icon-minus {
+    background-color: var(--theme-primary);
+    border-color: var(--theme-primary);
+    &:after {
+      display: block;
     }
   }
 }
@@ -120,18 +118,16 @@
     background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
   }
 
-  &.nds-checkbox--checked {
-    .narmi-icon-check {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: var(--space-default);
-      height: var(--space-default);
-      border-radius: 100%;
-      background-color: var(--theme-primary);
-      color: var(--color-white);
-      font-size: var(--font-size-s);
-      font-weight: var(--font-weight-default);
-    }
+  &.nds-checkbox--checked .narmi-icon-check, .narmi-icon-minus {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-default);
+    height: var(--space-default);
+    border-radius: 100%;
+    background-color: var(--theme-primary);
+    color: var(--color-white);
+    font-size: var(--font-size-s);
+    font-weight: var(--font-weight-default);
   }
 }

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -43,7 +43,7 @@ export const Indeterminate = () => {
   return (
     <>
       <Checkbox
-        label="Intermediate state"
+        label="Indeterminate state"
         indeterminate
         checked={isChecked}
         onChange={() => setIsChecked((isChecked) => !isChecked)}

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -38,6 +38,33 @@ export const MultipleCheckboxes = () => (
   </>
 );
 
+export const Indeterminate = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  return (
+    <>
+      <Checkbox
+        label="Intermediate state"
+        indeterminate
+        checked={isChecked}
+        onChange={() => setIsChecked((isChecked) => !isChecked)}
+      />
+      <Checkbox
+        label="Checked state"
+        checked={isChecked}
+        onChange={() => setIsChecked((isChecked) => !isChecked)}
+      />
+    </>
+  );
+};
+Indeterminate.parameters = {
+  docs: {
+    description: {
+      story:
+        "When passing `indeterminate`, the input renders as indeterminate regardless of the checked value but checked is still toggled on click.",
+    },
+  },
+};
+
 export const AsCard = Template.bind({});
 AsCard.args = {
   label: "Checkbox of 'card' kind",
@@ -54,16 +81,17 @@ AsCard.parameters = {
 
 export const Markdown = Template.bind({});
 Markdown.args = {
-  markdownLabel: "I agree to receive spam from [google](https://www.google.com/)",
+  markdownLabel:
+    "I agree to receive spam from [google](https://www.google.com/)",
   name: "spam",
 };
 Markdown.parameters = {
   docs: {
     description: {
-      story: "Renders markdown when markdownLabel prop is set"
-    }
-  }
-}
+      story: "Renders markdown when markdownLabel prop is set",
+    },
+  },
+};
 
 export default {
   title: "Components/Checkbox",

--- a/src/Checkbox/index.test.js
+++ b/src/Checkbox/index.test.js
@@ -90,8 +90,22 @@ describe("Checkbox", () => {
     expect(input).toBeChecked();
   });
 
+  it("renders as indeterminate with checked false", () => {
+    render(<Checkbox label={LABEL} checked={false} indeterminate />);
+    const { input } = getElements();
+    expect(input).not.toBeChecked();
+    expect(input).toHaveProperty("indeterminate");
+  });
+
+  it("renders as indeterminate with checked true", () => {
+    render(<Checkbox label={LABEL} checked={true} indeterminate />);
+    const { input } = getElements();
+    expect(input).toBeChecked();
+    expect(input).toHaveProperty("indeterminate");
+  });
+
   it("renders markdown when `markdownLabel` prop is set", () => {
-    render(<Checkbox markdownLabel="[Google](https://www.google.com/)"/>);
+    render(<Checkbox markdownLabel="[Google](https://www.google.com/)" />);
     const a = screen.getByText("Google");
     expect(a.tagName).toBe("A");
   });


### PR DESCRIPTION
Permits checkboxes to be rendered as indeterminate by passing `indeterminate`.

![image](https://github.com/narmi/design_system/assets/511342/44ec6f5d-d9ff-4c69-aae5-ea7fc3678e15)
