### PR TITLE
fix(Dialog): prevent misplaced scroll gradient in firefox

### DIFF
--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -16,9 +16,12 @@ const noop = () => {};
  * @returns {Boolean}
  */
 const getIsContentTooLong = (contentRef) => {
+  const threshold = 1; // Scrollheight in firefox is reported as 1px taller
   let result = false;
   if (contentRef.current) {
-    result = contentRef.current.scrollHeight > contentRef.current.clientHeight;
+    result =
+      contentRef.current.scrollHeight >
+      contentRef.current.clientHeight + threshold;
   }
   return result;
 };


### PR DESCRIPTION
closes #1126 

Firefox is off by one when calculating `scrollHeight`, causing our overflow detector to always return `true` in Firefox. This means that all dialogs in Firefox had the scroll indicator gradient covering up some of the content.

This fix adds a threshold for the clientHeight/scrollHeight math that prevents Firefox from treating short dialogs as scrollable.

#### Other options considered
One way to ensure the correct value is read is to cause a quick reflow by setting the CSS `overflow-y` value, reading scrollHeight, and then changing overflow back to `visible`. This causes another reflow, so I'd rather just pad the math.