### PR TITLE
feat(Combobox): add Combobox.Action support

### DIFF
--- a/src/Combobox/ComboboxAction.js
+++ b/src/Combobox/ComboboxAction.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-vars */
+import React from "react";
+import PropTypes from "prop-types";
+
+const noop = () => {};
+
+const ComboboxAction = ({ onSelect = noop }) => <></>;
+
+ComboboxAction.displayName = "Combobox.Action";
+
+ComboboxAction.propTypes = {
+  /** Side effect to run on selection */
+  onSelect: PropTypes.func.isRequired,
+  /** Label for action */
+  label: PropTypes.string.isRequired,
+};
+
+export default ComboboxAction;

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -13,7 +13,7 @@
   max-height: 40vh;
   overflow-y: scroll;
   z-index: 4;
-  
+
   &--error {
     border: 1px solid var(--color-errorDark);
   }
@@ -51,6 +51,10 @@
   &--highlighted {
     background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
   }
+}
+
+.nds-combobox-action {
+  color: var(--theme-secondary) !important;
 }
 
 .nds-combobox-category {

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -226,6 +226,33 @@ CustomFiltering.parameters = {
   },
 };
 
+export const WithActions = (args) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Combobox label="Select Account" {...args}>
+        <Combobox.Item value="Primary Checking - 4567" />
+        <Combobox.Item value="Secondary Checking - 9876" />
+        <Combobox.Item value="Primary Savings - 1234" />
+        <Combobox.Item value="Cheese Fund - 5432" />
+        <Combobox.Action
+          onSelect={() => {
+            setIsOpen(true);
+          }}
+          label="Do Action"
+        />
+      </Combobox>
+      <Dialog
+        title="You selected an action"
+        isOpen={isOpen}
+        onUserDismiss={() => setIsOpen(false)}
+      >
+        <div className="padding--y--s">🎬 Action!</div>
+      </Dialog>
+    </>
+  );
+};
+
 export default {
   title: "Components/Combobox",
   component: Combobox,

--- a/src/Row/RowItem.js
+++ b/src/Row/RowItem.js
@@ -7,10 +7,20 @@ import AsElement from "../util/AsElement";
  * Child component of `Row`.
  * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
  */
-const RowItem = ({ shrink = false, as = "div", className = "", children, testId }) => (
+const RowItem = ({
+  shrink = false,
+  as = "div",
+  className = "",
+  children,
+  testId,
+}) => (
   <AsElement
     elementType={as}
-    className={cc([className,"nds-row-item", { "nds-row-item--shrink": shrink }])}
+    className={cc([
+      className,
+      "nds-row-item",
+      { "nds-row-item--shrink": shrink },
+    ])}
     data-testid={testId}
   >
     {children}
@@ -24,7 +34,7 @@ RowItem.propTypes = {
    */
   shrink: PropTypes.bool,
   /** The html element to render as the root node of `Row` */
-  as: PropTypes.oneOf(["div", "li"]),
+  as: PropTypes.oneOf(["span", "div", "li"]),
   /** Optional: controls className while maintaining default nds-row-item styling if left unspecified */
   className: PropTypes.string,
   children: PropTypes.oneOfType([

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -57,7 +57,7 @@ Row.propTypes = {
   /** Controls horizontal flex justification */
   justifyContent: PropTypes.oneOf(["start", "end"]),
   /** The html element to render as the root node of `Row` */
-  as: PropTypes.oneOf(["div", "ul"]),
+  as: PropTypes.oneOf(["span", "div", "ul"]),
   /** Optional: controls className while maintaining default nds-row styling if left unspecified */
   className: PropTypes.string,
   /** Children must be of type `Row.Item` */


### PR DESCRIPTION
Closes NDS-458

Adds support for passing a `Combobox.Action` to Combobox. Matches the same pattern we use in `Select.Action` components.

When a user clicks or selects an action via keyboard, the menu will close and the `onSelect` callback of the action item will be invoked.

When filtering by text, the actions will **always** be visible at the bottom of the list of suggestions.

Developers may place an Action item at any position of the list, including inside a category. When filtering, all actions will appear at the bottom of the list as usual.

See storybook preview posted below to test the new feature.