### PR TITLE
docs: change theme colors

### DIFF
--- a/tokens/src/color/theme.json
+++ b/tokens/src/color/theme.json
@@ -1,7 +1,7 @@
 {
   "color": {
     "theme": {
-      "primary": { "value": "{color.narmi.pine.value}" },
+      "primary": { "value": "{color.narmi.azul.value}" },
       "secondary": { "value": "{color.narmi.moss.value}" },
       "tertiary": { "value": "{color.narmi.cactus.value}" },
       "link": { "value": "{color.theme.secondary.value}" }


### PR DESCRIPTION
Updates default theme colors. Affects storybook docs only.

**Why?**
To make it easier to visually verify theming support in components

<img width="635" alt="Screenshot 2024-09-30 at 4 03 58 PM" src="https://github.com/user-attachments/assets/aa4211ee-015b-46d5-9153-6158114a33b8">
<img width="631" alt="Screenshot 2024-09-30 at 4 04 48 PM" src="https://github.com/user-attachments/assets/24436dc2-b04e-47b9-b990-e35c50700b06">
<img width="457" alt="Screenshot 2024-09-30 at 4 04 56 PM" src="https://github.com/user-attachments/assets/e4ffc35f-2860-4e73-b7fc-a8ffaa462df6">
<img width="940" alt="Screenshot 2024-09-30 at 4 05 08 PM" src="https://github.com/user-attachments/assets/f6ec567a-46be-4d81-a650-a001fb703b74">
