### PR TITLE
fix(MenuButton): restore icon rendering

### DIFF
--- a/src/MenuButton/MenuButtonItem.js
+++ b/src/MenuButton/MenuButtonItem.js
@@ -1,22 +1,13 @@
+/* eslint-disable no-unused-vars */
 import React from "react";
 import PropTypes from "prop-types";
 import iconSelection from "src/icons/selection.json";
-import Row from "../Row";
 
 export const VALID_ICON_NAMES = iconSelection.icons.map(
-  (icon) => icon.properties.name
+  (icon) => icon.properties.name,
 );
 
-const MenuButtonItem = ({ label, startIcon }) => (
-  <Row gapSize="s">
-    {startIcon && (
-      <Row.Item shrink>
-        <span className={`narmi-icon-${startIcon}`} />
-      </Row.Item>
-    )}
-    <Row.Item>{label}</Row.Item>
-  </Row>
-);
+const MenuButtonItem = ({ label, startIcon }) => <></>;
 
 MenuButtonItem.propTypes = {
   /** Display label for menu item */

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -133,6 +133,7 @@ const MenuButton = ({
                     key={itemId}
                     id={itemId}
                     value={itemId}
+                    startIcon={child.props.startIcon}
                     /**
                      * react-aria provides a className interface similar
                      * to render props
@@ -152,7 +153,16 @@ const MenuButton = ({
                       ])
                     }
                   >
-                    {child.props.label}
+                    <Row gapSize="s">
+                      {child.props.startIcon && (
+                        <Row.Item shrink>
+                          <span
+                            className={`narmi-icon-${child.props.startIcon}`}
+                          />
+                        </Row.Item>
+                      )}
+                      <Row.Item>{child.props.label}</Row.Item>
+                    </Row>
                   </MenuItem>
                 );
               })}


### PR DESCRIPTION
closes NDS-577

The `MenuButtonItem` components passed into `MenuButton` get mapped to a react-aria MenuButton. When we refactored this component to use react-aria-components, we forgot to include rendering the `startIcon` prop where we render out the `menuItems`.

Now the `MenuButtonItem` only takes props and returns a fragment. The actual item rendering is in `MenuButton/index.jsx` now.

<img width="237" alt="Screenshot 2024-09-23 at 1 13 24 PM" src="https://github.com/user-attachments/assets/78014ca0-e555-4457-990a-e3e20d7cde4b">
