### PR TITLE
fix(Dialog): prevent overflow gradient text overlap

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -1,3 +1,7 @@
+.nds-dialog {
+  --overflow-gradient-height: 20px;
+}
+
 .nds-shim--dark {
   position: fixed;
   top: 0;
@@ -122,6 +126,12 @@
 .nds-dialog-footer--overflowing {
   position: relative;
 
+  // prevent edge case where last line of text is obscured by the overflow
+  // gradient above the dialog footer
+  .nds-dialog-content {
+    padding-bottom: var(--overflow-gradient-height);
+  }
+
   &::before {
     content: "";
     position: absolute;
@@ -129,7 +139,7 @@
     right: 0;
     top: -20px;
     /* stack on top of footer border */
-    height: 20px;
+    height: var(--overflow-gradient-height);
     background-image: linear-gradient(
       to top,
       var(--color-white),


### PR DESCRIPTION
Closes NDS-401

Automatically add padding to the bottom of the content area equal to the height of the gradient when content is overflowing. This prevents the gradient from covering up the last line of text when you scroll to the bottom of the content area.