### PR TITLE
feat(Slider): Add slider component

### DIFF
--- a/src/Slider/Thumbs.tsx
+++ b/src/Slider/Thumbs.tsx
@@ -1,0 +1,69 @@
+import { useRef } from "react";
+import { VisuallyHidden, mergeProps, useFocusRing, useSliderThumb } from "react-aria";
+
+const getRailWidth = (lowerInputThumbProps, higherInputThumbProps) => parseFloat(higherInputThumbProps.style?.left.toString().slice(0, -1)) - parseFloat(lowerInputThumbProps.style?.left.toString().slice(0, -1));
+
+const useThumb = (index, trackRef, name, state) => {
+  const inputRef = useRef(null);
+  const { thumbProps, inputProps } = useSliderThumb({
+    index,
+    trackRef,
+    inputRef,
+    name
+  }, state);
+  const { focusProps } = useFocusRing();
+  return {
+    inputRef,
+    thumbProps,
+    inputProps,
+    focusProps,
+  }
+}
+
+const Thumb = ({ thumbProps, inputRef, inputProps, focusProps }) => {
+  return (
+    <div
+      {...thumbProps}
+      className="thumb"
+    >
+      <VisuallyHidden>
+        <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
+      </VisuallyHidden>
+    </div>
+  )
+};
+
+const Thumbs = (props) => {
+  const { state, trackRef, lowerName, higherName} = props;
+
+  const lowerThumb = useThumb(0, trackRef, lowerName, state);
+
+  const higherThumb = useThumb(1, trackRef, higherName, state);
+
+  const width = getRailWidth(lowerThumb.thumbProps, higherThumb.thumbProps);
+  const activeRailStyle = {
+    left: lowerThumb.thumbProps.style?.left,
+    width: `${width}%`,
+  };
+
+  return (
+    <>
+      <Thumb
+        thumbProps={lowerThumb.thumbProps}
+        inputRef={lowerThumb.inputRef}
+        inputProps={lowerThumb.inputProps}
+        focusProps={lowerThumb.focusProps}
+      />
+      <div className="rail-active" style={activeRailStyle}/>
+      <Thumb
+        thumbProps={higherThumb.thumbProps}
+        inputRef={higherThumb.inputRef}
+        inputProps={higherThumb.inputProps}
+        focusProps={higherThumb.focusProps}
+      />
+    </>
+
+  );
+}
+
+export default Thumbs;

--- a/src/Slider/Thumbs.tsx
+++ b/src/Slider/Thumbs.tsx
@@ -23,14 +23,14 @@ const useThumb = (index, trackRef, name, state) => {
   }
 }
 
