### PR TITLE
feat(Combobox): allow custom end content

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -121,6 +121,7 @@ const Combobox = ({
   errorText,
   icon,
   testId,
+  inputEndContent,
 }) => {
   const allChildren = React.Children.toArray(children);
   const hasCategories = allChildren.some(
@@ -363,11 +364,12 @@ const Combobox = ({
           value={inputValue}
           startIcon={icon}
           endContent={
+            inputEndContent === undefined ? (
             <span
               className={`fontSize--l fontColor--primary narmi-icon-${
                 isOpen ? "chevron-up" : "chevron-down"
               }`}
-            />
+            />) : inputEndContent
           }
           {...getInputProps({
             onFocus: () => {
@@ -455,6 +457,10 @@ Combobox.propTypes = {
   icon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
+  /** Content to render at the end of the input. By default, a chevron that indicates whether
+   * the dropdown is open or closed.
+   */
+  inputEndContent: PropTypes.node,
 };
 
 Combobox.Item = ComboboxItem;

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -100,6 +100,20 @@ export const defaultFilterItemsByInput = (items, inputValue) =>
     return query.toLowerCase().startsWith(inputValue);
   });
 
+
+/**
+ * 
+ * @param {Boolean} isOpen whether the combobox is open
+ * @returns {React.ReactNode} chevron icon that toggles based on the open state of the combobox
+ */
+export const defaultRenderEndContent = (isOpen) => (
+  <span
+    className={`fontSize--l fontColor--primary narmi-icon-${
+      isOpen ? "chevron-up" : "chevron-down"
+    }`}
+  />
+);
+
 /**
  * Autocomplete input component following the accessible
  * [ARIA combobox pattern](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role).
@@ -121,7 +135,7 @@ const Combobox = ({
   errorText,
   icon,
   testId,
-  renderEndContent,
+  renderEndContent = defaultRenderEndContent,
 }) => {
   const allChildren = React.Children.toArray(children);
   const hasCategories = allChildren.some(
@@ -326,17 +340,6 @@ const Combobox = ({
     ) : null;
   };
 
-  // by default, render up/down chevron icon controlled by open state
-  renderEndContent = renderEndContent === undefined ? (
-    (isOpen) => (
-      <span
-        className={`fontSize--l fontColor--primary narmi-icon-${
-          isOpen ? "chevron-up" : "chevron-down"
-        }`}
-      />
-    )
-  ) : renderEndContent;
-
   const handleMenuToggle = () => {
     if (!isOpen) {
       // Reset filtered items every time user refocuses.
@@ -463,7 +466,8 @@ Combobox.propTypes = {
   testId: PropTypes.string,
   /** Function to render content at the end of the input.
    * Defaults to a function that renders a chevron icon that toggles based on the open state of the combobox.
-   * Function signature: `(isOpen) => React.ReactNode`
+   * 
+   * Signature: `(isOpen) => React.ReactNode`
    */
   renderEndContent: PropTypes.func,
 };

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -121,7 +121,7 @@ const Combobox = ({
   errorText,
   icon,
   testId,
-  inputEndContent,
+  renderEndContent,
 }) => {
   const allChildren = React.Children.toArray(children);
   const hasCategories = allChildren.some(
@@ -326,6 +326,17 @@ const Combobox = ({
     ) : null;
   };
 
+  // by default, render up/down chevron icon controlled by open state
+  renderEndContent = renderEndContent === undefined ? (
+    (isOpen) => (
+      <span
+        className={`fontSize--l fontColor--primary narmi-icon-${
+          isOpen ? "chevron-up" : "chevron-down"
+        }`}
+      />
+    )
+  ) : renderEndContent;
+
   const handleMenuToggle = () => {
     if (!isOpen) {
       // Reset filtered items every time user refocuses.
@@ -363,14 +374,7 @@ const Combobox = ({
           label={label}
           value={inputValue}
           startIcon={icon}
-          endContent={
-            inputEndContent === undefined ? (
-            <span
-              className={`fontSize--l fontColor--primary narmi-icon-${
-                isOpen ? "chevron-up" : "chevron-down"
-              }`}
-            />) : inputEndContent
-          }
+          endContent={renderEndContent(isOpen)}
           {...getInputProps({
             onFocus: () => {
               if (hasSelectedItem) {
@@ -457,10 +461,11 @@ Combobox.propTypes = {
   icon: PropTypes.oneOf(VALID_ICON_NAMES),
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
-  /** Content to render at the end of the input. By default, a chevron that indicates whether
-   * the dropdown is open or closed.
+  /** Function to render content at the end of the input.
+   * Defaults to a function that renders a chevron icon that toggles based on the open state of the combobox.
+   * Function signature: `(isOpen) => React.ReactNode`
    */
-  inputEndContent: PropTypes.node,
+  renderEndContent: PropTypes.func,
 };
 
 Combobox.Item = ComboboxItem;


### PR DESCRIPTION
Design would like to have a Combobox that doesn't have a up/down chevron indicating whether the Combobox is open/closed.

To address that in a more extensible way, I propose letting the consumer supply a `renderEndContent` function that receives an `isOpen` prop.

<img width="983" alt="image" src="https://github.com/user-attachments/assets/e966cf2f-6e3d-4f04-b3ce-30096afa0dd8">
