### PR TITLE
fix(TextInput): set label text to xs to avoid resizing container on focus

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -98,7 +98,7 @@
     pointer-events: none;
     font-family: var(--font-family-body);
     font-weight: 400;
-    font-size: var(--font-size-s);
+    font-size: var(--font-size-xs);
     color: var(--color-mediumGrey);
     line-height: var(--font-lineHeight-bodyText);
     white-space: nowrap;


### PR DESCRIPTION
This one had me stumped for a minute but it ended up being something pretty obvious - when the `TextInput` was focused, you could see the container get taller which resulted in the page content shifting downward, not desirable behavior. 

I figured out that it was caused by [this commit](https://github.com/narmi/design_system/commit/78bc50a8f765a2032be9baad09a8bbbe32f04890) because reverting it fixed the issue, but I was sure it must be something to do with the negative margins on the `label` that had been changed to use the `rem` function. Turns out, we were just setting the `label` font to be too big. After I made this change, I can confirm in my browser that `--font-size-xs` is `0.75rem` which calculates under default settings to `12px`, which is what it used to be before that commit. `--font-size-s` makes it `14px` 