### PR TITLE
feat(CollapsibleCard): add option for caret trigger

### DIFF
--- a/src/CollapsibleCard/index.js
+++ b/src/CollapsibleCard/index.js
@@ -133,8 +133,8 @@ const CollapsibleCard = ({
     >
       <div
         className="collapsible-card--title-expanded"
-        role="button"
-        tabIndex={0}
+      role={trigger === "header" ? "button" : undefined}
+      tabIndex={trigger === "header" ? 0 : undefined}
         onKeyUp={({ key }) => {
           if (key === "Enter" && trigger === "header")
             onTitleContainerClick(false, "close");

--- a/src/CollapsibleCard/index.js
+++ b/src/CollapsibleCard/index.js
@@ -1,12 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import Row from "../Row";
+import IconButton from "../IconButton";
 
 const CollapsibleCard = ({
   title,
   subtitle,
   statusText,
   isOpen,
+  trigger = "header",
   onOpen = () => {},
   onClose = () => {},
   isDisabled = false,
@@ -32,42 +35,84 @@ const CollapsibleCard = ({
     }
   };
 
+  const onCaretClick = () => {
+    setHover(false);
+    if (isOpen) {
+      onClose();
+    } else {
+      onOpen();
+    }
+  };
+
+  const caretTriggerJsx = (
+    <div
+      className={cc([
+        "collapsible-card-trigger",
+        "alignChild--center--center",
+        {
+          "padding--left": trigger == "caret-start",
+          "padding--right--l": trigger == "caret-end",
+        },
+      ])}
+    >
+      <IconButton
+        kind="action"
+        label={isOpen ? "Close" : "Open"}
+        onClick={onCaretClick}
+        name={`chevron-${isOpen ? "up" : "down"}`}
+        textSize="l"
+        onKeyUp={({ key }) => {
+          if (key === "Enter") onCaretClick();
+        }}
+      />
+    </div>
+  );
+
   const titleContainerJSX = (
     <div className="collapsible-card--title-container">
-      <div>
-        <h4
-          className={cc([
-            !isDisabled ? "title" : "title--disabled",
-            "fontWeight--bold",
-            "fontSize--l",
-            "padding--top--l",
-            "padding--left--l",
-            "fontFamily--body",
-          ])}
-        >
-          {title}
-        </h4>
-        <div
-          className={cc([
-            !isDisabled ? "subtitle" : "subtitle--disabled",
-            "padding--left--l",
-            "padding--bottom--l",
-            "margin--top--xxs",
-          ])}
-        >
-          {subtitle}
-        </div>
-      </div>
-      {statusText && (
-        <div style={{ display: "flex" }}>
-          <div
-            className="collapsible-card--statusText padding--right--l fontSize--s"
-            style={{ alignSelf: "center" }}
+      <Row alignItems="center" gapSize="s">
+        {trigger === "caret-start" && (
+          <Row.Item shrink>{caretTriggerJsx}</Row.Item>
+        )}
+        <Row.Item>
+          <h4
+            className={cc([
+              !isDisabled ? "title" : "title--disabled",
+              "fontWeight--bold",
+              "fontSize--l",
+              "padding--top--l",
+              "fontFamily--body",
+              {
+                "padding--left--l": trigger !== "caret-start",
+              },
+            ])}
           >
-            {statusText}
+            {title}
+          </h4>
+          <div
+            className={cc([
+              !isDisabled ? "subtitle" : "subtitle--disabled",
+              "padding--bottom--l",
+              "margin--top--xxs",
+              {
+                "padding--left--l": trigger !== "caret-start",
+              },
+            ])}
+          >
+            {subtitle}
           </div>
-        </div>
-      )}
+        </Row.Item>
+        {trigger === "caret-end" && (
+          <Row.Item shrink>{caretTriggerJsx}</Row.Item>
+        )}
+        {statusText && (
+          <Row.Item shrink>
+            <div className="collapsible-card--statusText padding--right--l fontSize--s alignChild--right--center">
+              <span>{statusText}</span>
+            </div>
+          </Row.Item>
+        )}
+      </Row>
     </div>
   );
 
@@ -76,9 +121,11 @@ const CollapsibleCard = ({
       className={cc([
         "collapsible-card--content-card",
         {
+          "content-card--hasCaretTrigger": trigger.includes("caret"),
           "content-card--error": hasError,
-          "content-card--hover": !disableHover && hover,
-          "collapsible-card--no-user-select": !disableHover,
+          "content-card--hover": trigger === "header" && !disableHover && hover,
+          "collapsible-card--no-user-select":
+            !disableHover || trigger === "header",
         },
         "rounded--bottom",
         "bgColor--white",
@@ -89,10 +136,15 @@ const CollapsibleCard = ({
         role="button"
         tabIndex={0}
         onKeyUp={({ key }) => {
-          if (key === "Enter") onTitleContainerClick(false, "close");
+          if (key === "Enter" && trigger === "header")
+            onTitleContainerClick(false, "close");
         }}
         aria-expanded="true"
-        onClick={() => onTitleContainerClick(false, "close")}
+        onClick={() => {
+          if (trigger === "header") {
+            onTitleContainerClick(false, "close");
+          }
+        }}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
       >
@@ -105,23 +157,30 @@ const CollapsibleCard = ({
       className={cc([
         "collapsible-card--content-card",
         {
+          "content-card--hasCaretTrigger": trigger.includes("caret"),
           "content-card--error": hasError,
           "content-card--disabled": isDisabled,
-          "content-card--hover": !disableHover && hover,
-          "collapsible-card--no-user-select": !disableHover,
+          "content-card--hover": trigger === "header" && !disableHover && hover,
+          "collapsible-card--no-user-select":
+            !disableHover || trigger === "header",
         },
         "content-card--closed",
         "rounded--all",
         "bgColor--white",
       ])}
-      role="button"
-      tabIndex={0}
+      role={trigger === "header" ? "button" : undefined}
+      tabIndex={trigger === "header" ? 0 : undefined}
       onKeyUp={({ key }) => {
-        if (key === "Enter") onTitleContainerClick(isDisabled, "open");
+        if (key === "Enter" && trigger === "header")
+          onTitleContainerClick(isDisabled, "open");
       }}
       aria-expanded="false"
       aria-disabled={isDisabled ? "true" : "false"}
-      onClick={() => onTitleContainerClick(isDisabled, "open")}
+      onClick={() => {
+        if (trigger === "header") {
+          onTitleContainerClick(isDisabled, "open");
+        }
+      }}
     >
       {titleContainerJSX}
     </div>
@@ -154,6 +213,8 @@ CollapsibleCard.propTypes = {
   hasError: PropTypes.bool,
   /** Disable hover. Useful for cards that are always open */
   disableHover: PropTypes.bool,
+  /** Controls which element is used as the open/close trigger */
+  trigger: PropTypes.oneOf(["header", "caret-start", "caret-end"]),
 };
 
 export default CollapsibleCard;

--- a/src/CollapsibleCard/index.scss
+++ b/src/CollapsibleCard/index.scss
@@ -9,7 +9,6 @@
 }
 
 .collapsible-card-trigger {
-  font-size: rem(28px);
   height: 100%;
 }
 

--- a/src/CollapsibleCard/index.scss
+++ b/src/CollapsibleCard/index.scss
@@ -8,6 +8,11 @@
   border-radius: rem(8px);
 }
 
+.collapsible-card-trigger {
+  font-size: rem(28px);
+  height: 100%;
+}
+
 .collapsible-card--content-card.content-card--disabled {
   background-color: var(--bgColor-smokeGrey) !important;
   border: 1px solid var(--color-lightGrey) !important;
@@ -26,6 +31,10 @@
 .collapsible-card--content-card.content-card--closed:hover {
   border: 1px solid var(--theme-primary);
   cursor: pointer;
+}
+.collapsible-card--content-card.content-card--hasCaretTrigger.content-card--closed:hover {
+  border: 1px solid var(--color-lightGrey) !important;
+  cursor: unset !important;
 }
 .collapsible-card--title-container {
   display: flex;
@@ -54,4 +63,5 @@
 
 .collapsible-card--statusText {
   color: var(--color-mediumGrey);
+  height: 100%;
 }

--- a/src/CollapsibleCard/index.stories.js
+++ b/src/CollapsibleCard/index.stories.js
@@ -108,6 +108,21 @@ Overview.args = {
   ),
 };
 
+export const CaretAsTrigger = Template.bind({});
+CaretAsTrigger.args = {
+  title: "Your title here",
+  trigger: "caret-end",
+  subtitle:
+    "Only the caret opens the card. Start and End positions are both supported.",
+  onOpen: () => {},
+  onClose: () => {},
+  children: (
+    <>
+      <div>Any content can go in here!</div>
+    </>
+  ),
+};
+
 export const WithStatusText = ChangingHelperText.bind({});
 WithStatusText.args = {
   title: "Your title here",

--- a/src/IconButton/index.js
+++ b/src/IconButton/index.js
@@ -57,7 +57,7 @@ IconButton.propTypes = {
   /** type attribute for underlying HTML button element */
   type: PropTypes.string,
   /** Optional text size of the icon in the icon button defaults different for different kinds (plain/action)*/
-  textSize: PropTypes.oneOf(["xs", "s", "m", "l", "xl"]),
+  textSize: PropTypes.oneOf(["xs", "s", "m", "l"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
   /** Optional value for `data-testid` attribute */

--- a/src/IconButton/index.js
+++ b/src/IconButton/index.js
@@ -4,7 +4,7 @@ import cc from "classcat";
 import iconSelection from "src/icons/selection.json";
 
 export const VALID_ICON_NAMES = iconSelection.icons.map(
-  (icon) => icon.properties.name
+  (icon) => icon.properties.name,
 );
 
 /**
@@ -20,7 +20,7 @@ const IconButton = ({
   testId = "nds-icon-button",
   label,
   name,
-  onClick = () => { },
+  onClick = () => {},
   type,
 }) => {
   return (
@@ -57,7 +57,7 @@ IconButton.propTypes = {
   /** type attribute for underlying HTML button element */
   type: PropTypes.string,
   /** Optional text size of the icon in the icon button defaults different for different kinds (plain/action)*/
-  textSize: PropTypes.oneOf(["xs", "s", "m", "l"]),
+  textSize: PropTypes.oneOf(["xs", "s", "m", "l", "xl"]),
   /** Click callback, with event object passed as argument */
   onClick: PropTypes.func,
   /** Optional value for `data-testid` attribute */

--- a/src/IconButton/index.scss
+++ b/src/IconButton/index.scss
@@ -41,7 +41,6 @@
 }
 
 .nds-icon-button--plain {
-  font-size: --font-size;
   font-weight: var(--font-weight-semibold);
 
   &:hover {


### PR DESCRIPTION
Closes NDS-193

### CollapsibleCard
- refactor header to use `Row` layout
- add `trigger` prop to configure which part of the card acts as the open/close trigger
- prevent hover on entire card when in "caret" trigger mode

### IconButton
- Remove invalid rule from 'plain' variant