### PR TITLE
feat(DisabledShim): add component to disable arbitrary areas

### DIFF
--- a/src/DisabledShim/index.scss
+++ b/src/DisabledShim/index.scss
@@ -1,0 +1,15 @@
+.nds-disabledShim {
+  position: relative;
+}
+.nds-disabledShim--disabled::after {
+  content: "";
+  user-select: none;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: var(--bgColor-scrimLight);
+  z-index: 2;
+}

--- a/src/DisabledShim/index.stories.js
+++ b/src/DisabledShim/index.stories.js
@@ -1,0 +1,34 @@
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
+import React from "react";
+import DisabledShim from "./";
+import ContentCard from "../ContentCard";
+
+export const Overview = (args) => (
+  <ContentCard kind="bordered">
+    <DisabledShim {...args} />
+  </ContentCard>
+);
+Overview.args = {
+  isDisabled: false,
+  children: (
+    <>
+      <h2>This card conains a DisabledShim</h2>
+      <p>
+        Toggle the <code>isDisabled</code> prop below to see the shim appear.
+      </p>
+      <p>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+        odit aut fugit, sed quia consequuntur magni dolores eos qui ratione
+        voluptatem sequi nesciunt
+      </p>
+    </>
+  ),
+};
+
+export default {
+  title: "Components/DisabledShim",
+  component: DisabledShim,
+};

--- a/src/DisabledShim/index.stories.js
+++ b/src/DisabledShim/index.stories.js
@@ -12,7 +12,7 @@ Overview.args = {
   isDisabled: false,
   children: (
     <>
-      <h2>This card conains a DisabledShim</h2>
+      <h2>This card contains a DisabledShim</h2>
       <p>
         Toggle the <code>isDisabled</code> prop below to see the shim appear.
       </p>

--- a/src/DisabledShim/index.tsx
+++ b/src/DisabledShim/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+
+interface DisabledShimProps {
+  children: React.ReactNode;
+  isDisabled?: boolean;
+}
+
+/**
+ * Disables any area of a page with a white overlay shim and the
+ * applicable `aria-disabled` value.
+ */
+const DisabledShim = ({ isDisabled = false, children }: DisabledShimProps) => (
+  <div
+    className={cc([
+      "nds-disabledShim",
+      { "nds-disabledShim--disabled": isDisabled },
+    ])}
+    aria-disabled={isDisabled ? "true" : "false"}
+  >
+    {children}
+  </div>
+);
+
+DisabledShim.propTypes = {
+  /**
+   * Sets disabled state over all `children` passed in.
+   */
+  isDisabled: PropTypes.bool,
+  /** Content that can be disabled */
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+};
+
+export default DisabledShim;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import CollapsibleCard from "./CollapsibleCard";
 import Combobox from "./Combobox";
 import DateInput from "./DateInput";
 import Dialog from "./Dialog";
+import DisabledShim from "./DisabledShim";
 import Drawer from "./Drawer";
 import Dropdown from "./Dropdown";
 import DropdownTrigger from "./DropdownTrigger";
@@ -53,6 +54,7 @@ export {
   Combobox,
   DateInput,
   Dialog,
+  DisabledShim,
   Drawer,
   Dropdown,
   DropdownTrigger,

--- a/src/index.scss
+++ b/src/index.scss
@@ -65,6 +65,7 @@
 @import "IconButton/";
 @import "MenuButton/";
 @import "LoadingShim/";
+@import "DisabledShim/";
 @import "LoadingSkeleton/";
 @import "Dialog/";
 @import "Drawer/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * Typed Components
  */
+import DisabledShim from "./DisabledShim";
 import SeparatorList from "./SeparatorList";
 import Slider from "./Slider";
 
@@ -51,8 +52,12 @@ declare const formatDate;
 
 export * from "./types/Icon.types";
 export {
+  // typed
+  DisabledShim,
   SeparatorList,
   Slider,
+
+  // untyped
   Alert,
   Button,
   Checkbox,


### PR DESCRIPTION
closes NDS-569

Adds a `DisabledShim` with the same basic interface as `LoadingShim`. This component allows disabling an arbitrary area of the screen (e.g. the contents of a card)