### PR TITLE
docs(Tooltip): use simpler endContent example for TextInput instead of absolute positioned Tooltip

### DIFF
--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -24,28 +24,21 @@ Overview.args = {
 };
 
 export const WithTextInput = () => (
-  <div style={{ position: "relative" }}>
-    <TextInput label="Account Number" />
-    <div
-      style={{
-        position: "absolute",
-        top: "50%",
-        right: "16px",
-        transform: "translateY(-44%)",
-      }}
-    >
+  <TextInput
+    label="Account Number"
+    endContent={
       <Tooltip text="If you don't have an account number, enter your customer ID">
         <span className="narmi-icon-info"></span>
       </Tooltip>
-    </div>
-  </div>
+    }
+  />
 );
 
 WithTextInput.parameters = {
   docs: {
     description: {
       story:
-        "Tooltip can be used in a TextInput by composing an absolutely positioned narmi icon as the Tooltip trigger.",
+        "Tooltip can be used in a TextInput by passing it as the endContent prop.",
     },
   },
 };


### PR DESCRIPTION
Updates the documentation for `Tooltip` so that the `Tooltip` + `TextInput` example uses the `endContent` prop on `TextInput` rather than a more homespun absolute positioned element.

![image](https://github.com/narmi/design_system/assets/87868033/235512e3-7e8e-4a5b-aa39-fc87f1a02430)

