### PR TITLE
add hasError prop to checkbox

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -19,6 +19,7 @@ const Checkbox = ({
   disabled = false,
   indeterminate = false,
   value,
+  hasError,
   error,
   kind = "normal",
   testId,
@@ -89,7 +90,7 @@ const Checkbox = ({
             {
               "narmi-icon-check": !indeterminate,
               "narmi-icon-minus": indeterminate,
-              error: !!error,
+              error: hasError || !!error,
             },
           ])}
         ></span>
@@ -154,6 +155,8 @@ Checkbox.propTypes = {
   disabled: PropTypes.bool,
   /** Sets the `value` attribute of the `input` */
   value: PropTypes.string,
+  /** Sets whether the checkbox has an error. To be used with multiple checkboxes */
+  hasError: PropTypes.bool,
   /** Text of error message to display under the checkbox */
   error: PropTypes.string,
   /** Optional value for `data-testid` attribute */


### PR DESCRIPTION
https://linear.app/narmi/issue/AO-876/beneficiaries-qa

Beneficiaries designs call for setting an error state on a group of checkboxes, but checkbox only allows for an error string to enable the error state on them.

This adds `hasError` prop to the checkbox that sets the error className and causes the red outline if hasError is true.

<img width="588" alt="image" src="https://github.com/narmi/design_system/assets/49824803/c0474117-baf9-4632-8e82-234a3fde1498">

