### PR TITLE
fix(RadioButtons): Fix duck-typing for radio buttons options

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -68,7 +68,7 @@ const RadioButtons = ({
     >
       {Object.entries(options).map(([label, subOptions]) => {
         const { value: inputValue, details } =
-          typeof subOptions === "string" ? { value: subOptions } : subOptions;
+          typeof subOptions === "object" ? subOptions : { value: subOptions };
         return (
           <label
             className={cc([


### PR DESCRIPTION
If a consumer of the component passed in a boolean then the ducktyping would try to destructure it.
This explicitly checks to see if what is being passed is an object.