### PR TITLE
feat(RadioButtons): add kind 'input-card'

### DIFF
--- a/src/RadioButtons/index.js
+++ b/src/RadioButtons/index.js
@@ -79,7 +79,10 @@ const RadioButtons = ({
                 "nds-radiobuttons-option--checked": checkedValue == inputValue,
                 "nds-radiobuttons-option--focused": focusedValue == inputValue,
                 "nds-radiobuttons-option--error": hasError,
-                "padding--all rounded--all border--all": kind === "card",
+                "padding--all rounded--all border--all": [
+                  "card",
+                  "input-card",
+                ].includes(kind),
               },
             ])}
             key={inputValue}
@@ -146,8 +149,10 @@ RadioButtons.propTypes = {
    * `normal` - display input and label normally
    *
    * `card` - display input and label as a toggleable card
+   *
+   * `input-card` - display toggleable card with a faux radio input
    */
-  kind: PropTypes.oneOf(["normal", "row", "card"]),
+  kind: PropTypes.oneOf(["normal", "row", "card", "input-card"]),
   /**
    * Error message. When passed, the `error` prop will
    * render the radio group in an error state.

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -209,3 +209,80 @@
     }
   }
 }
+
+// "input-card" variant
+.nds-radiobuttons--input-card {
+  display: block;
+
+  .nds-radiobutton-details {
+    color: var(--font-color-primary);
+  }
+
+  .nds-radiobuttons-option {
+    padding-left: rem(52px) !important;
+
+    .nds-radio {
+      position: absolute;
+      top: rem(20px);
+      left: rem(20px);
+      height: rem(20px);
+      width: rem(20px);
+      background-color: var(--color-white);
+      border: 1px solid var(--color-lightGrey);
+      border-radius: 50%;
+
+      &:after {
+        content: "";
+        position: absolute;
+        display: none;
+        top: 50%;
+        left: 50%;
+        width: rem(12px);
+        height: rem(12px);
+        transform: translate(-50%, -50%);
+        border-radius: 50%;
+        background: var(--theme-primary);
+      }
+    }
+
+    &:hover .nds-radio,
+    &.nds-radiobuttons-option--focused .nds-radio,
+    &.nds-radiobuttons-option--checked .nds-radio {
+      border: 1px solid var(--theme-primary);
+    }
+
+    &.nds-radiobuttons-option--error .nds-radio {
+      border-color: var(--color-errorDark);
+    }
+
+    &.nds-radiobuttons-option--checked .nds-radio {
+      background-color: transparent;
+
+      &:after {
+        display: block;
+      }
+    }
+  }
+
+  .nds-radiobuttons-option {
+    .nds-radiobuttons-label-container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      color: var(--theme-primary);
+      font-weight: var(--font-weight-bold) !important;
+      font-size: var(--font-size-default);
+    }
+
+    &:hover,
+    &.nds-radiobuttons-option--focused,
+    &.nds-radiobuttons-option--checked {
+      border-color: var(--theme-primary);
+    }
+
+    &.nds-radiobuttons-option--error {
+      border-color: var(--color-errorDark);
+    }
+  }
+}

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -150,6 +150,32 @@ AsCard.parameters = {
   },
 };
 
+export const AsCardWithInput = Template.bind({});
+AsCardWithInput.args = {
+  alwaysShowDetails: true,
+  options: {
+    ["You will complete the form"]: {
+      value: "A",
+      details: "You'll enter all necessary details for this owner.",
+    },
+    ["Owner will complete the form"]: {
+      value: "B",
+      details:
+        "Enter the owner's name and email and they'll securely input their own information.",
+    },
+  },
+  name: "card_options",
+  kind: "input-card",
+};
+AsCardWithInput.parameters = {
+  docs: {
+    description: {
+      story:
+        "When radio options are displayed as cards on a busier screen, use `input-card` to render a faux radio input inside a card as an extra affordance, helping the user recognize it as an interactive element.",
+    },
+  },
+};
+
 export const AsCardWithDetails = Template.bind({});
 AsCardWithDetails.args = {
   options: {
@@ -188,8 +214,7 @@ AsRow.args = {
 AsRow.parameters = {
   docs: {
     description: {
-      story:
-        "Renders a radio group styled as a row.",
+      story: "Renders a radio group styled as a row.",
     },
   },
 };


### PR DESCRIPTION
Closes NDS-568

Adds new RadioButtons variant, `input-card`.

<img width="1081" alt="Screenshot 2024-09-30 at 7 27 14 PM" src="https://github.com/user-attachments/assets/91c3a7e2-a8e7-4e5d-950f-9bf3011794ba">
