### PR TITLE
feat(input): add a character counter to text inputs

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -82,7 +82,7 @@ const Input = ({
         {endContent && <div>{endContent}</div>}
       </div>
       <div className="nds-input-subline">
-        {/* this is in opposite direction to 1. make it easier to render and 2. accommodate screen reading order better */}
+        {/* this is styled using row-reverse to 1. make it easier to render and 2. accommodate screen reading order better */}
         {tailContent && (
           <div className="nds-input-tail margin--top--xxs">{tailContent}</div>
         )}

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -25,6 +25,7 @@ const Input = ({
   endIconClass,
   startContent,
   endContent,
+  tailContent,
   showClearButton,
   clearInput,
   disabled,
@@ -80,7 +81,13 @@ const Input = ({
         {(endIconClass || showClearButton) && endIconJsx}
         {endContent && <div>{endContent}</div>}
       </div>
-      <Error error={error} />
+      <div className="nds-input-subline">
+        {/* this is in opposite direction to 1. make it easier to render and 2. accommodate screen reading order better */}
+        {tailContent && (
+          <div className="nds-input-tail margin--top--xxs">{tailContent}</div>
+        )}
+        <Error error={error} />
+      </div>
     </div>
   );
 };
@@ -96,6 +103,8 @@ Input.propTypes = {
   startContent: PropTypes.node,
   /** arbitrary JSX to place at the end of the input */
   endContent: PropTypes.node,
+  /** arbitrary JSX to place at the end of the subtitle/error */
+  tailContent: PropTypes.node,
   showClearButton: PropTypes.bool,
   clearInput: PropTypes.func,
   decoration: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -50,6 +50,20 @@
     flex-grow: 1;
   }
 
+  .nds-input-subline {
+    font-size: 12px;
+    color: var(--color-mediumGrey);
+    margin-top: 4px;
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row-reverse;
+    width: 100%;
+
+    &:has(.nds-input-error) .nds-input-tail {
+      color: var(--color-errorDark);
+    }
+  }
+
   &.disabled .nds-input-box {
     pointer-events: none;
     user-select: none;

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -56,12 +56,6 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     </div>
   ) : null;
 
-  console.log(
-    maxLength,
-    inputValue.length,
-    maxLength && inputValue.length > maxLength
-  );
-
   return (
     <Input
       {...props}

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -22,8 +22,10 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     defaultValue,
     onChange,
     onBlur,
+    maxLength,
     testId,
     type = "text",
+    error,
     ...nativeElementProps
   } = props;
 
@@ -48,15 +50,34 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     setInputValue("");
   }
 
+  const characterCounter = maxLength ? (
+    <div className="nds-input-character-counter">
+      {inputValue.length}/{maxLength}
+    </div>
+  ) : null;
+
+  console.log(
+    maxLength,
+    inputValue.length,
+    maxLength && inputValue.length > maxLength
+  );
+
   return (
     <Input
       {...props}
+      error={
+        error ||
+        (maxLength && inputValue.length > maxLength
+          ? "Exceeds character limits"
+          : undefined)
+      }
       startIconClass={startIcon ? `narmi-icon-${startIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
       startContent={startContent}
       endContent={endContent}
       showClearButton={showClearButton && inputValue}
       clearInput={_onClearInput}
+      tailContent={characterCounter}
     >
       {multiline ? (
         <div
@@ -122,6 +143,8 @@ TextInput.propTypes = {
   showClearButton: PropTypes.bool,
   /** Text of error message to display under the input */
   error: PropTypes.string,
+  /** Maximum number of characters allowed in the input */
+  maxLength: PropTypes.number,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
   type: PropTypes.oneOf([

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -43,6 +43,19 @@ export const Example = () => {
             autoComplete="on"
           />
         </form>
+        <TextInput type="text" label="Text" maxLength={10} />
+        <TextInput
+          type="text"
+          label="Text"
+          maxLength={10}
+          error={"Error message"}
+        />
+        <TextInput
+          type="text"
+          label="Text"
+          defaultValue="Text input that is too long"
+          maxLength={10}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Adds these three states to `TextInput`:

![image](https://github.com/narmi/design_system/assets/511342/2dfd89fd-c6ea-45e5-93c6-3c18c31d9f6b)

They are located in the storybook under `TextInput > Examples`.