### PR TITLE
feat(TextInput): allow component to control native HTML 'required' attribute

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -88,7 +88,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
             value={inputValue}
             onChange={_onChange}
             onBlur={_onBlur}
-            required
+            required={props.required}
             placeholder={props.label}
             aria-label={props.label}
             data-testid={testId}
@@ -104,7 +104,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
           onBlur={_onBlur}
           ref={forwardedRef}
           type={type}
-          required
+          required={props.required}
           aria-label={props.label}
           placeholder={props.label}
           data-testid={testId}
@@ -157,11 +157,14 @@ TextInput.propTypes = {
     "time",
     "datetime-local",
   ]),
+  /** Native element prop passed to the underlying input/textarea element. Defaults to true. */
+  required: PropTypes.bool,
 };
 
 TextInput.defaultProps = {
   multiline: false,
   formatter: (x) => x,
+  required: true,
 };
 
 export default TextInput;


### PR DESCRIPTION
Previously, the `input` underlying the `TextInput` component was always set to `required`.

This led to unexpected browser behavior such as this pop-up for a field that wasn't actually required:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/6e3880a2-7ffc-4c96-9d5d-141adbeab1c2">

This PR preserves the existing behavior -- defaulting the input to be required -- while allowing individual `TextInput` instances to override it as needed.