### PR TITLE
feat(drawer): allow the close button to be hidden

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -20,6 +20,7 @@ const Drawer = ({
   onUserDismiss = noop,
   onNext = null,
   onPrev = null,
+  showClose = true,
   showControls = true,
   children,
   position = "right",
@@ -87,15 +88,21 @@ const Drawer = ({
       data-testid={testId}
     >
       <div className={`navigation-container--${position}`}>
-        <div
-          className={`navigation-button navigation-button--${position} alignChild--center--center`}
-          onClick={onUserDismiss}
-        >
-          <span className="narmi-icon-x clickable fontSize--heading3" />
-        </div>
-        <div
-          className={isHorizontal ? "margin--right--xl" : "margin--bottom--xl"}
-        />
+        {showClose && (
+          <div
+            className={`navigation-button navigation-button--${position} alignChild--center--center`}
+            onClick={onUserDismiss}
+          >
+            <span className="narmi-icon-x clickable fontSize--heading3" />
+          </div>
+        )}
+        {showClose && showControls && (
+          <div
+            className={
+              isHorizontal ? "margin--right--xl" : "margin--bottom--xl"
+            }
+          />
+        )}
         {showControls && (
           <>
             <div
@@ -204,6 +211,10 @@ Drawer.propTypes = {
    * Use the full CSS value with the percentage (e.g. `"400px"` or `"70%"`)
    */
   depth: PropTypes.string,
+  /**
+   * Determines whether the close button shows.
+   */
+  showClose: PropTypes.bool,
   /**
    * Determines whether the next and prev buttons show.
    */

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -174,6 +174,19 @@ ScrollingContentWithoutNavigation.parameters = {
   },
 };
 
+export const WithoutClose = BaseTemplate.bind({});
+WithoutClose.args = {
+  showClose: false,
+};
+WithoutClose.parameters = {
+  docs: {
+    description: {
+      story:
+        "The Drawer will hide the close button when `showClose` is set to false.",
+    },
+  },
+};
+
 export const ContentWithPopover = BaseTemplate.bind({});
 ContentWithPopover.args = {
   showControls: false,


### PR DESCRIPTION
Adds a parameter to allow for creating a drawer that does not render the close button.

![image](https://github.com/narmi/design_system/assets/511342/53f8c879-cf26-40a1-b97d-5f7732d62625)

