### PR TITLE
fix(Combobox, Select): color both input and dropdown borders on error

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -404,7 +404,7 @@ const Combobox = ({
             {...getMenuProps(layerProps)}
             style={{
               width: triggerBounds?.width || "auto",
-              transform: `translateY(${layerSide === "top" ? "0px" : "-22px"})`,
+              transform: `${errorText ? `translateY(${layerSide === "top" ? "0px" : "-22px"} )` : "none"}`,
               ...layerProps.style,
             }}
           >

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -398,6 +398,7 @@ const Combobox = ({
                   isOpen && displayedItems.length > 0,
                 "nds-combobox-list--bottom": layerSide === "bottom",
                 "nds-combobox-list--top": layerSide === "top",
+                "nds-combobox-list--error": !!errorText,
               },
             ])}
             {...getMenuProps(layerProps)}

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -8,7 +8,6 @@ import ComboboxItem from "./ComboboxItem";
 import ComboboxHeading from "./ComboboxHeading";
 import ComboboxCategory from "./ComboboxCategory";
 import TextInput from "../TextInput";
-import Error from "../Error";
 import { getItemIndex } from "../Select";
 
 const noop = () => {};

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -359,6 +359,7 @@ const Combobox = ({
         data-testid={testId}
       >
         <TextInput
+          error={errorText}
           label={label}
           value={inputValue}
           startIcon={icon}
@@ -403,6 +404,7 @@ const Combobox = ({
             {...getMenuProps(layerProps)}
             style={{
               width: triggerBounds?.width || "auto",
+              transform: `translateY(${layerSide === "top" ? "0px" : "-22px"})`,
               ...layerProps.style,
             }}
           >
@@ -413,7 +415,6 @@ const Combobox = ({
           </ul>,
         )}
       </div>
-      <Error error={errorText} />
     </>
   );
 };

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -13,6 +13,10 @@
   max-height: 40vh;
   overflow-y: scroll;
   z-index: 4;
+  
+  &--error {
+    border: 1px solid var(--color-errorDark);
+  }
 
   &--bottom {
     border-top: 1px solid var(--border-color-default);

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -271,6 +271,7 @@ const Select = ({
               "rounded--bottom": layerSide === "bottom",
               "rounded--top": layerSide === "top",
               [`nds-select-list--active--${layerSide}`]: showMenu,
+              "nds-select-list--error": !!errorText
             },
           ])}
           {...getMenuProps(layerProps)}

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -6,10 +6,14 @@
   &:focus {
     outline: none;
   }
-
+  
   &--active--top,
   &--active--bottom {
     border: 1px solid var(--theme-primary);
+  }
+  
+  &--error {
+    border: 1px solid var(--color-errorDark);
   }
 
   &--active--top {


### PR DESCRIPTION
I noticed that if you supply an `errorText` prop to a Combobox with children, the error highlighting doesn't apply to the border of the input.

![image](https://github.com/user-attachments/assets/517121d2-e00a-4287-9e2b-6f1a4a67b80e)

This is different from the behavior for Select, for example:

![image](https://github.com/user-attachments/assets/bc5c78fa-be5d-4f1e-8a74-ca0b82738b32)

As of this PR, the red border will apply to both the input and dropdown borders for both Combobox and Select:


![image](https://github.com/user-attachments/assets/729a7ce6-2bfa-45d9-a225-426bea08659f)

![image](https://github.com/user-attachments/assets/f997c524-3d6d-4d93-839d-2ee2a7fdef21)

![image](https://github.com/user-attachments/assets/2c1ea9eb-bf68-4de7-8f80-1e23ba3db7e5)


I somewhat blindly followed some existing patterns, e.g.

https://github.com/narmi/design_system/blob/e75a10a84b6fd9f9d4296d0450f749d206f78f53/src/Select/index.js#L277-L281

and

https://github.com/narmi/design_system/blob/a468bba33e847a01f07b79197ef2f3b82bf42ce3/src/Combobox/index.js#L256-L262

I'm open to suggestions for other ways of doing this