### PR TITLE
chore(*): fix typos in comments and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-component-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-component-issue.md
@@ -10,7 +10,7 @@ labels: New Component,UI-Platform
 
 ### Mockup
 
-<!-- insert relevant screenshots or figma/zerohieght links -->
+<!-- insert relevant screenshots or figma/zeroheight links -->
 
 ### Responsibilities
 <!-- what are the functional boundaries of this component? -->

--- a/.github/ISSUE_TEMPLATE/other-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/other-issue-template.md
@@ -1,6 +1,6 @@
 ---
 name: Other
-about: Generial issue template
+about: General issue template
 title: ""
 labels: UI-Platform
 ---

--- a/.storybook/helpers/ClassExample.jsx
+++ b/.storybook/helpers/ClassExample.jsx
@@ -4,10 +4,10 @@ import Row from "../../src/Row";
 
 /**
  * Component used in helper-classes stories to render
- * an interactive exmaple.
+ * an interactive example.
  *
  * A category from the class manifest is passed in to generate
- * options and show a preivew.
+ * options and show a preview.
  */
 
 const ClassSelector = ({ baseName, classCategory, onChange = () => {} }) => {
@@ -92,7 +92,7 @@ ClassExample.propTypes = {
   signature: PropTypes.string.isRequired,
   /**
    * A single child to render as a preview.
-   * The strigified className from the selector will
+   * The stringified className from the selector will
    * be applied to this element.
    */
   children: PropTypes.node.isRequired,
@@ -106,7 +106,7 @@ ClassExample.propTypes = {
       base: PropTypes.string.isRequired,
       variant1: PropTypes.string.isRequired,
       variant2: PropTypes.string,
-    })
+    }),
   ),
   /** optionally hides debug border from example */
   hideBorder: PropTypes.bool,

--- a/.storybook/helpers/TokenTable.jsx
+++ b/.storybook/helpers/TokenTable.jsx
@@ -4,7 +4,7 @@ import cc from "classcat";
 import { useClipboard } from "use-clipboard-copy";
 
 /**
- * rendereers responsible for showing token previews
+ * renderers responsible for showing token previews
  */
 const previewRenderers = {
   color: (value) => (
@@ -81,15 +81,15 @@ const CopyableCell = ({ text }) => {
 };
 
 /**
- * Displays token doucumentation table
+ * Displays token documentation table
  */
 const TokenTable = ({ rows, previewType }) => (
   <table className="docs-tokenTable">
     <thead>
       <tr>
         {Boolean(previewType) && <th>Preview</th>}
-        <th scope="coloumn">CSS</th>
-        <th scope="coloumn">Value</th>
+        <th scope="column">CSS</th>
+        <th scope="column">Value</th>
       </tr>
     </thead>
     <tbody>
@@ -115,7 +115,7 @@ TokenTable.propTypes = {
     PropTypes.shape({
       name: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
-    })
+    }),
   ).isRequired,
   previewType: PropTypes.oneOf(Object.keys(previewRenderers)),
 };

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -11,7 +11,7 @@
     color: #66a2d6 !important; /* cove 600 */
   }
 
-  /* item icons (teaking for Mulish cap height) */
+  /* item icons (tweaking for Mulish cap height) */
   .sidebar-item svg {
     margin-top: 2px;
   }

