### PR TITLE
feat(RadioButtons): Add details to the RadioButtons component

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -6,10 +6,18 @@ import cc from "classcat";
 The Narmi RadioButtons component expects an "options" Prop, which is an object where the keys are the radiobutton
 labels and the values are the radiobutton values. An "initialvalue" Prop can be passed to set a default checked
 radiobutton.
+```
+  options={{
+    "First Label": { value: "firstValue", details: "This is the explanation of the firstValue" },
+    "Second Label": { value: "secondValue", details: "This is the explanation of the secondValue" }
+  }
+```
 
+The other options configuration without details would be:
 ```
   options={{ "First Label": "firstValue", "Second Label": "secondValue" }}
 ```
+
 */
 const RadioButtons = ({
   options,
@@ -20,12 +28,13 @@ const RadioButtons = ({
   onChange = () => {},
   testId,
   error,
+  alwaysShowDetails = false,
   ...containerProps
 }) => {
   const isControlled = value !== undefined;
   const hasError = error !== undefined && error.length > 0;
   const [checkedValue, setCheckedValue] = useState(
-    isControlled ? value : initialValue
+    isControlled ? value : initialValue,
   );
   const [focusedValue, setFocusedValue] = useState(null);
 
@@ -57,40 +66,61 @@ const RadioButtons = ({
       data-testid={testId}
       {...containerProps}
     >
-      {Object.entries(options).map(([label, inputValue]) => (
-        <label
-          className={cc([
-            "nds-radiobuttons-option",
-            "fontWeight--default",
-            {
-              "nds-radiobuttons-option--checked": checkedValue == inputValue,
-              "nds-radiobuttons-option--focused": focusedValue == inputValue,
-              "nds-radiobuttons-option--error": hasError,
-              "padding--all rounded--all border--all": kind === "card",
-            },
-          ])}
-          key={inputValue}
-        >
-          {label}
-          <input
-            type="radio"
-            aria-label={`Radio ${name} option ${label}`}
-            checked={checkedValue === inputValue}
-            onChange={handleChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            value={inputValue}
-            name={name}
-          />
-          <div
-            role="presentation"
+      {Object.entries(options).map(([label, subOptions]) => {
+        const { value: inputValue, details } =
+          typeof subOptions === "string" ? { value: subOptions } : subOptions;
+        return (
+          <label
             className={cc([
-              "nds-radio",
-              { "narmi-icon-check": kind === "card" },
+              "nds-radiobuttons-option",
+              "fontWeight--default",
+              {
+                "nds-radiobuttons-option--checked": checkedValue == inputValue,
+                "nds-radiobuttons-option--focused": focusedValue == inputValue,
+                "nds-radiobuttons-option--error": hasError,
+                "padding--all rounded--all border--all": kind === "card",
+              },
             ])}
-          />
-        </label>
-      ))}
+            key={inputValue}
+          >
+            <div className="nds-radiobuttons-label-container">
+              {label}
+              <input
+                type="radio"
+                aria-label={`Radio ${name} option ${label}`}
+                checked={checkedValue === inputValue}
+                onChange={handleChange}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                value={inputValue}
+                name={name}
+              />
+              <div
+                role="presentation"
+                className={cc([
+                  "nds-radio",
+                  { "narmi-icon-check": kind === "card" },
+                ])}
+              />
+            </div>
+            {details && (
+              <div
+                className={cc([
+                  "nds-radiobutton-details",
+                  {
+                    "nds-radiobutton-details--checked":
+                      alwaysShowDetails || checkedValue == inputValue,
+                    "fontColor--secondary": kind != "card",
+                    "fontSize--s": kind != "card",
+                  },
+                ])}
+              >
+                {details}
+              </div>
+            )}
+          </label>
+        );
+      })}
       {hasError && (
         <div className="fontColor--error">
           <span className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
@@ -127,6 +157,13 @@ RadioButtons.propTypes = {
    * render the radio group in an error state.
    */
   error: PropTypes.string,
+  /**
+   * Always show details. When `true`, the details will
+   * always be shown, regardless of if an radio button is selected.
+   * When `false`, the details will only be shown when a radio
+   * button is selected. Defaults to `false`
+   */
+  alwaysShowDetails: PropTypes.bool,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -91,6 +91,7 @@
   .nds-radiobutton-details {
     max-height: 0;
     transition: max-height 0.3s ease-in;
+    transition: margin-top 0.2s ease-in;
     overflow: hidden;
 
     &.nds-radiobutton-details--checked {

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -90,11 +90,15 @@
 
   .nds-radiobutton-details {
     max-height: 0;
-    transition: max-height 0.3s ease-in;
-    transition: margin-top 0.2s ease-in;
+    line-height: 0;
+    transition:
+      max-height 0.3s ease-in,
+      line-height 0.2s ease-in,
+      margin-top 0.2s ease-in;
     overflow: hidden;
 
     &.nds-radiobutton-details--checked {
+      line-height: var(--font-lineHeight-default);
       max-height: 300px;
       margin-top: var(--space-s);
       padding-right: 60px;

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -20,6 +20,17 @@
   &:last-child {
     margin-bottom: 0;
   }
+
+  .nds-radiobutton-details {
+    max-height: 0;
+    margin-top: 0;
+    overflow: hidden;
+
+    &.nds-radiobutton-details--checked {
+      margin-top: var(--space-xs);
+      max-height: 300px;
+    }
+  }
 }
 
 // normal variant of radiobuttons
@@ -77,15 +88,30 @@
 .nds-radiobuttons--card {
   display: block;
 
+  .nds-radiobutton-details {
+    max-height: 0;
+    transition: max-height 0.3s ease-in;
+    overflow: hidden;
+
+    &.nds-radiobutton-details--checked {
+      max-height: 300px;
+      margin-top: var(--space-s);
+      padding-right: 60px;
+    }
+  }
+
   .nds-radiobuttons-option {
     position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    background-color: var(--color-white);
-    color: var(--theme-primary);
-    font-weight: var(--font-weight-bold) !important;
+
+    .nds-radiobuttons-label-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      background-color: var(--color-white);
+      color: var(--theme-primary);
+      font-weight: var(--font-weight-bold) !important;
+    }
 
     .narmi-icon-check {
       display: none;
@@ -103,6 +129,9 @@
 
     &.nds-radiobuttons-option--checked {
       background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+      .nds-radiobuttons-label-container {
+        background-color: transparent;
+      }
     }
 
     &.nds-radiobuttons-option--checked .narmi-icon-check {

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -84,6 +84,53 @@ FullyControlled.parameters = {
   },
 };
 
+export const AsRadioButtonsWithDetails = Template.bind({});
+AsRadioButtonsWithDetails.args = {
+  options: {
+    OptionA: {
+      value: "A",
+      details:
+        "Option A details. The Option A details are very long and will wrap to the next line. The Option A details are very long and will wrap to the next line.",
+    },
+    OptionB: { value: "B", details: "Option B details" },
+    OptionC: { value: "C", details: "Option C details" },
+  },
+  name: "card_options_with_details",
+};
+
+AsRadioButtonsWithDetails.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a cards. The cards will grow to fill the width of their parent container. Each card can have a `details` property to show additional information when the card is selected.",
+    },
+  },
+};
+
+export const AsRadioButtonsWithDetailsAlwaysShown = Template.bind({});
+AsRadioButtonsWithDetailsAlwaysShown.args = {
+  options: {
+    OptionA: {
+      value: "A",
+      details:
+        "Option A details. The Option A details are very long and will wrap to the next line. The Option A details are very long and will wrap to the next line.",
+    },
+    OptionB: { value: "B", details: "Option B details" },
+    OptionC: { value: "C", details: "Option C details" },
+  },
+  alwaysShowDetails: true,
+  name: "card_options_with_details",
+};
+
+AsRadioButtonsWithDetailsAlwaysShown.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a cards. The cards will grow to fill the width of their parent container. Each card can have a `details` property to show additional information when the card is selected.",
+    },
+  },
+};
+
 export const AsCard = Template.bind({});
 AsCard.args = {
   options: {
@@ -99,6 +146,30 @@ AsCard.parameters = {
     description: {
       story:
         "Renders a radio group styled as a cards. The cards will grow to fill the width of their parent container.",
+    },
+  },
+};
+
+export const AsCardWithDetails = Template.bind({});
+AsCardWithDetails.args = {
+  options: {
+    OptionA: {
+      value: "A",
+      details:
+        "Option A details. The Option A details are very long and will wrap to the next line. The Option A details are very long and will wrap to the next line.",
+    },
+    OptionB: { value: "B", details: "Option B details" },
+    OptionC: { value: "C", details: "Option C details" },
+  },
+  name: "card_options_with_details",
+  kind: "card",
+};
+
+AsCardWithDetails.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a cards. The cards will grow to fill the width of their parent container. Each card can have a `details` property to show additional information when the card is selected.",
     },
   },
 };


### PR DESCRIPTION
resolves: #1153

This update adds details to the options property for the `RadioButtons` component.

### Normal radio buttons with details:
![2024-03-29 11 26 21](https://github.com/narmi/design_system/assets/1588957/83070759-0339-48b7-9326-c08882c245bd)

### Normal radio buttons with details always shown:
![Screenshot 2024-03-29 at 12 31 08 PM](https://github.com/narmi/design_system/assets/1588957/73b96df2-ee6c-4cf0-96c7-5d8c19f92d03)

### Card radio buttons with details:
![2024-03-29 12 44 41](https://github.com/narmi/design_system/assets/1588957/55c3338c-861f-4a83-bf11-61f67c3c0398)
