### PR TITLE
feat(MultiSelect): add tokenLabel prop to items

### DIFF
--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -156,7 +156,9 @@ const MultiSelect = ({
 
   const renderTokens = () =>
     selectedItems.map((itemComponent, i) => {
-      const tokenLabel = itemToString(itemComponent);
+      const tokenLabel = itemComponent.props.tokenLabel
+        ? itemComponent.props.tokenLabel
+        : itemToString(itemComponent);
       const isLastToken = i === selectedItems.length - 1;
       return (
         <span

--- a/src/MultiSelect/index.stories.js
+++ b/src/MultiSelect/index.stories.js
@@ -119,6 +119,36 @@ ControlledSelectedItems.parameters = {
   },
 };
 
+export const CustomTokenValues = () => {
+  const [selectedItems, setSelectedItems] = useState(["film"]);
+  const handleSelectedItemsChange = (selectedItems) => {
+    setSelectedItems(selectedItems);
+  };
+  return (
+    <MultiSelect
+      name="custom-token-labels"
+      label="Favorite Icons"
+      selectedItems={selectedItems}
+      onSelectedItemsChange={handleSelectedItemsChange}
+    >
+      <MultiSelect.Item value="film" tokenLabel="Movies">
+        <span className="narmi-icon-film padding--right--xs" /> Film
+      </MultiSelect.Item>
+      <MultiSelect.Item value="coffee" tokenLabel="Hot Bean Water">
+        <span className="narmi-icon-coffee padding--right--xs" /> Coffee
+      </MultiSelect.Item>
+    </MultiSelect>
+  );
+};
+CustomTokenValues.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `tokenValue` prop may be used on MultiSelect items to declare the string that should render in the token when the item is selected.",
+    },
+  },
+};
+
 export default {
   title: "Components/MultiSelect",
   component: MultiSelect,


### PR DESCRIPTION
Closes NDS-622

Adds `tokenLabel` to `MultiSelect.Item` props, allowing developers to customize the token label for each option.


<img width="666" alt="Screenshot 2024-10-15 at 5 52 57 PM" src="https://github.com/user-attachments/assets/d2e46580-1d2c-4dd7-9ac0-3a524585abbb">
