### PR TITLE
fix(RadioButtons): Background color and transition fix for RadioButtons

### DIFF
--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -90,30 +90,33 @@
 
   .nds-radiobutton-details {
     max-height: 0;
+    opacity: 0;
+    padding-right: 60px;
     line-height: 0;
     transition:
-      max-height 0.3s ease-in,
-      line-height 0.2s ease-in,
-      margin-top 0.2s ease-in;
+      max-height 0.3s ease,
+      opacity 0.15s ease,
+      line-height 0.15s ease,
+      margin-top 0.2s ease;
     overflow: hidden;
 
     &.nds-radiobutton-details--checked {
       line-height: var(--font-lineHeight-default);
       max-height: 300px;
+      opacity: 1;
       margin-top: var(--space-s);
-      padding-right: 60px;
     }
   }
 
   .nds-radiobuttons-option {
     position: relative;
+    background-color: var(--color-white);
 
     .nds-radiobuttons-label-container {
       display: flex;
       align-items: center;
       justify-content: space-between;
       width: 100%;
-      background-color: var(--color-white);
       color: var(--theme-primary);
       font-weight: var(--font-weight-bold) !important;
     }


### PR DESCRIPTION
Subtle, but the background color of the whole card isn't white. We need to fix that.
![Screenshot 2024-04-01 at 4 18 15 PM](https://github.com/narmi/design_system/assets/1588957/b423b228-eb3c-4c5b-b3a7-2c403ff86856)
Cleaned up the transitions a little.
![2024-04-01 16 18 00](https://github.com/narmi/design_system/assets/1588957/dfadc034-f72c-4972-917d-944fc5d6f74e)
