### PR TITLE
fix(Drawer): When padding none is set on mobile the top nav padding should be retained

### DIFF
--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -74,8 +74,8 @@ because we need to replace the left/right controls with controls that are inside
   but retain the padding for the controls at the top of the drawer.
 */
 .padding--all--none.drawer--vertical--mobile {
-  padding: 0 !important;
-  padding-top: 48px !important;
+  padding: 0;
+  padding-top: 48px;
 }
 
 .backdrop {

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -69,6 +69,15 @@ because we need to replace the left/right controls with controls that are inside
   }
 }
 
+/*
+  Remove padding from the content of the drawer when set to none,
+  but retain the padding for the controls at the top of the drawer.
+*/
+.padding--all--none.drawer--vertical--mobile {
+  padding: 0 !important;
+  padding-top: 48px !important;
+}
+
 .backdrop {
   visibility: hidden;
   opacity: 0;


### PR DESCRIPTION
resolves #1272

![Screenshot 2024-06-24 at 10 26 03 AM](https://github.com/narmi/design_system/assets/1588957/ff8dce2f-7fcc-4ecf-9355-a504efd3b2d2)
