### PR TITLE
fix(TextInput): use value in initial state instead of passing through…

### DIFF
--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -38,7 +38,7 @@ describe("Combobox", () => {
     it("returns all children when list is not filtered", () => {
       const actual = getVisibleChildrenByCategory(
         MOCK_DISPLAYED_ITEMS,
-        MOCK_CATEGORY_CHILDREN
+        MOCK_CATEGORY_CHILDREN,
       );
       expect(actual).toStrictEqual(MOCK_CATEGORY_CHILDREN);
     });
@@ -46,7 +46,7 @@ describe("Combobox", () => {
     it("returns only visible children when first child is filtered out", () => {
       const actual = getVisibleChildrenByCategory(
         [...MOCK_DISPLAYED_ITEMS].slice(1, 4), // items: dos, tres, quatro
-        MOCK_CATEGORY_CHILDREN // contains: uno, dos
+        MOCK_CATEGORY_CHILDREN, // contains: uno, dos
       );
       const expected = [MOCK_CATEGORY_CHILDREN[1]];
       expect(actual).toStrictEqual(expected);
@@ -59,7 +59,7 @@ describe("Combobox", () => {
         "",
         1,
         MOCK_DISPLAYED_ITEMS,
-        MOCK_CATEGORY_CHILDREN
+        MOCK_CATEGORY_CHILDREN,
       );
       expect(actual).toBe(true);
     });
@@ -69,7 +69,7 @@ describe("Combobox", () => {
         "",
         3,
         MOCK_DISPLAYED_ITEMS,
-        MOCK_CATEGORY_CHILDREN
+        MOCK_CATEGORY_CHILDREN,
       );
       expect(actual).toBe(false);
     });
@@ -79,7 +79,7 @@ describe("Combobox", () => {
         "tre",
         -1,
         MOCK_DISPLAYED_ITEMS,
-        MOCK_CATEGORY_CHILDREN
+        MOCK_CATEGORY_CHILDREN,
       );
       expect(actual).toBe(true);
     });
@@ -89,7 +89,7 @@ describe("Combobox", () => {
         "",
         -1,
         MOCK_DISPLAYED_ITEMS,
-        MOCK_CATEGORY_CHILDREN
+        MOCK_CATEGORY_CHILDREN,
       );
       expect(actual).toBe(false);
     });
@@ -97,12 +97,12 @@ describe("Combobox", () => {
 
   it("isSelectable: detects selectable options correctly", () => {
     expect(isSelectable(<Combobox.Heading text="just a heading" />)).toBe(
-      false
+      false,
     );
     expect(
       isSelectable(
-        <Combobox.Item value="selectable item">selectable item</Combobox.Item>
-      )
+        <Combobox.Item value="selectable item">selectable item</Combobox.Item>,
+      ),
     ).toBe(true);
   });
 
@@ -117,7 +117,7 @@ describe("Combobox", () => {
     render(
       <Combobox label={LABEL} onChange={handleChange}>
         {STATE_ITEMS}
-      </Combobox>
+      </Combobox>,
     );
 
     // open the dropdown
@@ -160,7 +160,7 @@ describe("Combobox", () => {
     render(
       <Combobox label={LABEL} onChange={handleChange}>
         {STATE_ITEMS}
-      </Combobox>
+      </Combobox>,
     );
 
     // open the dropdown
@@ -189,7 +189,7 @@ describe("Combobox", () => {
     render(
       <Combobox label={LABEL} inputValue={value}>
         {STATE_ITEMS}
-      </Combobox>
+      </Combobox>,
     );
     const input = screen.getByPlaceholderText(LABEL);
     expect(screen.getByDisplayValue(value)).toBeInTheDocument();

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -50,16 +50,19 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
     setInputValue("");
   }
 
-  const characterCounter = maxLength ? (
+  const charCount = (nativeElementProps?.value || inputValue).length;
+  const showCharacterCounter = maxLength && charCount > 0;
+  const characterCounter = showCharacterCounter ? (
     <div className="nds-input-character-counter">
-      {inputValue.length}/{maxLength}
+      {charCount}/{maxLength}
     </div>
   ) : null;
 
-  const inputError = error ||
+  const inputError =
+    error ||
     (maxLength && inputValue.length > maxLength
-    ? "Exceeds character limits"
-    : undefined)
+      ? "Exceeds character limits"
+      : undefined);
 
   return (
     <Input

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -177,6 +177,22 @@ export const PasswordShowHide = () => {
   );
 };
 
+export const WithMaxLength = () => {
+  const [inputValue, setInputValue] = useState("Default value");
+  return (
+    <>
+      <TextInput
+        label="Limited to 20 chars"
+        maxLength={20}
+        value={inputValue}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+        }}
+      />
+    </>
+  );
+};
+
 export default {
   title: "Components/TextInput",
   component: TextInput,


### PR DESCRIPTION
… as spread props

closes NDS-305

### What is the bug?
`TextInput` takes spread props and passes them down to `Input`. 
The `TextInput` component is the one managing the state variable `inputValue`.

The problem is that `value` is not used to initialize state, and is drilled down to `Input` without `TextInput` actually using it, making the value on initial render opaque to the character counter.

### How was this bug surfaced?
This hasn't caused any harm until now. We added a character counter, and we [noticed some weird behavior](https://linear.app/narmi/issue/NDS-305/nds-textinput-maxlength-not-updating-on-page-refresh) on initial render, where the counter wasn't reflecting the initial value.

### What is the fix?
**Without changing the current behavior of TextInput ,** make the counter check if there is a `value` prop being passed through.

### Long term fix
Combine `TextInput` and `Input` into a single, fully controlled component.
See also: [Roadmap](https://github.com/narmi/design_system/wiki/Roadmap#-fixes)