### PR TITLE
fix(MultiSelect): prevent field autofocus

### DIFF
--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -64,7 +64,6 @@ const MultiSelect = ({
   /** @see https://www.downshift-js.com/use-multiple-selection/#usage-with-select  */
   const {
     getSelectedItemProps,
-    getDropdownProps,
     addSelectedItem,
     removeSelectedItem,
     selectedItems,
@@ -191,22 +190,20 @@ const MultiSelect = ({
         id={name}
         value={fieldValue || selectedItems.map(itemToString).join(",")}
       />
-      <DropdownTrigger
-        disabled={disabled}
-        isOpen={isOpen}
-        labelText={label}
-        startContent={renderTokens()}
-        errorText={errorText}
-        labelProps={{ ...getLabelProps() }}
-        {...getToggleButtonProps(
-          getDropdownProps({
-            ...triggerProps,
-          }),
-        )}
-        style={{
-          ...triggerProps.style,
-        }}
-      />
+      <div {...triggerProps}>
+        <DropdownTrigger
+          disabled={disabled}
+          isOpen={isOpen}
+          labelText={label}
+          startContent={renderTokens()}
+          errorText={errorText}
+          labelProps={{ ...getLabelProps() }}
+          {...getToggleButtonProps()}
+          style={{
+            ...triggerProps.style,
+          }}
+        />
+      </div>
       {renderLayer(
         <div
           className={cc([


### PR DESCRIPTION
closes NDS-378

We observed the `MultiSelect` component stealing focus on page load in the staff app.

It looks like the prop getters being used on the `DropdownTrigger` inside the multiselect were competing over binding refs and events.

This PR resolves the issue by:
- Creating a separate, dedicated element around the `DropdownTrigger` to receive the `ref` for the `userLayer` positioning engine
- Simplify the downshift props being passed to the `DropdownTrigger` by applying only the `getToggleButtonProps` from the `useSelect` hook

-----

### tl;dr

The `triggerProps` returned by the `useLayer` positioning engine does one thing, and only one thing: it applies a `ref` to an element so the element may be used as the positioning reference.

Wrapping the `DropdownTrigger` in a div does effectively the same thing, without being in competition with downshift prop getters attempting to apply a ref