### PR TITLE
fix(Checkbox): remove top-padding for subsequent sibling condensed checkboxes

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -15,7 +15,6 @@
   margin-top: var(--space-default);
 }
 
-
 // reset paragraph spacing in markdown labels
 .nds-checkbox-label p {
   margin: 0;

--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -4,10 +4,17 @@
   padding-top: var(--space-s);
 }
 
-// normal checkboxes git a bit of extra spacing
+// condensed checkboxes get no extra top spacing;
+// any extra spacing should be applied by the consumer
+.nds-checkbox-container--condensed ~ .nds-checkbox-container--condensed {
+  padding-top: 0;
+}
+
+// normal checkboxes get a bit of extra spacing
 .nds-checkbox-container--normal ~ .nds-checkbox-container--normal {
   margin-top: var(--space-default);
 }
+
 
 // reset paragraph spacing in markdown labels
 .nds-checkbox-label p {


### PR DESCRIPTION
Follow-up to https://github.com/narmi/design_system/pull/1315.

One consequence of this PR is that spacing for groups of condensed checkboxes needs to be handled by the consumer. That's fine by me -- the purpose of the "condensed" style is to be un-opinionated about spacing.