### PR TITLE
fix(IconButton): use default browser outline styling on focus-visible

### DIFF
--- a/src/IconButton/index.scss
+++ b/src/IconButton/index.scss
@@ -17,6 +17,10 @@
       transform: translate(0px, -1px);
     }
   }
+
+  &:focus {
+    outline: revert;
+  }
 }
 
 .nds-icon-button--action {

--- a/src/IconButton/index.scss
+++ b/src/IconButton/index.scss
@@ -18,7 +18,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     outline: revert;
   }
 }


### PR DESCRIPTION
If you tab through a page on Chrome or Edge, IconButtons don't show evidence that they're being focused on. This is because they explicitly their set `outline` value to `inherit`. In practice, that means that they all have `outline: none`, even on `:focus-visible`.

I'm cool with us keeping the inherit behavior for the regular state, but unless there's a strong reason not to, on `:focus-visible`, let's revert the `outline` back to the default browser stylesheet.

### Before (these are focused, I promise)

![image](https://github.com/narmi/design_system/assets/87868033/ad3e1574-0076-4826-9a13-c4769a97814d)

![image](https://github.com/narmi/design_system/assets/87868033/7f2947e6-b0af-4d8f-94e5-2c7b4d833357)

### After

![image](https://github.com/narmi/design_system/assets/87868033/2665b949-85a2-42d8-ba15-995278602d86)

![Screenshot 2024-05-01 at 10 30 38 AM](https://github.com/narmi/design_system/assets/87868033/e9988df2-908f-4d81-991f-9e729a29004d)
