### PR TITLE
feat(popover): allow popover to be controlled

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -68,7 +68,7 @@ const Popover = ({
   };
 
   const { renderLayer, triggerProps, triggerBounds, layerProps } = useLayer({
-    isOpen: open,
+    isOpen: shouldRenderPopover,
     onOutsideClick: closePopover,
     onDisappear: closePopover,
     auto: !disableAutoPlacement,

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import Popover from "./";
 import Button from "../Button";
+import Checkbox from "../Checkbox";
 
 const Template = (args) => (
   <div
@@ -68,6 +69,27 @@ FocusManagement.args = {
       within the Popover while it is open.
     </div>
   ),
+};
+
+export const Controlled = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Checkbox
+        label="Show popover"
+        checked={isOpen}
+        onChange={() => setIsOpen(!isOpen)}
+      />
+      <div className="margin--top--m">
+        <Popover
+          content={<div className="padding--all--m">📦 Any content</div>}
+          isOpen={isOpen}
+        >
+          <div>Arbitrary target</div>
+        </Popover>
+      </div>
+    </>
+  );
 };
 
 export default {

--- a/src/Popover/index.test.js
+++ b/src/Popover/index.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import Popover from "./";
 
 const TRIGGER_TEXT = "Toggle Popover";
@@ -57,5 +57,50 @@ describe("Popover", () => {
     expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
     fireEvent.keyDown(trigger, { key: "Escape" });
     expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("shows popover on controlled", () => {
+    render(
+      <Popover content={<p>{CONTENT_TEXT}</p>} isOpen={true}>
+        <button>{TRIGGER_TEXT}</button>
+      </Popover>
+    );
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+  });
+
+  it("calls onUserDismiss on escape key", () => {
+    const onUserDismiss = jest.fn();
+    render(
+      <Popover
+        content={<p>{CONTENT_TEXT}</p>}
+        isOpen={true}
+        onUserDismiss={onUserDismiss}
+      >
+        <button>{TRIGGER_TEXT}</button>
+      </Popover>
+    );
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+    act(() => fireEvent.keyDown(trigger, { key: "Escape" }));
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+
+    expect(onUserDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onUserDismiss on outside click", () => {
+    const onUserDismiss = jest.fn();
+    render(
+      <Popover content={<p>{CONTENT_TEXT}</p>} onUserDismiss={onUserDismiss}>
+        <button>{TRIGGER_TEXT}</button>
+      </Popover>
+    );
+    const trigger = getTrigger();
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+    act(() => fireEvent.click(trigger));
+    expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
+    act(() => fireEvent.click(document.body));
+    expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
+
+    expect(onUserDismiss).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Allows `Popover` to accept `isOpen` and `onUserDismiss`, following the same pattern as `Dialog` and `Tooltip`.