--- a/.storybook/theme/narmi.js
+++ b/.storybook/theme/narmi.js
@@ -15,14 +15,14 @@ const shared = {
 };
 
 /**
- * Thmes the contents of the docs area
+ * Themes the contents of the docs area
  */
 export const docs = create({
   ...shared,
 });
 
 /**
- * Thmes the Storybook UI (sidebar, toolbars, etc)
+ * Themes the Storybook UI (sidebar, toolbars, etc)
  */
 export const ui = create({
   ...shared,

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For full documentation of available classes, see [storybook docs](https://narmi.
 ### Design tokens
 
 All available distributions of design tokens can be found in `dist/tokens`.
-All CSS custom properites from design tokens are already included in the base
+All CSS custom properties from design tokens are already included in the base
 stylesheet, `dist/style.css`.
 
 To request a new distribution, please [file an issue](https://github.com/narmi/design_system/issues/new/choose).
@@ -94,7 +94,7 @@ npm run dev
 | `build:jsdoc`      | builds jsDoc documentation to `dist/`                |
 | `build:tokens`     | builds all distributions of design tokens to `dist/` |
 | `build:components` | builds all components and base stylesheet to `dist/` |
-| `build`            | builds everytyhing                                   |
+| `build`            | builds everything                                    |
 | `test`             | runs all jest tests                                  |
 | `storybook`        | starts storybook in dev server mode on `:6006`       |
 | `watch`            | watches `src` dir, triggering `build` on changes     |
@@ -112,7 +112,7 @@ parse recent git tags and commit messages to determine the new version number, t
 
 #### Major releases
 
-All PRs target `main` unless it contains breaking changes. Any branch continaing breaking change commits should target the open major release branch.
+All PRs target `main` unless it contains breaking changes. Any branch containing breaking change commits should target the open major release branch.
 For example, if NDS is on major version `1`, breaking changes should target the branch `major/v2`.
 
 Branches containing breaking change commits should follow the naming convention `breaking/<branch name>`.

--- a/contributing/naming-conventions.md
+++ b/contributing/naming-conventions.md
@@ -54,7 +54,7 @@ Props that accept more than one thing should be pluralized:
 
 ## CSS
 
-We use BEM-like naming conventions in Narmi Design System. Single hyphens refere to a parent-child relationship. Double hyphens refer to a variant/modifier.
+We use BEM-like naming conventions in Narmi Design System. Single hyphens refer to a parent-child relationship. Double hyphens refer to a variant/modifier.
 
 ```css
 /* <base> */
@@ -65,11 +65,11 @@ We use BEM-like naming conventions in Narmi Design System. Single hyphens refere
 .dialog-content {
 }
 
-/* <base>--<modifer> */
+/* <base>--<modifier> */
 .dialog--extraWide {
 }
 
-/* <base>--<modifer>--<modifier> */
+/* <base>--<modifier>--<modifier> */
 .alignChild--left--center {
 }
 ```

--- a/contributing/principles.md
+++ b/contributing/principles.md
@@ -2,7 +2,7 @@
 
 ## 1) Build Narmi
 
-**Namri Design System is not a general purpose UI framework.**
+**Narmi Design System is not a general purpose UI framework.**
 
 Because the goal of this design system is to match the look and feel of Narmi applications, components
 may not be as flexible or configurable as they might be in other frameworks. This is by design.

--- a/scripts/class-adoption.mjs
+++ b/scripts/class-adoption.mjs
@@ -15,8 +15,8 @@ const TARGET_DIR = process.argv[2];
 const CLASSES = getHelperClassNames();
 
 /**
- * Prints a table of total casses found in target project and a count for each class
- * @param {Object} countMap className keys to occurance count values
+ * Prints a table of total classes found in target project and a count for each class
+ * @param {Object} countMap className keys to occurrence count values
  */
 const printResults = (countMap) => {
   const ansi = { bold: "\x1b[1m", reset: "\x1b[0m" };
@@ -63,7 +63,7 @@ glob(`${resolve(TARGET_DIR)}/**/*.+(js|jsx)`, { ignore }, (error, files) => {
     .map((path) => readFileSync(path).toString())
     .reduce((acc, curr) => {
       // check each file for matches on every available helper class
-      // if matches exist, increment totals key by occurrance count
+      // if matches exist, increment totals key by occurrence count
       CLASSES.forEach((className) => {
         acc[className] = acc[className] + getNumMatches(curr, className);
       });

--- a/scripts/util/getHelperClassNames.mjs
+++ b/scripts/util/getHelperClassNames.mjs
@@ -8,7 +8,7 @@ import { parse } from "css";
  * @returns {Array} full list of helper class strings from NDS
  */
 const getHelperClassNames = () => {
-  // join all scss files in `helper-classes` insto a single scss string
+  // join all scss files in `helper-classes` into a single scss string
   const sassString = glob
     .sync(`${resolve(process.cwd(), "src/helper-classes")}/*.scss`)
     .map((file) => readFileSync(file).toString())

--- a/src/Alert/index.jsx
+++ b/src/Alert/index.jsx
@@ -6,7 +6,7 @@ import Row from "../Row";
 const noop = () => {};
 
 /**
- * Inline system message, for a sepcific region of a page.
+ * Inline system message, for a specific region of a page.
  * The `isActive` prop is used to hide and show the Alert to ensure the Alert
  * is always rendered in an [ARIA live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
  * for accessibility.

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -1,5 +1,5 @@
 // only apply top spacing to a checkbox container
-// that is preceeded by another checkbox container
+// that is preceded by another checkbox container
 .nds-checkbox-container ~ .nds-checkbox-container {
   padding-top: var(--space-s);
 }

--- a/src/CollapsibleCard/index.js
+++ b/src/CollapsibleCard/index.js
@@ -207,7 +207,7 @@ CollapsibleCard.propTypes = {
   onClose: PropTypes.func,
   /** Disabled cards are greyed out and do not open */
   isDisabled: PropTypes.bool,
-  /** Callback to handle user clickling on disabled card */
+  /** Callback to handle user clicking on disabled card */
   onDisabledClick: PropTypes.func,
   /** Displays a red border on the card. Does not interfere with user interactions */
   hasError: PropTypes.bool,

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -34,7 +34,7 @@ export const isSelectable = (component) => {
  * @param {Number} highlightedIndex index of highlighted item from downshift
  * @param {Array} displayedItems list of all items currently displayed
  * @param {Array} categoryChildren list of items in category
- * @returns {Boolean} if the category should be fored open
+ * @returns {Boolean} if the category should be forced open
  */
 export const shouldOpenCategory = (
   inputValue,
@@ -196,7 +196,7 @@ const Combobox = ({
       const { type, changes } = actionAndChanges;
       let inputValue = changes.inputValue;
 
-      // if there's already a selected item when the user revisists the input,
+      // if there's already a selected item when the user revisits the input,
       // wipe away the old input value so they can start typing right away.
       // (selection is preserved until user picks another item)
       if (
@@ -338,7 +338,7 @@ const Combobox = ({
 
   // It is possible that a consumer may have nothing to pass to `children`.
   // For example, if an API response hasn't completed to load in the autocomplete
-  // options. In that case, Cobmobox should render a normal TextInput.
+  // options. In that case, Combobox should render a normal TextInput.
   if (items.length < 1) {
     return (
       <TextInput

--- a/src/DateInput/index.scss
+++ b/src/DateInput/index.scss
@@ -90,8 +90,8 @@ body {
   }
 
   /**
-  * Border management - overrides flatpicker nth-child border styles.
-  * The uncessary left border on the Sunday days are masked by the .dayContainer element
+  * Border management - overrides Flatpickr nth-child border styles.
+  * The unnecessary left border on the Sunday days are masked by the .dayContainer element
   */
   .dayContainer {
     overflow: hidden;

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -36,7 +36,7 @@ AltInput.parameters = {
   docs: {
     description: {
       story:
-        "The `altInput` prop will make the input show a date in an alternat format defined by `altFormat`. See [flatpickr docs](https://flatpickr.js.org/formatting/) for formatting options.",
+        "The `altInput` prop will make the input show a date in an alternate format defined by `altFormat`. See [flatpickr docs](https://flatpickr.js.org/formatting/) for formatting options.",
     },
   },
 };

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -45,7 +45,7 @@
   flex-wrap: nowrap;
 
   // the modal dialog takes over the whole screen by default
-  // (small veiwports)
+  // (small viewports)
   height: 100vh; // fall back to 100vh for older mobile browsers
   height: 100dvh; // prevents toolbar overlap in modern mobile browsers
   width: 100vw;

--- a/src/DropdownTrigger/index.js
+++ b/src/DropdownTrigger/index.js
@@ -93,10 +93,10 @@ DropdownTrigger.propTypes = {
    * Usually, this represents the name of a selected option
    */
   displayValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** Error message. When this prop is passed, an error state is dsiplayed */
+  /** Error message. When this prop is passed, an error state is displayed */
   errorText: PropTypes.string,
   /**
-   * Sets a mimimum width.
+   * Sets a minimum width.
    * Use the full CSS value with the unit (e.g. "400px")
    */
   minWidth: PropTypes.string,

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -1,5 +1,5 @@
 // Sass placeholder for styles shared between
-// `textarea` and the psuedo-element that enables CSS auto growing
+// `textarea` and the pseudo-element that enables CSS auto growing
 %shared-multiline-styles {
   line-height: 1.2;
   vertical-align: middle;
@@ -195,7 +195,7 @@ textarea::autofill {
     @extend %shared-multiline-styles;
   }
 
-  // The growth of the psuedo-element will expand the grid container.
+  // The growth of the pseudo-element will expand the grid container.
   // The textarea will grow with it, as it is placed over the entire grid area
   &::after,
   & > textarea {

--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -18,7 +18,7 @@ const itemToString = (item) =>
   !item?.props ? "" : item.props.searchValue || item.props.value;
 
 /**
- * Check an item component against the tokens list to see if it's currentlly selected
+ * Check an item component against the tokens list to see if it's currently selected
  */
 const isSelected = (selectedItems, item) =>
   selectedItems.map(itemToString).includes(itemToString(item));

--- a/src/MultiSelect/index.stories.js
+++ b/src/MultiSelect/index.stories.js
@@ -42,7 +42,7 @@ ErrorState.args = {
   label: "Account",
   children: [
     <MultiSelect.Item value="checking1234">Checking (1234)</MultiSelect.Item>,
-    <MultiSelect.Item value="checkint4321">Checking (4321)</MultiSelect.Item>,
+    <MultiSelect.Item value="checking4321">Checking (4321)</MultiSelect.Item>,
   ],
   errorText: "Required",
 };

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -65,7 +65,7 @@ export const _getAttributes = (
  * The component will handle which page numbers to render, next and previous arrows,
  * and conditionally rendering first and last pages.
  *
- * If your pagination setup expectes a fully controlled component, you may set `defaultSelectedPage` on every `onPageChange` call.
+ * If your pagination setup expects a fully controlled component, you may set `defaultSelectedPage` on every `onPageChange` call.
  */
 const Pagination = ({
   onPageChange = noop,

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -135,7 +135,7 @@ Popover.propTypes = {
   children: PropTypes.node.isRequired,
   /** Content of popover */
   content: PropTypes.node.isRequired,
-  /** Sets prefferred side of the trigger the tooltip should appear */
+  /** Sets preferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
   /** Sets preferred alignment of the tooltip relative to the trigger */
   alignment: PropTypes.oneOf(["start", "center", "end"]),

--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -141,7 +141,7 @@ RadioButtons.propTypes = {
   /**
    * selected option by input value (fully controlled)
    * When passing a `value` prop, you must use the `onChange`
-   * hanlder to update the `value`
+   * handler to update the `value`
    */
   value: PropTypes.string,
   /** change callback invoked with input value */

--- a/src/ResponsiveFlex/index.test.js
+++ b/src/ResponsiveFlex/index.test.js
@@ -1,7 +1,7 @@
 import { getFlexDirection } from "./index";
 
 describe("ResponsiveFlex: getFlexDirection", () => {
-  describe("Handles direction change correcly", () => {
+  describe("Handles direction change correctly", () => {
     const props = {
       direction: "column",
       toColumnAt: undefined,

--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -5,7 +5,7 @@ import AsElement from "../util/AsElement";
 
 /**
  * Child component of `Row`.
- * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
+ * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
  */
 const RowItem = ({ shrink = false, as = "div", children, testId }) => (
   <AsElement

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -23,7 +23,7 @@ const _getRowStyle = (alignItems, justifyContent, gapSize) => {
  * Basic flexbox helper that arranges content into a non-wrapping row.
  * `Row` will grow to fill the width of its parent container.
  * Items of `Row` will grow to fit remaining space by default.
- * When a `Row.Item` has a boolean prop of `shrink`, it will shirnk to content width.
+ * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
  */
 const Row = ({
   alignItems = "top",

--- a/src/Row/index.stories.js
+++ b/src/Row/index.stories.js
@@ -42,7 +42,7 @@ export const DebugView = () => (
   `,
       }}
     />
-    <div className="sb-nds-row-debug nds-typogrpahy fontSize--s">
+    <div className="sb-nds-row-debug nds-typography fontSize--s">
       <Row>
         <Row.Item shrink>
           <code>Row.Item shrink</code>

--- a/src/Row/index.test.js
+++ b/src/Row/index.test.js
@@ -15,7 +15,7 @@ describe("Row", () => {
     expect(container.firstChild).toHaveStyle("align-items: center");
   });
 
-  it("has correct override styles for 'end' justificiation", () => {
+  it("has correct override styles for 'end' justification", () => {
     const { container } = render(<Row justifyContent="end" />);
     expect(container.firstChild).toHaveStyle("justify-content: flex-end");
   });

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -41,15 +41,15 @@ export const getSelectedItemDisplay = (item) => {
 /**
  * @param {String} value `value` of the Select.Item to get
  * @param {Array} items Select.Item nodes
- * @returns {ReactElement|String} the Select.Item elemenet found or an empty string
+ * @returns {ReactElement|String} the Select.Item element found or an empty string
  */
 export const getItemByValue = (value, items) => {
-  const founditem = items
+  const foundItem = items
     .filter((item) => !isAction(item)) // action items are not selectable
     .filter(({ props }) => props.value === value)
     .pop();
 
-  return founditem || "";
+  return foundItem || "";
 };
 
 /**
@@ -82,7 +82,7 @@ export const isHighlightedInCategory = (
 /**
  * @param {Object} selectedItem
  * @param {Array} categoryChildren child items in a given category
- * @returns {Boolean} if the selected item is in the given cagetory children
+ * @returns {Boolean} if the selected item is in the given category children
  */
 export const isSelectedItemInCategory = (selectedItem, categoryChildren) => {
   if (!selectedItem) return false;
@@ -180,7 +180,7 @@ const Select = ({
   };
 
   // When `value` prop is passed, the Select becomes fully controlled and the
-  // selected item is set programmitically by the consumer only
+  // selected item is set programmatically by the consumer only
   if (value !== undefined) {
     downshiftOpts.selectedItem = getItemByValue(value, items);
   }

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -53,7 +53,7 @@ ErrorState.args = {
   label: "Account",
   children: [
     <Select.Item value="checking1234">Checking (1234)</Select.Item>,
-    <Select.Item value="checkint4321">Checking (4321)</Select.Item>,
+    <Select.Item value="checking4321">Checking (4321)</Select.Item>,
   ],
   defaultValue: "checking1234",
   errorText: "Checking (1234) is not eligible",
@@ -145,7 +145,7 @@ CustomTypeahead.parameters = {
   docs: {
     description: {
       story:
-        "By default, typeahead highlights items based on `value`. You may pass a `searchValue` to customize the string users search against when using typeahead. In this example, the value is a numeric code, but we'd like the user to filter on industry namej",
+        "By default, typeahead highlights items based on `value`. You may pass a `searchValue` to customize the string users search against when using typeahead. In this example, the value is a numeric code, but we'd like the user to filter on industry name",
     },
   },
 };

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useNumberFormatter, useSlider, VisuallyHidden } from "react-aria";
-import { useSliderState } from "react-stately";
+import { useSliderState } from 'react-stately';
 import Thumbs from "./Thumbs";
 
 export interface Props {
@@ -13,7 +13,7 @@ export interface Props {
   /** value of the input */
   value?: number[];
   /** change callback invoked when the value of the `input` changes */
-  onChange?: (value: number[]) => void;
+  onChange?: (value: number[]) => void
   /** optionally format the input value */
   formatOptions?: Intl.NumberFormatOptions;
   /** lower bound for the input, inclusive */
@@ -35,33 +35,33 @@ const Slider = (props: Props) => {
 
   const numberFormatter = useNumberFormatter(props.formatOptions);
   const state = useSliderState({ ...props, numberFormatter });
-  const { groupProps, trackProps, labelProps, outputProps } = useSlider(
-    props,
-    state,
-    trackRef,
-  );
+  const {
+    groupProps,
+    trackProps,
+    labelProps,
+    outputProps
+  } = useSlider(props, state, trackRef);
 
   return (
     <div {...groupProps} className="nds-slider">
-      {props.label && (
-        <VisuallyHidden>
-          <label {...labelProps}>{props.label}</label>
-        </VisuallyHidden>
-      )}
+      {props.label &&
+        (
+          <VisuallyHidden>
+            <label {...labelProps}>{props.label}</label>
+          </VisuallyHidden>
+        )}
       <div className="output-container">
         <output {...outputProps}>
-          {props.output ||
-            `Between ${state.getThumbValueLabel(0)} and ${state.getThumbValueLabel(1)}`}
+          {props.output || `Between ${state.getThumbValueLabel(0)} and ${state.getThumbValueLabel(1)}`}
         </output>
       </div>
-      <div {...trackProps} ref={trackRef} className="track">
+      <div
+        {...trackProps}
+        ref={trackRef}
+        className="track"
+      >
         <div className="rail" />
-        <Thumbs
-          state={state}
-          trackRef={trackRef}
-          lowerName={props.lowerName}
-          higherName={props.higherName}
-        />
+        <Thumbs state={state} trackRef={trackRef} lowerName={props.lowerName} higherName={props.higherName} />
       </div>
     </div>
   );

--- a/src/Slider/index.tsx
+++ b/src/Slider/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { useNumberFormatter, useSlider, VisuallyHidden } from "react-aria";
-import { useSliderState } from 'react-stately';
+import { useSliderState } from "react-stately";
 import Thumbs from "./Thumbs";
 
 export interface Props {
@@ -13,14 +13,14 @@ export interface Props {
   /** value of the input */
   value?: number[];
   /** change callback invoked when the value of the `input` changes */
-  onChange?: (value: number[]) => void
+  onChange?: (value: number[]) => void;
   /** optionally format the input value */
   formatOptions?: Intl.NumberFormatOptions;
   /** lower bound for the input, inclusive */
   minValue?: number;
   /** upper bound for the input, inclusive */
   maxValue?: number;
-  /** if uncontrolled, intial value for the input */
+  /** if uncontrolled, initial value for the input */
   defaultValue?: number[];
   /** increment number for the range input */
   step?: number;
@@ -35,33 +35,33 @@ const Slider = (props: Props) => {
 
   const numberFormatter = useNumberFormatter(props.formatOptions);
   const state = useSliderState({ ...props, numberFormatter });
-  const {
-    groupProps,
-    trackProps,
-    labelProps,
-    outputProps
-  } = useSlider(props, state, trackRef);
+  const { groupProps, trackProps, labelProps, outputProps } = useSlider(
+    props,
+    state,
+    trackRef,
+  );
 
   return (
     <div {...groupProps} className="nds-slider">
-      {props.label &&
-        (
-          <VisuallyHidden>
-            <label {...labelProps}>{props.label}</label>
-          </VisuallyHidden>
-        )}
+      {props.label && (
+        <VisuallyHidden>
+          <label {...labelProps}>{props.label}</label>
+        </VisuallyHidden>
+      )}
       <div className="output-container">
         <output {...outputProps}>
-          {props.output || `Between ${state.getThumbValueLabel(0)} and ${state.getThumbValueLabel(1)}`}
+          {props.output ||
+            `Between ${state.getThumbValueLabel(0)} and ${state.getThumbValueLabel(1)}`}
         </output>
       </div>
-      <div
-        {...trackProps}
-        ref={trackRef}
-        className="track"
-      >
+      <div {...trackProps} ref={trackRef} className="track">
         <div className="rail" />
-        <Thumbs state={state} trackRef={trackRef} lowerName={props.lowerName} higherName={props.higherName} />
+        <Thumbs
+          state={state}
+          trackRef={trackRef}
+          lowerName={props.lowerName}
+          higherName={props.higherName}
+        />
       </div>
     </div>
   );

--- a/src/Tabs/Arrow.js
+++ b/src/Tabs/Arrow.js
@@ -10,7 +10,7 @@ const Arrow = ({ direction, onClick, show }) => {
 
   return (
     isResponsive && (
-      <div className="arrow-responsive">
+      <div className="arrow-reponsive">
         <CSSTransition
           nodeRef={arrowRef}
           in={show}

--- a/src/Tabs/Arrow.js
+++ b/src/Tabs/Arrow.js
@@ -10,7 +10,7 @@ const Arrow = ({ direction, onClick, show }) => {
 
   return (
     isResponsive && (
-      <div className="arrow-reponsive">
+      <div className="arrow-responsive">
         <CSSTransition
           nodeRef={arrowRef}
           in={show}

--- a/src/Tabs/index.js
+++ b/src/Tabs/index.js
@@ -12,7 +12,7 @@ const noop = () => {};
  * Component that handles tabs and tab panels based on WAI-ARIA [best practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel)
  * for the "tabs" design pattern.
  *
- * The `Tabs` component mananges its own state, changing the visible tab panel based
+ * The `Tabs` component manages its own state, changing the visible tab panel based
  * on user events. Use the `onTabChange` callback to add any custom behaviors.
  */
 const Tabs = ({

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -67,7 +67,7 @@
   transition: max-width 300ms, opacity 300ms;
 }
 
-.arrow-responsive {
+.arrow-reponsive {
   flex: 0 0 32px;
 }
 

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -67,7 +67,7 @@
   transition: max-width 300ms, opacity 300ms;
 }
 
-.arrow-reponsive {
+.arrow-responsive {
   flex: 0 0 32px;
 }
 

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -97,7 +97,7 @@ WithoutPanels.parameters = {
   docs: {
     description: {
       story:
-        "You can decouple tabs from conent by omitting the panel components. Use the `onTabChange` callback to respond to user events.",
+        "You can decouple tabs from content by omitting the panel components. Use the `onTabChange` callback to respond to user events.",
     },
   },
 };

--- a/src/TimelineEvent/index.js
+++ b/src/TimelineEvent/index.js
@@ -57,7 +57,7 @@ const TimelineEvent = ({ kind = "node", icon, imgUrl, initial, children }) => {
 
 TimelineEvent.propTypes = {
   /**
-   * Timline node variant.
+   * Timeline node variant.
    */
   kind: PropTypes.oneOf(["node", "start", "pending"]),
   /**
@@ -77,7 +77,7 @@ TimelineEvent.propTypes = {
    */
   initial: PropTypes.string,
   /**
-   * Timline event content (any JSX)
+   * Timeline event content (any JSX)
    */
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/src/TokenInput/index.jsx
+++ b/src/TokenInput/index.jsx
@@ -119,7 +119,7 @@ TokenInput.propTypes = {
    * This should be the value of the field in the submitted form.
    */
   fieldValue: PropTypes.string.isRequired,
-  /** Input change calback */
+  /** Input change callback */
   onInputChange: PropTypes.func,
   /** Value of input element */
   inputValue: PropTypes.string,

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -92,7 +92,7 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   /** Message shown inside the tooltip */
   text: PropTypes.string.isRequired,
-  /** Sets prefferred side of the trigger the tooltip should appear */
+  /** Sets preferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
   /** CSS `display` value for the element that wraps the Tooltip children */
   wrapperDisplay: PropTypes.oneOf([

--- a/src/base-styles/Typography.stories.mdx
+++ b/src/base-styles/Typography.stories.mdx
@@ -6,7 +6,7 @@ import { Meta, Canvas } from "@storybook/addon-docs";
 
 ## Setting a typography context
 
-Adding the `nds-typography` class to an element enables Narmi typsetting defaults
+Adding the `nds-typography` class to an element enables Narmi typesetting defaults
 on child elements:
 
 <Canvas isExpanded>
@@ -22,7 +22,7 @@ on child elements:
 
 ## Elements styled by typography context
 
-The `nds-typograhy` context targets heading and paragraph elements:
+The `nds-typography` context targets heading and paragraph elements:
 
 <Canvas isExpanded>
   <div className="nds-typography">

--- a/src/base-styles/reset.scss
+++ b/src/base-styles/reset.scss
@@ -1,6 +1,6 @@
 /**
 * reset.css
-* Custom normailze/reset
+* Custom normalize/reset
 *
 * - Normalizes styling across browsers
 * - Sets sensible defaults for base elements

--- a/src/formatters/formatNumber.test.js
+++ b/src/formatters/formatNumber.test.js
@@ -1,7 +1,7 @@
 import formatNumber from "./formatNumber";
 
 describe("formatNumber", () => {
-  it("formats as currecny by default", () => {
+  it("formats as currency by default", () => {
     const actual = formatNumber("0");
     const expected = "$0.00";
     expect(actual).toEqual(expected);

--- a/tokens/src/color/color.stories.mdx
+++ b/tokens/src/color/color.stories.mdx
@@ -31,7 +31,7 @@ properties are intended to be overridden by institution settings.
 ### Enabling theming in your application
 
 To set the value of these theming variables, redeclare theme custom properties
-in your application _after_ the design system styleheet link.
+in your application _after_ the design system stylesheet link.
 
 You will need to declare both full values and RGB list values, which are used by
 this design system for composing transparent colors:


### PR DESCRIPTION
Praise be to [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker).

This fixes non-functional typos in comments, templates, and one instance of an internal variable. It does not address typos that would cause breaking changes, such as

https://github.com/narmi/design_system/blob/aca096f59f0955ba0536f76a04e77c04e5efbf05/src/Tabs/Arrow.js#L13

or

https://github.com/narmi/design_system/blob/aca096f59f0955ba0536f76a04e77c04e5efbf05/src/Alert/index.jsx#L16

