### PR TITLE
feat(RadioButtons): add checkmark variant

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -100,7 +100,7 @@ const RadioButtons = ({
                 role="presentation"
                 className={cc([
                   "nds-radio",
-                  { "narmi-icon-check": kind === "card" },
+                  { "narmi-icon-check": ["card", "checkmark"].includes(kind) },
                 ])}
               />
             </div>
@@ -147,7 +147,7 @@ RadioButtons.propTypes = {
    *
    * `card` - display input and label as a toggleable card
    */
-  kind: PropTypes.oneOf(["normal", "row", "card"]),
+  kind: PropTypes.oneOf(["normal", "row", "card", "checkmark"]),
   /**
    * Error message. When passed, the `error` prop will
    * render the radio group in an error state.

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -136,6 +136,48 @@
   }
 }
 
+// checkmark style variant
+.nds-radiobuttons--checkmark {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+  .nds-radiobuttons-label-container {
+    display: flex;
+    justify-content: flex-end;
+    flex-direction: row-reverse;
+    gap: var(--space-xs);
+  }
+  .nds-radio {
+    visibility: hidden;
+    font-weight: var(--font-weight-bold);
+    flex-shrink: 1;
+    &:before {
+      font-size: var(--font-size-l);
+      font-weight: var(--font-weight-bold);
+    }
+  }
+  .nds-radiobuttons-option {
+    margin: 0;
+    &:hover .nds-radio,
+    &.nds-radiobuttons-option--focused .nds-radio,
+    &.nds-radiobuttons-option--checked .nds-radio {
+      visibility: visible;
+    }
+    &:hover .nds-radio,
+    &.nds-radiobuttons-option--focused .nds-radio {
+      color: var(--color-lightGrey);
+    }
+    &.nds-radiobuttons-option--checked {
+      color: var(--theme-primary);
+      .nds-radio {
+        &:before {
+          color: var(--theme-primary);
+        }
+      }
+    }
+  }
+}
+
 // card style radiobuttons variant
 .nds-radiobuttons--card {
   display: block;

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -131,6 +131,25 @@ AsRadioButtonsWithDetailsAlwaysShown.parameters = {
   },
 };
 
+export const AsCheckmark = Template.bind({});
+AsCheckmark.args = {
+  options: {
+    OptionA: "A",
+    OptionB: "B",
+    OptionC: "C",
+  },
+  name: "card_options",
+  kind: "checkmark",
+};
+AsCheckmark.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a radio group styled as labels with a checkmark indicating selection",
+    },
+  },
+};
+
 export const AsCard = Template.bind({});
 AsCard.args = {
   options: {
@@ -188,8 +207,7 @@ AsRow.args = {
 AsRow.parameters = {
   docs: {
     description: {
-      story:
-        "Renders a radio group styled as a row.",
+      story: "Renders a radio group styled as a row.",
     },
   },
 };


### PR DESCRIPTION
closes NDS-461

Adds `checkmark` variant of `RadioButtons`. Useful for popovers with selection.

Example of where this would be used:
<img width="193" alt="Screenshot 2024-08-22 at 10 36 44 AM" src="https://github.com/user-attachments/assets/2e915bff-0821-438e-96aa-72f1c8c54374">

Screenshot from storybook preview:
<img width="555" alt="Screenshot 2024-09-16 at 7 00 38 PM" src="https://github.com/user-attachments/assets/961b0047-920c-4bba-9b17-b356b4d28e67">
