### PR TITLE
fix(slider): reduce z-index on thumb

### DIFF
--- a/src/Slider/index.scss
+++ b/src/Slider/index.scss
@@ -27,7 +27,7 @@
   }
 
   .thumb {
-    z-index: 4;
+    z-index: 3;
     top: 8px;
     width: 16px;
     height: 16px;


### PR DESCRIPTION
The z-index being 4 here resulted in some odd behavior when interacting with the nds dialogs. There's probably a more elegant solution to make sure these play nice together, but this is the most straightforward way to solve the immediate problem. Setting the z-index to 3 here still means this component renders as expected and also fixes the issue. 