### PR TITLE
fix(MultiSelect): apply even spacing to tokens; hide label on selection

### DIFF
--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -159,18 +159,8 @@ const MultiSelect = ({
       const tokenLabel = itemComponent.props.tokenLabel
         ? itemComponent.props.tokenLabel
         : itemToString(itemComponent);
-      const isLastToken = i === selectedItems.length - 1;
       return (
-        <span
-          key={`${i}-${tokenLabel}`}
-          className={cc([
-            "padding--y--xs",
-            {
-              "padding--right--s": isLastToken,
-              "padding--right--xs": !isLastToken,
-            },
-          ])}
-        >
+        <div key={`${i}-${tokenLabel}`}>
           <FieldToken
             disabled={disabled}
             label={tokenLabel}
@@ -180,9 +170,11 @@ const MultiSelect = ({
               i,
             })}
           />
-        </span>
+        </div>
       );
     });
+
+  const hasSelectedItems = selectedItems.length > 0;
 
   return (
     <div className="nds-multiselect" data-testid={testId}>
@@ -196,8 +188,17 @@ const MultiSelect = ({
         <DropdownTrigger
           disabled={disabled}
           isOpen={isOpen}
-          labelText={label}
-          startContent={renderTokens()}
+          labelText={hasSelectedItems ? undefined : label}
+          startContent={
+            <div
+              className={cc([
+                "nds-multiselect-tokensList",
+                { "padding--y--xs": hasSelectedItems },
+              ])}
+            >
+              {renderTokens()}
+            </div>
+          }
           errorText={errorText}
           labelProps={{ ...getLabelProps() }}
           {...getToggleButtonProps()}

--- a/src/MultiSelect/index.scss
+++ b/src/MultiSelect/index.scss
@@ -39,3 +39,10 @@
     background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
   }
 }
+
+.nds-multiselect-tokensList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs) var(--space-s);
+  margin-right: var(--space-s); // make room for the right caret
+}


### PR DESCRIPTION
Closes NDS-621
Closes NDS-639

- Remove the placeholder label text when the component has at least one selection
- Change layout mode of tokens from _inline_ to _flex_

Tokens now wrap nicely and the selectedItems state looks better in general:

<img width="317" alt="Screenshot 2024-10-16 at 2 49 45 PM" src="https://github.com/user-attachments/assets/5623ac8c-70bd-428e-b088-cb436329ce08">
<img width="315" alt="Screenshot 2024-10-16 at 2 49 52 PM" src="https://github.com/user-attachments/assets/f15e558c-9030-4249-9b6b-ac141a782a5a">
<img width="299" alt="Screenshot 2024-10-16 at 2 50 45 PM" src="https://github.com/user-attachments/assets/c971bab9-c7bc-4c06-9592-abf000d5b059">
<img width="239" alt="Screenshot 2024-10-16 at 2 50 58 PM" src="https://github.com/user-attachments/assets/abfd4ea8-ec78-4caa-918c-17d3e5b58699">
<img width="321" alt="Screenshot 2024-10-16 at 2 49 39 PM" src="https://github.com/user-attachments/assets/01dfe887-695d-4172-8e9f-b8ada1a1fada">
