### PR TITLE
feat(Popover): add onUserEnable prop for controlled mode

### DIFF
--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -29,6 +29,7 @@ const Popover = ({
   closeOnContentClick = false,
   isOpen,
   onUserDismiss = noop,
+  onUserEnable = noop,
 }) => {
   const isControlled = isOpen === true || isOpen === false;
   const [open, setOpen] = useState(false);
@@ -52,12 +53,18 @@ const Popover = ({
 
   const togglePopover = (event) => {
     event.stopPropagation();
-    setOpen(!open);
+    setOpen((open) => {
+      if (!open) {
+        onUserEnable();
+      }
+      return !open;
+    });
   };
 
   const handleKeyDown = ({ key }) => {
     if (key === "Enter") {
       setOpen(true);
+      onUserEnable();
     }
   };
 
@@ -124,7 +131,7 @@ const Popover = ({
               </div>
             </div>
           )}
-        </>
+        </>,
       )}
     </>
   );
@@ -164,10 +171,15 @@ Popover.propTypes = {
   /** If isOpen is set the component becomes a controlled component. Use the `onUserDismiss` callback to update. */
   isOpen: PropTypes.bool,
   /**
-   * Callback to handle user taking an action to dismiss the popover
+   * Callback to handle user taking an action to __dismiss__ the popover
    * (click outside, Escape key)
    */
   onUserDismiss: PropTypes.func,
+  /**
+   * Callback to handle user taking an action to __enable__ the popover
+   * (click or key interaction on the trigger button rendered in Popover)
+   */
+  onUserEnable: PropTypes.func,
 };
 
 export default Popover;

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import Popover from "./";
 import Button from "../Button";
-import Checkbox from "../Checkbox";
 
 const Template = (args) => (
   <div
@@ -75,21 +74,32 @@ export const Controlled = () => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <Checkbox
-        label="Show popover"
-        checked={isOpen}
-        onChange={() => setIsOpen(!isOpen)}
+      <Button
+        kind="secondary"
+        size="s"
+        label="show popover"
+        onClick={() => setIsOpen(!isOpen)}
       />
       <div className="margin--top--m">
         <Popover
           content={<div className="padding--all--m">📦 Any content</div>}
           isOpen={isOpen}
+          onUserDismiss={() => setIsOpen(false)}
+          onUserEnable={() => setIsOpen(true)}
         >
-          <div>Arbitrary target</div>
+          <div>Popover trigger and positioning reference</div>
         </Popover>
       </div>
     </>
   );
+};
+Controlled.parameters = {
+  docs: {
+    description: {
+      story:
+        "In this example, the user may click on either the button, or the text below to open the Popover. The `children` (trigger element) of Popover will always be the positioning reference. The `onUserEnable` prop can be used to subscribe to user interactions on the trigger, and `onUserDismiss` is used to subscribe to user events that dismiss the popover.",
+    },
+  },
 };
 
 export default {


### PR DESCRIPTION
closes NDS-572

Accessibility fix and controlled Popover improvement.

The `Popover` component was designed to behave as uncontrolled by default, and controlled when `isOpen` is passed in.
To close the popover based on user dismissal events, we provided an `onUserDismiss` callback that the parent can use to manage the `isOpen` state.

The poor assumption was that in controlled mode, we would be using a trigger somewhere outside the `Popover` children. If you want a fully controlled popover with a normal trigger defined in `children`, you would have to define your own interactive element with event handlers. This is bad because the `Popover` automatically wraps its children in a `role="button"` which is invalid.

**This PR adds the `onUserEnable` method so a parent of `Popover` may manage trigger events without redefining an interactive element**


<img width="1053" alt="Screenshot 2024-09-20 at 10 30 14 AM" src="https://github.com/user-attachments/assets/abdf8671-f8d5-4917-881d-973c5e1c75a3">

<img width="500" alt="Screenshot 2024-09-20 at 10 35 10 AM" src="https://github.com/user-attachments/assets/d3470e2e-42cc-4dc1-a584-725f3fe5a91e">



