### PR TITLE
feat(RadioButton): Add inline row kind

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -151,7 +151,7 @@ RadioButtons.propTypes = {
    *
    * `card` - display input and label as a toggleable card
    */
-  kind: PropTypes.oneOf(["normal", "card"]),
+  kind: PropTypes.oneOf(["normal", "row", "card"]),
   /**
    * Error message. When passed, the `error` prop will
    * render the radio group in an error state.

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -84,6 +84,58 @@
   }
 }
 
+// row variant of radiobuttons
+.nds-radiobuttons--row {
+  display: flex;
+  justify-content: space-between;
+
+  .nds-radiobuttons-option {
+    padding-left: rem(28px);
+
+    .nds-radio {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: rem(20px);
+      width: rem(20px);
+      background-color: var(--color-white);
+      border: 1px solid var(--color-lightGrey);
+      border-radius: 50%;
+
+      &:after {
+        content: "";
+        position: absolute;
+        display: none;
+        top: 50%;
+        left: 50%;
+        width: rem(12px);
+        height: rem(12px);
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+        background: var(--theme-primary);
+      }
+    }
+
+    &:hover .nds-radio,
+    &.nds-radiobuttons-option--focused .nds-radio,
+    &.nds-radiobuttons-option--checked .nds-radio {
+      border: 1px solid var(--theme-primary);
+    }
+
+    &.nds-radiobuttons-option--error .nds-radio {
+      border-color: var(--color-errorDark);
+    }
+
+    &.nds-radiobuttons-option--checked .nds-radio {
+      background-color: transparent;
+
+      &:after {
+        display: block;
+      }
+    }
+  }
+}
+
 // card style radiobuttons variant
 .nds-radiobuttons--card {
   display: block;

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -174,6 +174,49 @@ AsCardWithDetails.parameters = {
   },
 };
 
+export const AsRow = Template.bind({});
+AsRow.args = {
+  options: {
+    OptionA: "A",
+    OptionB: "B",
+    OptionC: "C",
+  },
+  name: "row_options",
+  kind: "row",
+};
+
+AsRow.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a row.",
+    },
+  },
+};
+
+export const AsRowWithDetails = Template.bind({});
+AsRowWithDetails.args = {
+  options: {
+    OptionA: {
+      value: "A",
+      details: "Option A details",
+    },
+    OptionB: { value: "B", details: "Option B details" },
+    OptionC: { value: "C", details: "Option C details" },
+  },
+  name: "row_options_with_details",
+  kind: "row",
+};
+
+AsRowWithDetails.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as a row. Each radio button can have a `details` property to show additional information when the radio button is selected.",
+    },
+  },
+};
+
 export default {
   title: "Components/RadioButtons",
   component: RadioButtons,


### PR DESCRIPTION
Adds a row `kind` to the `RadioButtons` component.

Implementation Details:
Flex parent div with:

- `justify-content: space-between`

Usage:
`<RadioButtons kind="row" />`