### PR TITLE
feat(Checkbox): add condensed Checkbox

### DIFF
--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -164,7 +164,7 @@ Checkbox.propTypes = {
   /**
    * `normal` - visually matches a checkbox input
    *
-   * `condensed` - like `normal`, but without added top margin
+   * `condensed` - like `normal`, but without added top margin when there are multiple checkboxes
    * 
    * `card` - visually present as a toggleable card
    */

--- a/src/Checkbox/index.js
+++ b/src/Checkbox/index.js
@@ -162,11 +162,13 @@ Checkbox.propTypes = {
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
   /**
-   * `normal` - visually matche a checkbox input
+   * `normal` - visually matches a checkbox input
    *
+   * `condensed` - like `normal`, but without added top margin
+   * 
    * `card` - visually present as a toggleable card
    */
-  kind: PropTypes.oneOf(["normal", "card", "table"]),
+  kind: PropTypes.oneOf(["normal", "condensed", "card", "table"]),
 };
 
 export default Checkbox;

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -33,6 +33,7 @@
 * kind="normal|table"
 */
 .nds-checkbox--normal,
+.nds-checkbox--condensed,
 .nds-checkbox--table {
   display: flex;
   width: fit-content;

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -29,12 +29,12 @@ FullyControlled.parameters = {
   },
 };
 
-export const MultipleCheckboxes = () => (
+export const MultipleCheckboxes = (args) => (
   <>
     <h3 className="margin--bottom">Permissions</h3>
-    <Checkbox label="See statements and documents" name="view" />
-    <Checkbox label="Make deposits" name="deposit" />
-    <Checkbox label="Make withdraws" name="widthdraw" />
+    <Checkbox label="See statements and documents" name="view" {...args} />
+    <Checkbox label="Make deposits" name="deposit" {...args} />
+    <Checkbox label="Make withdrawals" name="withdrawal" {...args} />
   </>
 );
 


### PR DESCRIPTION
Top margin was added to normal checkboxes that are subsequent siblings to normal checkboxes in https://github.com/narmi/design_system/pull/1089/files#diff-cfd872c173d6e6389363869af77b48becfc03fed480f697ec12eee4faea06f6aR7-R10

This results in spacing that is too large for our "filter chip" dropdowns, so we have to use custom styling to fend off the extra margin.

What we want:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/7ba97817-93e4-4d91-abd7-c4c97d54578a">

What we get with the default:
<img width="390" alt="image" src="https://github.com/user-attachments/assets/071b3f36-c634-4efd-aab9-eeadd0920b4c">

To preserve backwards compatibility, I've added a new "condensed" kind that is like "normal", but without the extra top margin when there are multiple checkboxes. In my heart of hearts, I think the "normal" margin should be the one that changes, but I don't want to break anything.

Here's the Storybook in action:

https://github.com/user-attachments/assets/82909764-6ac9-4c18-be2f-fe3fb5158745

