### PR TITLE
fix(Popover): don't bubble up the user events that we handle

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -55,16 +55,14 @@ const Popover = ({
     setOpen(!open);
   };
 
-  const handleKeyDown = (event) => {
-    event.stopPropagation();
-    if (event.key === "Enter") {
+  const handleKeyDown = ({ key }) => {
+    if (key === "Enter") {
       setOpen(true);
     }
   };
 
-  const handleKeyUp = (event) => {
-    event.stopPropagation();
-    if (event.key === "Escape" && shouldRenderPopover) {
+  const handleKeyUp = ({ key }) => {
+    if (key === "Escape" && shouldRenderPopover) {
       setOpen(false);
       onUserDismiss();
     }

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -50,18 +50,21 @@ const Popover = ({
     onUserDismiss();
   };
 
-  const togglePopover = () => {
+  const togglePopover = (event) => {
+    event.stopPropagation();
     setOpen(!open);
   };
 
-  const handleKeyDown = ({ key }) => {
-    if (key === "Enter") {
+  const handleKeyDown = (event) => {
+    event.stopPropagation();
+    if (event.key === "Enter") {
       setOpen(true);
     }
   };
 
-  const handleKeyUp = ({ key }) => {
-    if (key === "Escape" && shouldRenderPopover) {
+  const handleKeyUp = (event) => {
+    event.stopPropagation();
+    if (event.key === "Escape" && shouldRenderPopover) {
       setOpen(false);
       onUserDismiss();
     }


### PR DESCRIPTION
resolves https://github.com/narmi/banking/issues/43694

If a Popover is inside another component, like a tab or a summary, interacting with the Popover will also interact with the parent. Calling a stopPropagation() on the events that we handle in this component should prevent this bubbling.