-const Thumb = ({ thumbProps, inputRef, inputProps, focusProps, isFocusVisible }) => {
+const Thumb = ({ thumbProps, inputRef, inputProps, focusProps, isFocusVisible, ariaLabel }) => {
   return (
     <div
       {...thumbProps}
       className={cc(["thumb", { "focus": isFocusVisible }])}
     >
       <VisuallyHidden>
-        <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
+        <input ref={inputRef} {...mergeProps(inputProps, focusProps)} aria-label={ariaLabel} />
       </VisuallyHidden>
     </div>
   )
@@ -57,6 +57,7 @@ const Thumbs = (props) => {
         inputProps={lowerThumb.inputProps}
         focusProps={lowerThumb.focusProps}
         isFocusVisible={lowerThumb.isFocusVisible}
+        ariaLabel="minimum"
       />
       <div className="rail-active" style={activeRailStyle}/>
       <Thumb
@@ -65,6 +66,7 @@ const Thumbs = (props) => {
         inputProps={higherThumb.inputProps}
         focusProps={higherThumb.focusProps}
         isFocusVisible={higherThumb.isFocusVisible}
+        ariaLabel="maximum"
       />
     </>
 

--- a/src/Slider/Thumbs.tsx
+++ b/src/Slider/Thumbs.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React, { useRef } from "react";
 import { VisuallyHidden, mergeProps, useFocusRing, useSliderThumb } from "react-aria";
+import cc from "classcat";
 
 const getRailWidth = (lowerInputThumbProps, higherInputThumbProps) => parseFloat(higherInputThumbProps.style?.left.toString().slice(0, -1)) - parseFloat(lowerInputThumbProps.style?.left.toString().slice(0, -1));
 
@@ -12,20 +13,21 @@ const useThumb = (index, trackRef, name, state) => {
     inputRef,
     name
   }, state);
-  const { focusProps } = useFocusRing();
+  const { focusProps, isFocusVisible } = useFocusRing();
   return {
     inputRef,
     thumbProps,
     inputProps,
     focusProps,
+    isFocusVisible
   }
 }
 
-const Thumb = ({ thumbProps, inputRef, inputProps, focusProps }) => {
+const Thumb = ({ thumbProps, inputRef, inputProps, focusProps, isFocusVisible }) => {
   return (
     <div
       {...thumbProps}
-      className="thumb"
+      className={cc(["thumb", { "focus": isFocusVisible }])}
     >
       <VisuallyHidden>
         <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
@@ -54,6 +56,7 @@ const Thumbs = (props) => {
         inputRef={lowerThumb.inputRef}
         inputProps={lowerThumb.inputProps}
         focusProps={lowerThumb.focusProps}
+        isFocusVisible={lowerThumb.isFocusVisible}
       />
       <div className="rail-active" style={activeRailStyle}/>
       <Thumb
@@ -61,6 +64,7 @@ const Thumbs = (props) => {
         inputRef={higherThumb.inputRef}
         inputProps={higherThumb.inputProps}
         focusProps={higherThumb.focusProps}
+        isFocusVisible={higherThumb.isFocusVisible}
       />
     </>
 

--- a/src/Slider/Thumbs.tsx
+++ b/src/Slider/Thumbs.tsx
@@ -1,4 +1,5 @@
-import { useRef } from "react";
+/* eslint-disable react/prop-types */
+import React, { useRef } from "react";
 import { VisuallyHidden, mergeProps, useFocusRing, useSliderThumb } from "react-aria";
 
 const getRailWidth = (lowerInputThumbProps, higherInputThumbProps) => parseFloat(higherInputThumbProps.style?.left.toString().slice(0, -1)) - parseFloat(lowerInputThumbProps.style?.left.toString().slice(0, -1));

--- a/src/Slider/index.scss
+++ b/src/Slider/index.scss
@@ -1,6 +1,6 @@
 .nds-slider {
   position: relative;
-  width: 300px;
+  width: auto;
   touch-action: none;
 
   .rail {

--- a/src/Slider/index.scss
+++ b/src/Slider/index.scss
@@ -1,5 +1,3 @@
-
-
 .nds-slider {
   position: relative;
   width: 300px;
@@ -39,5 +37,3 @@
     margin-bottom: var(--space-l);
   }
 }
-
-

--- a/src/Slider/index.scss
+++ b/src/Slider/index.scss
@@ -4,6 +4,7 @@
   touch-action: none;
 
   .rail {
+    z-index: 1;
     position: absolute;
     background-color: rgba(var(--theme-rgb-primary), var(--alpha-20));
     height: 2px;
@@ -11,6 +12,7 @@
   }
 
   .rail-active {
+    z-index: 2;
     position: relative;
     background-color: var(--theme-primary);
     height: 2px;
@@ -18,19 +20,42 @@
 
   .track {
     position: relative;
-    height: 15px;
+    height: 17px;
     width: 100%;
     display: flex;
     align-items: center;
   }
 
   .thumb {
+    z-index: 4;
     top: 8px;
     width: 16px;
     height: 16px;
     border-radius: 50%;
     box-sizing: border-box;
     background-color: var(--theme-primary);
+
+    &:hover::before, &.focus::before {
+      z-index:3;
+      content: " ";
+      position: absolute;
+      top: -2px;
+      left: -2px;
+      background-color: rgba(var(--theme-rgb-primary), var(--alpha-5));
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+    }
+
+    &:hover::after, &.focus::after {
+      z-index:3;
+      content: " ";
+      position: absolute;
+      background-color: var(--theme-primary);
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+    }
   }
 
   .output-container {

--- a/src/Slider/index.scss
+++ b/src/Slider/index.scss
@@ -1,0 +1,43 @@
+
+
+.nds-slider {
+  position: relative;
+  width: 300px;
+  touch-action: none;
+
+  .rail {
+    position: absolute;
+    background-color: rgba(var(--theme-rgb-primary), var(--alpha-20));
+    height: 2px;
+    width: 100%;
+  }
+
+  .rail-active {
+    position: relative;
+    background-color: var(--theme-primary);
+    height: 2px;
+  }
+
+  .track {
+    position: relative;
+    height: 15px;
+    width: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  .thumb {
+    top: 8px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    box-sizing: border-box;
+    background-color: var(--theme-primary);
+  }
+
+  .output-container {
+    margin-bottom: var(--space-l);
+  }
+}
+
+

--- a/src/Slider/index.stories.js
+++ b/src/Slider/index.stories.js
@@ -15,13 +15,16 @@ Overview.args = {
 export const AsControlled = () => {
   const [value, setValue] = useState([20, 50]);
   return (
-    <Slider
-      label="Age"
-      maxValue={120}
-      step={1}
-      value={value}
-      onChange={setValue}
-    />
+    <>
+      <div className="fontSize--l margin--bottom--xl">{`State in controlling component: ${value.join(" - ")}`}</div>
+      <Slider
+        label="Age"
+        maxValue={120}
+        step={1}
+        value={value}
+        onChange={setValue}
+      />
+    </>
   )
 }
 

--- a/src/Slider/index.stories.js
+++ b/src/Slider/index.stories.js
@@ -1,0 +1,31 @@
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
+import React, { useState } from "react";
+import Slider from "./";
+
+const Template = (args) => <Slider {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  label: "Price Range",
+  maxValue: 120,
+  defaultValue: [20, 50],
+  step: 1,
+};
+
+export const AsControlled = () => {
+  const [value, setValue] = useState([20, 50]);
+  return (
+    <Slider
+      label="Age"
+      maxValue={120}
+      step={1}
+      value={value}
+      onChange={setValue}
+    />
+  )
+}
+
+export default {
+  title: "Components/Slider",
+  component: Slider,
+};

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -13,7 +13,7 @@ interface Props {
   defaultValue?: number[];
   step: number;
   value?: number[];
-  setValue?: CallableFunction
+  onChange?: (value: number[]) => void
 }
 const Slider = (props: Props) => {
   const trackRef = useRef(null);

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import React, { useRef } from "react";
 import { useNumberFormatter, useSlider, VisuallyHidden } from "react-aria";
 import { useSliderState } from 'react-stately';
 import Thumbs from "./Thumbs";
@@ -8,7 +8,7 @@ interface Props {
   output?: string;
   higherName?: string;
   lowerName?: string;
-  formatOptions: Object;
+  formatOptions: Intl.NumberFormatOptions;
   maxValue: number;
   defaultValue?: number[];
   step: number;

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -1,0 +1,56 @@
+import { useRef } from "react";
+import { useNumberFormatter, useSlider, VisuallyHidden } from "react-aria";
+import { useSliderState } from 'react-stately';
+import Thumbs from "./Thumbs";
+
+interface Props {
+  label: string;
+  output?: string;
+  higherName?: string;
+  lowerName?: string;
+  formatOptions: Object;
+  maxValue: number;
+  defaultValue?: number[];
+  step: number;
+  value?: number[];
+  setValue?: CallableFunction
+}
+const Slider = (props: Props) => {
+  const trackRef = useRef(null);
+
+  const numberFormatter = useNumberFormatter(props.formatOptions);
+  const state = useSliderState({ ...props, numberFormatter });
+  const {
+    groupProps,
+    trackProps,
+    labelProps,
+    outputProps
+  } = useSlider(props, state, trackRef);
+
+  return (
+    <div {...groupProps} className="nds-slider">
+      {props.label &&
+        (
+          <VisuallyHidden>
+            <label {...labelProps}>{props.label}</label>
+          </VisuallyHidden>
+        )}
+      <div className="output-container">
+        <output {...outputProps}>
+          {props.output || `Between ${state.getThumbValueLabel(0)} and ${state.getThumbValueLabel(1)}`}
+        </output>
+      </div>
+      <div
+        {...trackProps}
+        ref={trackRef}
+        className="track"
+      >
+        <div className="rail" />
+        <Thumbs state={state} trackRef={trackRef} lowerName={props.lowerName} higherName={props.higherName} />
+      </div>
+    </div>
+
+  );
+};
+
+export default Slider;

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -49,7 +49,6 @@ const Slider = (props: Props) => {
         <Thumbs state={state} trackRef={trackRef} lowerName={props.lowerName} higherName={props.higherName} />
       </div>
     </div>
-
   );
 };
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -80,3 +80,4 @@
 @import "Tag/";
 @import "Error/";
 @import "FormSection/";
+@import "Slider/";


### PR DESCRIPTION
for https://github.com/narmi/design_system/issues/1172

This adds the `<Slider>` input component. It is a dual thumb range slider.

I referenced the example in https://react-spectrum.adobe.com/react-aria/useSlider.html#useslider-hook

below is the Figma for the desired look of the Slider

![image](https://github.com/narmi/design_system/assets/4285085/be7b60f4-074d-405a-a72e-68c99676e55f)

and how it behaves as implemented: 

https://github.com/narmi/design_system/assets/4285085/b8ae636b-075f-4c8c-9836-dc386b60815b



