### PR TITLE
feat(CollapsibleCard): add radiusSize prop to configure border radius

### DIFF
--- a/src/CollapsibleCard/index.js
+++ b/src/CollapsibleCard/index.js
@@ -21,6 +21,7 @@ const CollapsibleCard = ({
   hasError = false,
   disableHover = false,
   children,
+  radiusSize = "m",
 }) => {
   const [hover, setHover] = React.useState(false);
 
@@ -73,7 +74,9 @@ const CollapsibleCard = ({
   );
 
   const titleContainerJSX = (
-    <div className="collapsible-card--title-container">
+    <div
+      className={`collapsible-card--title-container rounded--top--${radiusSize}`}
+    >
       <DisabledShim isDisabled={isDisabled}>
         {typeof renderTitle === "function" ? (
           renderTitle(isOpen)
@@ -137,12 +140,12 @@ const CollapsibleCard = ({
           "collapsible-card--no-user-select":
             !disableHover || trigger === "header",
         },
-        "rounded--bottom",
+        `rounded--all--${radiusSize}`,
         "bgColor--white",
       ])}
     >
       <div
-        className="collapsible-card--title-expanded"
+        className={`collapsible-card--title-expanded rounded--top--${radiusSize}`}
         role={trigger === "header" ? "button" : undefined}
         tabIndex={trigger === "header" ? 0 : undefined}
         onKeyUp={({ key }) => {
@@ -175,7 +178,7 @@ const CollapsibleCard = ({
             !disableHover || trigger === "header",
         },
         "content-card--closed",
-        "rounded--all",
+        `rounded--all--${radiusSize}`,
         "bgColor--white",
       ])}
       role={trigger === "header" ? "button" : undefined}
@@ -229,6 +232,10 @@ CollapsibleCard.propTypes = {
    * Called with `(isOpen)` arg you may use for conditional rendering in your custom title JSX.
    */
   renderTitle: PropTypes.func,
+  /**
+   * Amount of border radius to add on all sides of card.
+   */
+  radiusSize: PropTypes.oneOf(["s", "m", "l"]),
 };
 
 export default CollapsibleCard;

--- a/src/CollapsibleCard/index.scss
+++ b/src/CollapsibleCard/index.scss
@@ -5,7 +5,6 @@
   text-align: left;
   background-color: var(--color-white);
   border: 1px solid var(--color-lightGrey);
-  border-radius: rem(8px);
 }
 
 .collapsible-card-trigger {
@@ -38,6 +37,7 @@
 .collapsible-card--title-container {
   display: flex;
   justify-content: space-between;
+  background-clip: border-box;
 }
 .collapsible-card--no-user-select {
   user-select: none;


### PR DESCRIPTION
closes NDS-717

Allows border radius of `CollapsibleCard` to be configured via props. Sets "m" as default.

<img width="673" alt="Screenshot 2024-11-04 at 12 10 19 PM" src="https://github.com/user-attachments/assets/62b300e0-7340-4689-85be-b726539c7d39">
