### PR TITLE
feat(Drawer): use takeover drawer for mobile sized screens

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -38,10 +38,7 @@ const Drawer = ({
 
   // The depth is how far the drawer opens out, but the CSS prop depends
   // on whether the Drawer is vertical or not
-  const depthStyle = {
-    width: isHorizontal ? "auto" : depth,
-    height: isHorizontal ? depth : "100%",
-  };
+  const depthStyle = isHorizontal ? { height: depth } : { width: depth };
   if (isVerticalMobileDrawer) {
     depthStyle.width = "100%";
   }

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -38,7 +38,14 @@ const Drawer = ({
 
   // The depth is how far the drawer opens out, but the CSS prop depends
   // on whether the Drawer is vertical or not
-  const depthStyle = isHorizontal ? { height: depth } : { width: !isVerticalMobileDrawer ? depth : "100%" };
+  const depthStyle = {
+    width: isHorizontal ? "auto" : depth,
+    height: isHorizontal ? depth : "100%",
+  };
+  if (isVerticalMobileDrawer) {
+    depthStyle.width = "100%";
+  }
+
   useLockBodyScroll(isOpen);
 
   const handleKeyDown = ({ key }) => {
@@ -155,9 +162,14 @@ const Drawer = ({
   const childrenJSX = (
     <div
       style={depthStyle}
-      className={`drawer drawer-children drawer--${position} ${
-        isOpen && isTransitioning ? `drawer--open--${position}` : ""
-      } ${isVerticalMobileDrawer ? "drawer--vertical--mobile" : ""}`}
+      className={cc([
+        "drawer",
+        `drawer--${position}`,
+        {
+          [`drawer--open--${position}`]: isOpen && isTransitioning,
+          "drawer--vertical--mobile": isVerticalMobileDrawer,
+        },
+      ])}
       role="dialog"
       data-testid={testId}
     >

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -172,20 +172,24 @@ const Drawer = ({
     >
       {isVerticalMobileDrawer && (
         <>
-          <div
-            onClick={onPrev}
-          >
-            <span
-              className="narmi-icon-chevron-left fontSize--heading3"
-            />
-          </div>
-          <div
-            onClick={onNext}
-          >
-            <span
-              className="narmi-icon-chevron-right fontSize--heading3"
-            />
-          </div>
+          {showControls && (
+            <>
+              <div
+                onClick={onPrev}
+              >
+                <span
+                  className="narmi-icon-chevron-left fontSize--heading3"
+                />
+              </div>
+              <div
+                onClick={onNext}
+              >
+                <span
+                  className="narmi-icon-chevron-right fontSize--heading3"
+                />
+              </div>
+            </>
+          )}
           <div
             onClick={onUserDismiss}
           >

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -171,11 +171,27 @@ const Drawer = ({
       data-testid={testId}
     >
       {isVerticalMobileDrawer && (
-        <div
-          onClick={onUserDismiss}
-        >
-          <span className="narmi-icon-x clickable fontSize--heading3" />
-        </div>
+        <>
+          <div
+            onClick={onPrev}
+          >
+            <span
+              className="narmi-icon-chevron-left fontSize--heading3"
+            />
+          </div>
+          <div
+            onClick={onNext}
+          >
+            <span
+              className="narmi-icon-chevron-right fontSize--heading3"
+            />
+          </div>
+          <div
+            onClick={onUserDismiss}
+          >
+            <span className="narmi-icon-x clickable fontSize--heading3" />
+          </div>
+        </>
       )}
       {typeof children === "function"
         ? children({ isVisible: isTransitioning })

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -3,6 +3,7 @@ import React, { useRef, useEffect } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import useBreakpoints from "../hooks/useBreakpoints";
 import useMountTransition from "./useMountTransition";
 import useLockBodyScroll from "../hooks/useLockBodyScroll";
 
@@ -31,10 +32,13 @@ const Drawer = ({
   const navRef = useRef(null);
 
   const isTransitioning = useMountTransition(isOpen, 300);
+  const { m } = useBreakpoints();
   const isHorizontal = position === "bottom" || position === "top";
+  const isVerticalMobileDrawer = (!m) && !isHorizontal;
+
   // The depth is how far the drawer opens out, but the CSS prop depends
   // on whether the Drawer is vertical or not
-  const depthStyle = isHorizontal ? { height: depth } : { width: depth };
+  const depthStyle = isHorizontal ? { height: depth } : { width: !isVerticalMobileDrawer ? depth : "100%" };
   useLockBodyScroll(isOpen);
 
   const handleKeyDown = ({ key }) => {
@@ -77,7 +81,7 @@ const Drawer = ({
   };
 
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
-  const navigationContainerJSX = (
+  const navigationContainerJSX = isVerticalMobileDrawer ? null : (
     <div
       ref={navRef}
       onClick={handleShimClick}
@@ -151,12 +155,19 @@ const Drawer = ({
   const childrenJSX = (
     <div
       style={depthStyle}
-      className={`drawer drawer--${position} ${
+      className={`drawer drawer-children drawer--${position} ${
         isOpen && isTransitioning ? `drawer--open--${position}` : ""
-      }`}
+      } ${isVerticalMobileDrawer ? "drawer--vertical--mobile" : ""}`}
       role="dialog"
       data-testid={testId}
     >
+      {isVerticalMobileDrawer && (
+        <div
+          onClick={onUserDismiss}
+        >
+          <span className="narmi-icon-x clickable fontSize--heading3" />
+        </div>
+      )}
       {typeof children === "function"
         ? children({ isVisible: isTransitioning })
         : children}

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -53,11 +53,20 @@ because we need to replace the left/right controls with controls that are inside
 */
 .drawer--vertical--mobile {
   padding: 48px var(--space-l);
-  .narmi-icon-x {
+  .narmi-icon-x,
+  .narmi-icon-chevron-left,
+  .narmi-icon-chevron-right {
     position: absolute;
     top: var(--space-s);
+  }
+  .narmi-icon-x {
     right: var(--space-s);
-    font-size: var(--font-size-heading3);
+  }
+  .narmi-icon-chevron-left {
+    left: var(--space-s);
+  }
+  .narmi-icon-chevron-right {
+    left: 45px;
   }
 }
 

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -12,6 +12,7 @@
   transition: transform var(--transition-speed-fast) ease;
   border: var(--border-size-s);
   border-color: var(--border-color-light);
+  padding: var(--space-xxl);
   z-index: 3;
 }
 .drawer--left {
@@ -47,23 +48,16 @@
   transform: translateX(0);
 }
 /*
-the drawer--mobile class styles only apply to mobile drawers that open from the right or left,
+this class only applies to mobile drawers that open from the right or left,
 because we need to replace the left/right controls with controls that are inside the drawer
 */
 .drawer--vertical--mobile {
+  padding: 48px var(--space-l);
   .narmi-icon-x {
     position: absolute;
     top: var(--space-s);
     right: var(--space-s);
     font-size: var(--font-size-heading3);
-  }
-}
-// for extra small screens, ensure there's a minimum amount of padding inside the drawer content
-.drawer-children {
-  padding: 48px var(--space-l);
-
-  @include atMediaUp("s") {
-    padding: var(--space-xxl);
   }
 }
 
@@ -88,7 +82,6 @@ because we need to replace the left/right controls with controls that are inside
 }
 
 .navigation {
-  padding: var(--space-xxl);
   background: transparent;
   transition: transform var(--transition-speed-medium) ease;
   z-index: 1;

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -12,7 +12,6 @@
   transition: transform var(--transition-speed-fast) ease;
   border: var(--border-size-s);
   border-color: var(--border-color-light);
-  padding: var(--space-xxl);
   z-index: 3;
 }
 .drawer--left {
@@ -47,6 +46,26 @@
 .drawer--open--bottom {
   transform: translateX(0);
 }
+/*
+the drawer--mobile class styles only apply to mobile drawers that open from the right or left,
+because we need to replace the left/right controls with controls that are inside the drawer
+*/
+.drawer--vertical--mobile {
+  .narmi-icon-x {
+    position: absolute;
+    top: var(--space-s);
+    right: var(--space-s);
+    font-size: var(--font-size-heading3);
+  }
+}
+// for extra small screens, ensure there's a minimum amount of padding inside the drawer content
+.drawer-children {
+  padding: 48px var(--space-l);
+
+  @include atMediaUp("s") {
+    padding: var(--space-xxl);
+  }
+}
 
 .backdrop {
   visibility: hidden;
@@ -69,6 +88,7 @@
 }
 
 .navigation {
+  padding: var(--space-xxl);
   background: transparent;
   transition: transform var(--transition-speed-medium) ease;
   z-index: 1;


### PR DESCRIPTION
closes #1132

- For mobile screen sizes, renders a full screen width drawer & moves controls to the top of the drawer

### Extra Small right/left (toggling b/t old & new)
![2024-03-28 13 05 56](https://github.com/narmi/design_system/assets/50111807/a7f6b666-e726-472b-b023-19f59e97389e)

### Small right/left (toggling b/t old & new)
![2024-03-28 13 08 40](https://github.com/narmi/design_system/assets/50111807/a38746a4-80ed-4488-9d58-5713c154581a)

### No changes were made for top/bottom on extra small/small, and no changes were made to drawers at or above the `m` breakpoint of 768px
