### PR TITLE
chore(Slider): improve story

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   typescript: {
-    reactDocgen: "react-docgen-typescript-plugin",
+    reactDocgen: "react-docgen",
   },
 
   stories: [

--- a/src/Slider/index.stories.tsx
+++ b/src/Slider/index.stories.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React, { useState } from "react";
-import Slider from "./";
+import Slider from "./index";
 
 const Template = (args) => <Slider {...args} />;
 
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Price Range",
+  lowerName: "lower_price",
+  higherName: "higher_price",
+  minValue: 10,
   maxValue: 120,
   defaultValue: [20, 50],
   step: 1,
@@ -18,6 +21,8 @@ export const AsControlled = () => {
     <>
       <div className="fontSize--l margin--bottom--xl">{`State in controlling component: ${value.join(" - ")}`}</div>
       <Slider
+        lowerName="lower_age"
+        higherName="higher_age"
         label="Age"
         maxValue={120}
         step={1}
@@ -31,4 +36,4 @@ export const AsControlled = () => {
 export default {
   title: "Components/Slider",
   component: Slider,
-};
+}

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -3,17 +3,32 @@ import { useNumberFormatter, useSlider, VisuallyHidden } from "react-aria";
 import { useSliderState } from 'react-stately';
 import Thumbs from "./Thumbs";
 
-interface Props {
+export interface Props {
+  /** Visually hidden label to describe the input */
   label: string;
-  output?: string;
-  higherName?: string;
-  lowerName?: string;
-  formatOptions: Intl.NumberFormatOptions;
-  maxValue: number;
-  defaultValue?: number[];
-  step: number;
+  /** `name` attribute passed to the lower value input thumb */
+  lowerName: string;
+  /** `name` attribute passed to the higher value input thumb */
+  higherName: string;
+  /** value of the input */
   value?: number[];
+  /** change callback invoked when the value of the `input` changes */
   onChange?: (value: number[]) => void
+  /** optionally format the input value */
+  formatOptions?: Intl.NumberFormatOptions;
+  /** lower bound for the input, inclusive */
+  minValue?: number;
+  /** upper bound for the input, inclusive */
+  maxValue?: number;
+  /** if uncontrolled, intial value for the input */
+  defaultValue?: number[];
+  /** increment number for the range input */
+  step?: number;
+  /**
+   * Text rendered within an `<output>` element.
+   * If omitted, will default to `Between {lower} and {upper}`
+   */
+  output?: string;
 }
 const Slider = (props: Props) => {
   const trackRef = useRef(null);


### PR DESCRIPTION
A quick PR to improve the `<Slider>` storybook story. Autodocs wasn't really working well with typescript components that define prop interfaces instead of using `prop-types`, but I seem to have fixed that by using `react-docgen`. Inspired by [this comment](https://github.com/storybookjs/storybook/issues/21007#issuecomment-1430273342)

before:
![image](https://github.com/narmi/design_system/assets/4285085/1b1043e6-0f21-4c20-b32e-19abfc50a6bf)

after:
![image](https://github.com/narmi/design_system/assets/4285085/32153460-4176-4785-a2ad-40ea254f0eb8)
