### PR TITLE
feat(alert): Customizable icon and new alert kind

### DIFF
--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -64,7 +64,7 @@ Alert.propTypes = {
   /** Callback for user dismissal actions */
   onUserDismiss: PropTypes.func,
   /** Variant of Alert to use */
-  kind: PropTypes.oneOf(["info", "error", "success", "plain"]),
+  kind: PropTypes.oneOf(["info", "error", "success", "warn"]),
   /** Override the default icon of the alert */
   icon: PropTypes.string,
   /** Message content of the Alert */

--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -16,6 +16,7 @@ const Alert = ({
   isDismissable = true,
   onUserDismiss = noop,
   kind = "info",
+  icon = null,
   children,
 }) => {
   const iconName = kind === "success" ? "check" : "info";
@@ -33,7 +34,7 @@ const Alert = ({
         >
           <Row gapSize="s">
             <Row.Item shrink>
-              <span className={`nds-alert-icon narmi-icon-${iconName}`} />
+              <span className={`nds-alert-icon narmi-icon-${icon || iconName}`} />
             </Row.Item>
             <Row.Item>{children}</Row.Item>
             {isDismissable && (
@@ -63,7 +64,9 @@ Alert.propTypes = {
   /** Callback for user dismissal actions */
   onUserDismiss: PropTypes.func,
   /** Variant of Alert to use */
-  kind: PropTypes.oneOf(["info", "error", "success"]),
+  kind: PropTypes.oneOf(["info", "error", "success", "plain"]),
+  /** Override the default icon of the alert */
+  icon: PropTypes.string,
   /** Message content of the Alert */
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -35,3 +35,11 @@
     color: var(--color-successDark);
   }
 }
+
+.nds-alert--plain {
+  background-color: var(--color-infoLight);
+
+  .nds-alert-icon::before {
+    color: var(--color-infoDark);
+  }
+}

--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.nds-alert--info {
+.nds-alert--warn {
   background-color: var(--color-warnLight);
 
   .nds-alert-icon::before {
@@ -36,7 +36,7 @@
   }
 }
 
-.nds-alert--plain {
+.nds-alert--info {
   background-color: var(--color-infoLight);
 
   .nds-alert-icon::before {

--- a/tokens/src/color/system.json
+++ b/tokens/src/color/system.json
@@ -5,6 +5,8 @@
       "successLight": { "value": "#E3FAE7" },
       "warnDark": { "value": "#EAC348" },
       "warnLight": { "value": "#FEF8E3" },
+      "infoDark": { "value": "#195274" },
+      "infoLight": { "value": "#E8EEF1" },
       "errorDark": { "value": "#D93B3B" },
       "errorLight": { "value": "#FDF1F1" }
     }


### PR DESCRIPTION
New designs for fednow require additional customization of the alert component. 

Designs: https://www.figma.com/file/TG6rH21v231JFcZy9jaIz6/fednow-manager?type=design&node-id=1101-2&mode=design&t=942hC19EsHzktDbo-0

Dev storybook:
<img width="1029" alt="image" src="https://github.com/narmi/design_system/assets/32401210/d072e3ba-ff4b-496f-85de-873a5f2b1150">
