### PR TITLE
feat(Row): Add className override support for Row and Row.Item

### DIFF
--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -25,7 +25,7 @@ RowItem.propTypes = {
   shrink: PropTypes.bool,
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "li"]),
-  /** Controls className while maintaining default nds-row-item styling if left unspecified */
+  /** Optional: controls className while maintaining default nds-row-item styling if left unspecified */
   className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -7,10 +7,10 @@ import AsElement from "../util/AsElement";
  * Child component of `Row`.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
  */
-const RowItem = ({ shrink = false, as = "div", children, testId }) => (
+const RowItem = ({ shrink = false, as = "div", className = "", children, testId }) => (
   <AsElement
     elementType={as}
-    className={cc(["nds-row-item", { "nds-row-item--shrink": shrink }])}
+    className={cc([className,"nds-row-item", { "nds-row-item--shrink": shrink }])}
     data-testid={testId}
   >
     {children}
@@ -25,6 +25,8 @@ RowItem.propTypes = {
   shrink: PropTypes.bool,
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "li"]),
+  /** Controls className while maintaining default nds-row-item styling if left unspecified */
+  className: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import AsElement from "../util/AsElement";
 import RowItem from "./RowItem";
+import cc from "classcat";
 
 /**
  * builds style object for `Row`
@@ -30,12 +31,13 @@ const Row = ({
   justifyContent = "start",
   gapSize = "l",
   as = "div",
+  className = "",
   children,
   testId,
 }) => (
   <AsElement
     elementType={as}
-    className="nds-row"
+    className={cc([className, "nds-row"])}
     style={_getRowStyle(alignItems, justifyContent, gapSize)}
     data-testid={testId}
   >
@@ -56,6 +58,8 @@ Row.propTypes = {
   justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "ul"]),
+  /** Controls className while maintaining default nds-row styling if left unspecified */
+  className: PropTypes.string,
   /** Children must be of type `Row.Item` */
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   /** Optional value for `data-testid` attribute */

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -60,7 +60,7 @@ Row.propTypes = {
   as: PropTypes.oneOf(["div", "ul"]),
   /** Controls className while maintaining default nds-row styling if left unspecified */
   className: PropTypes.string,
-  /** Children must be of type `Row.Item` */
+  /** Optional: controls must be of type `Row.Item` */
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -58,9 +58,9 @@ Row.propTypes = {
   justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["div", "ul"]),
-  /** Controls className while maintaining default nds-row styling if left unspecified */
+  /** Optional: controls className while maintaining default nds-row styling if left unspecified */
   className: PropTypes.string,
-  /** Optional: controls must be of type `Row.Item` */
+  /** Children must be of type `Row.Item` */
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,


### PR DESCRIPTION
Often in `./staff` we would save a lot of code if we could just override the `Row` and `Row.Item` `className` opposed to having to create a wrapper div with the extra styling requirements.