### PR TITLE
fix(Select): fix text size for Select error

### DIFF
--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import Error from "../Error";
 
 /**
  * Generic trigger button for dropdowns. `DropdownTrigger` can be composed with
@@ -71,14 +72,7 @@ const DropdownTrigger = React.forwardRef(
             )}
           </button>
         </div>
-        {errorText && (
-          <div className="nds-dropdownTrigger-error fontColor--error">
-            <span role="img" className="narmi-icon-x-circle fontSize--s" />
-            <span className="padding--left--xxs fontColor--error fontSize--xs">
-              {errorText}
-            </span>
-          </div>
-        )}
+        <Error error={errorText} />
       </>
     );
   },

--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -77,10 +77,3 @@
     z-index: 4;
   }
 }
-
-.nds-dropdownTrigger-error {
-  .narmi-icon-x-circle::before {
-    position: relative;
-    top: rem(1px);
-  }
-}

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -53,7 +53,6 @@
   .nds-input-subline {
     font-size: var(--font-size-s);
     color: var(--color-mediumGrey);
-    margin-top: rem(4px);
     display: flex;
     justify-content: space-between;
     flex-direction: row-reverse;


### PR DESCRIPTION
close https://github.com/narmi/design_system/issues/1309

Hard to tell from this screenshot, but the error text for the `Select` component is now consistent with other input components (namely, `TextInput`)

I've also noticed that `TextInput` has more space between the input field and the error message - this is caused by the recent addition of the character counter. I think we're better off without that space, so I've removed it


![image](https://github.com/user-attachments/assets/de0389b6-3d20-43fa-9f61-1d474cd8afde)

<br />

![image](https://github.com/user-attachments/assets/3890ee03-2fa0-412e-9bcc-33e4dbbfb0df)
