### PR TITLE
fix(menu): allow closing the menu via the trigger

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -80,16 +80,7 @@ const MenuButton = ({
   return (
     <MenuTrigger
       isOpen={isOpen}
-      onOpenChange={(o) => {
-        /**
-         * We only need to use MenuTrigger to manage when
-         * the popover opens. Closing the popover is managed
-         * by `useLayer`
-         */
-        if (o) {
-          setIsOpen(true);
-        }
-      }}
+      onOpenChange={(o) => setIsOpen(o)}
       data-testid={testId}
       className="nds-menubutton"
     >


### PR DESCRIPTION
Clicking on the trigger itself doesn't seem to be caught by `useLayer()`. Updates the logic so `Menu` respects any `onMenuChange` events.