### PR TITLE
fix(RadioButtons): make error text small font size

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
+import Error from "../Error";
 
 /**
 The Narmi RadioButtons component expects an "options" Prop, which is an object where the keys are the radiobutton
@@ -121,12 +122,7 @@ const RadioButtons = ({
           </label>
         );
       })}
-      {hasError && (
-        <div className="fontColor--error">
-          <span className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
-          {error}
-        </div>
-      )}
+      <Error error={error} />
     </div>
   );
 };


### PR DESCRIPTION
resolve https://github.com/narmi/design_system/issues/1333

This PR changes the `RadioButtons` component to use the `Error` component instead of rolling its own error rendering. 

This makes it so that the error text font size is consistent with design standards (small font size or 12px). 

![image](https://github.com/user-attachments/assets/454a2a5a-0f90-4230-8918-0ab4a8aef72c)
