### PR TITLE
fix(Tooltip): use even spacing around tooltip content

### DIFF
--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -1,6 +1,6 @@
 .nds-tooltip {
   border-radius: var(--border-radius-default);
-  padding: var(--space-s) var(--space-m);
+  padding: var(--space-s);
   font-size: var(--font-size-s);
   background-color: var(--color-black);
   color: var(--color-white);


### PR DESCRIPTION
Closes NDS-460

Reduces horizontal spacing in tooltip per design

<img width="362" alt="Screenshot 2024-08-28 at 3 42 41 PM" src="https://github.com/user-attachments/assets/b8d33ce4-024b-43e7-bcad-3cd90a19efc0">
