### PR TITLE
feat(Error): enable displaying of multiple errors

### DIFF
--- a/src/Error/index.js
+++ b/src/Error/index.js
@@ -1,18 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Error = ({ error, marginTop = "xxs" }) => {
-  if (!error) return null;
+const ErrorLine = ({ errorLine, marginTop = "xxs" }) => {
+  if (!errorLine) return null;
   return (
     <div className={`nds-input-error margin--top--${marginTop}`}>
       <div className="fontSize--s margin--right--xxs narmi-icon-x-circle" />
-      {error}
+      {errorLine}
     </div>
   );
 };
-Error.propTypes = {
+ErrorLine.propTypes = {
   error: PropTypes.string,
   marginTop: PropTypes.oneOf(["xxs", "xs", "s", "m", "l", "xl", "xxl", "none"])
 };
+
+const Error = ({ error, marginTop = "xxs" }) => {
+  if (!error) return null;
+  if (Array.isArray(error)) {
+    return (
+      <div className="nds-input-errorlist">
+        {error.map((errorLine, index) => (
+          <ErrorLine key={index} errorLine={errorLine} marginTop={index ? marginTop : "xxs"} />
+        ))}
+      </div>
+    );
+  }
+  return <ErrorLine errorLine={error} marginTop={marginTop} />;
+};
+Error.propTypes = {
+  error: PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  marginTop: PropTypes.oneOf(["xxs", "xs", "s", "m", "l", "xl", "xxl", "none"])
+};
+
 
 export default Error;

--- a/src/Error/index.scss
+++ b/src/Error/index.scss
@@ -13,3 +13,9 @@
     width: 1.2em;
   }
 }
+
+.nds-input-errorlist {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -142,7 +142,7 @@ TextInput.propTypes = {
   /** Display an X at the end of label that clears input and calls onChange on click. */
   showClearButton: PropTypes.bool,
   /** Text of error message to display under the input */
-  error: PropTypes.string,
+  error: PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   /** Maximum number of characters allowed in the input */
   maxLength: PropTypes.number,
   /** Optional value for `data-testid` attribute */


### PR DESCRIPTION
resolves https://linear.app/narmi/issue/BANKW-1152/enable-display-of-error-arrays

Sometimes, more than a single error is present for a single field. When this happens, we may want to display all of the errors in a list:

<img width="640" alt="Screenshot 2024-09-23 at 9 56 54 AM" src="https://github.com/user-attachments/assets/37209f46-8e3b-4072-9745-5ffce3b36f4f">
