### PR TITLE
fix(TextInput):  prop was not being passed down to native input element

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -56,15 +56,15 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     </div>
   ) : null;
 
+  const inputError = error ||
+    (maxLength && inputValue.length > maxLength
+    ? "Exceeds character limits"
+    : undefined)
+
   return (
     <Input
       {...props}
-      error={
-        error ||
-        (maxLength && inputValue.length > maxLength
-          ? "Exceeds character limits"
-          : undefined)
-      }
+      error={inputError}
       startIconClass={startIcon ? `narmi-icon-${startIcon}` : undefined}
       endIconClass={endIcon ? `narmi-icon-${endIcon}` : undefined}
       startContent={startContent}
@@ -89,6 +89,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
             placeholder={props.label}
             aria-label={props.label}
             data-testid={testId}
+            error={inputError}
             {...nativeElementProps}
           />
         </div>
@@ -104,6 +105,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
           aria-label={props.label}
           placeholder={props.label}
           data-testid={testId}
+          error={inputError}
           {...nativeElementProps}
         />
       )}

--- a/src/TextInput/index.test.jsx
+++ b/src/TextInput/index.test.jsx
@@ -49,4 +49,11 @@ describe("TextInput", () => {
     const multilineInput = screen.getByPlaceholderText("Label");
     expect(multilineInput).toBeInTheDocument();
   });
+
+  it.only("passes prop down to native input element", () => {
+    render(<TextInput label={"Label"} error="the cake is a lie" testId="inputEl" />);
+    const inputEl = screen.getByPlaceholderText("Label")
+    const errorAttribute = inputEl.getAttribute("error");
+    expect(errorAttribute).toBe("the cake is a lie");
+  });
 });


### PR DESCRIPTION
resolve https://github.com/narmi/design_system/issues/1237

The moral of this is not to rely on prop-spreading - in https://github.com/narmi/design_system/commit/5e8de462cf642cbbe87e2d2489ffcf83f38824d6, we added a seemingly innocent change to sometimes display an error based on exceeding a given `maxLength` prop. But in so doing we removed the error field from `nativeElementProps`, which is spread onto the `<input>` element. So the `<input>` element doesn't receive the error prop. 

The `error` attribute is nonstandard on the native input element though, so we should maybe reconsider being dependent on it. 