### PR TITLE
fix(TokenInput): stop clearing input on blur

### DIFF
--- a/src/TokenInput/index.jsx
+++ b/src/TokenInput/index.jsx
@@ -79,9 +79,6 @@ const TokenInput = ({
         label={label}
         disabled={disabled}
         onChange={onInputChange}
-        onBlur={() => {
-          onInputChange(INPUT_RESET_EVENT);
-        }}
         value={inputValue}
         startContent={
           <div

--- a/src/TokenInput/index.stories.js
+++ b/src/TokenInput/index.stories.js
@@ -27,7 +27,6 @@ export const UsingWithState = () => {
         </output>
       </div>
       <TokenInput
-        disabled
         label="Favorite Foods"
         fieldName="favorite_foods"
         fieldValue={value}


### PR DESCRIPTION
closes NDS-428

`TokenInput` originally cleared the input value on blur. This PR removes that behavior per design.