### PR TITLE
fix(Drawer): add classname to navigation icons in mobile drawer

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -176,15 +176,15 @@ const Drawer = ({
         <>
           {showControls && (
             <>
-              <div onClick={onPrev}>
+              <div className="mobile-navigation-button" onClick={onPrev}>
                 <span className="narmi-icon-chevron-left fontSize--heading3" />
               </div>
-              <div onClick={onNext}>
+              <div className="mobile-navigation-button" onClick={onNext}>
                 <span className="narmi-icon-chevron-right fontSize--heading3" />
               </div>
             </>
           )}
-          <div onClick={onUserDismiss}>
+          <div className="mobile-navigation-button" onClick={onUserDismiss}>
             <span className="narmi-icon-x clickable fontSize--heading3" />
           </div>
         </>

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -52,20 +52,22 @@ because we need to replace the left/right controls with controls that are inside
 */
 .drawer--vertical--mobile {
   padding: 48px var(--space-l);
-  .narmi-icon-x,
-  .narmi-icon-chevron-left,
-  .narmi-icon-chevron-right {
-    position: absolute;
-    top: var(--space-s);
-  }
-  .narmi-icon-x {
-    right: var(--space-s);
-  }
-  .narmi-icon-chevron-left {
-    left: var(--space-s);
-  }
-  .narmi-icon-chevron-right {
-    left: 45px;
+  .mobile-navigation-button {
+    .narmi-icon-x,
+    .narmi-icon-chevron-left,
+    .narmi-icon-chevron-right {
+      position: absolute;
+      top: var(--space-s);
+    }
+    .narmi-icon-x {
+      right: var(--space-s);
+    }
+    .narmi-icon-chevron-left {
+      left: var(--space-s);
+    }
+    .narmi-icon-chevron-right {
+      left: 45px;
+    }
   }
 }
 


### PR DESCRIPTION
resolves BANKW-821

- `X`, `chevron-left` and `chevron-right` icons under `drawer--vertical--mobile` were being affected by styles meant specifically for the navigation icon buttons
- added a classname `mobile-navigation-button` to the navigation icon's parent in order to make the styles more targeted 
- this is also consistent with how the navigation icons exist in non-mobile view where the parent has a `navigation-button` classname