### PR TITLE
feat(drawer): allow children to be a render function

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -150,7 +150,9 @@ const Drawer = ({
       role="dialog"
       data-testid={testId}
     >
-      {children}
+      {typeof children === "function"
+        ? children({ isVisible: isTransitioning })
+        : children}
     </div>
   );
 
@@ -179,7 +181,7 @@ const Drawer = ({
 
 Drawer.propTypes = {
   /** Scrollable contents of the Drawer */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   /** Controls open/close state of the modal. Use the `onUserDismiss` callback to update. */
   isOpen: PropTypes.bool,
   /**

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -259,7 +259,7 @@ LazyLoadedContent.parameters = {
   docs: {
     description: {
       story:
-        "The Drawer component accepts a render prop for its children. This can be used to lazy load content or to render content conditionally.",
+        "The Drawer component accepts a render prop for its children with argument `isVisible`. This can be used to lazy load content or to render content conditionally.",
     },
   },
 };

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -230,6 +230,40 @@ export const ContentWithDialog = () => {
   );
 };
 
+export const LazyLoadedContent = () => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setIsDrawerOpen(true)}>Open Drawer</Button>
+      <Drawer
+        isOpen={isDrawerOpen}
+        onUserDismiss={() => setIsDrawerOpen(false)}
+      >
+        {({ isVisible }) => {
+          if (!isVisible) {
+            return null;
+          }
+          return (
+            <div>
+              <h2>Lazy Loaded Content</h2>
+              <p>Content that was loaded after the Drawer was opened</p>
+            </div>
+          );
+        }}
+      </Drawer>
+    </>
+  );
+};
+LazyLoadedContent.parameters = {
+  docs: {
+    description: {
+      story:
+        "The Drawer component accepts a render prop for its children. This can be used to lazy load content or to render content conditionally.",
+    },
+  },
+};
+
 export default {
   title: "Components/Drawer",
   component: Drawer,


### PR DESCRIPTION
Adds support for a render function children in `Drawer`. This allows content inside the drawer to be rendered on-demand and destroyed when the drawer is closed. Notably, such behavior cannot be accomplished by conditioning on `isOpen` because `isOpen` would destroy the contents too quickly and we want to wait until the drawer is fully closed.

See storybook example for a more descriptive demonstration.