### PR TITLE
feat(Avatar): Implement Avatar Component

### DIFF
--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -1,0 +1,10 @@
+.nds-avatar {
+  width: 100px;
+  height: 500px;
+  color: white;
+  border: 2px solid black;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  position: relative;
+}

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -2,6 +2,7 @@
   color: white;
   border-radius: 50%;
   display: flex;
+  align-items: center;
   justify-content: center;
   position: relative;
 }
@@ -20,6 +21,7 @@
 .nds-avatar--m {
   height: 40px;
   width: 40px;
+  font-size: var(--font-size-l);
 }
 
 .nds-avatar--l,

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -24,9 +24,3 @@
   width: 40px;
   font-size: var(--font-size-l);
 }
-
-.nds-avatar--l,
-.nds-avatar--xl {
-  @extend .nds-avatar--m;
-}
-

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -9,18 +9,18 @@
 }
 
 .nds-avatar--xs {
-  height: 24px;
+  height: rem(24px);
   width: 24px;
   font-size: var(--font-size-s);
 }
 
 .nds-avatar--s {
-  height: 32px;
+  height: rem(32px);
   width: 32px;
 }
 
 .nds-avatar--m {
-  height: 40px;
+  height: rem(40px);
   width: 40px;
   font-size: var(--font-size-l);
 }

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -10,17 +10,17 @@
 
 .nds-avatar--xs {
   height: rem(24px);
-  width: 24px;
+  width: rem(24px);
   font-size: var(--font-size-s);
 }
 
 .nds-avatar--s {
   height: rem(32px);
-  width: 32px;
+  width: rem(32px);
 }
 
 .nds-avatar--m {
   height: rem(40px);
-  width: 40px;
+  width: rem(40px);
   font-size: var(--font-size-l);
 }

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -1,8 +1,7 @@
 .nds-avatar {
-  width: 100px;
-  height: 500px;
+  width: 32px;
+  height: 32px;
   color: white;
-  border: 2px solid black;
   border-radius: 50%;
   display: flex;
   justify-content: center;

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -5,6 +5,7 @@
   align-items: center;
   justify-content: center;
   position: relative;
+  text-transform: uppercase;
 }
 
 .nds-avatar--xs {

--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -1,9 +1,29 @@
 .nds-avatar {
-  width: 32px;
-  height: 32px;
   color: white;
   border-radius: 50%;
   display: flex;
   justify-content: center;
   position: relative;
 }
+
+.nds-avatar--xs {
+  height: 24px;
+  width: 24px;
+  font-size: var(--font-size-s);
+}
+
+.nds-avatar--s {
+  height: 32px;
+  width: 32px;
+}
+
+.nds-avatar--m {
+  height: 40px;
+  width: 40px;
+}
+
+.nds-avatar--l,
+.nds-avatar--xl {
+  @extend .nds-avatar--m;
+}
+

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -17,9 +17,7 @@ export const WithImage = () => {
 };
 
 export const WithLink = () => {
-  return (
-    <Avatar initials="CP" label="Christian Paz" linkurl="https://narmi.com" />
-  );
+  return <Avatar initials="NM" label="Narmi" linkurl="https://narmi.com" />;
 };
 
 export const Sizes = () => {

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/jsx-key */
+import React, { useState } from "react";
+import Avatar from "../Avatar";
+
+// FIXME: code and story for `footerContent`
+// FIXME: code and story for render prop trigger
+
+export const Overview = () => {
+  return (
+    <div style={{ margin: "8rem" }}>
+      <Avatar initials="CP" label="Christian Paz" />
+    </div>
+  );
+};
+
+export default {
+  title: "Components/Avatar",
+  component: Avatar,
+};

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable react/jsx-key */
 import React from "react";
-import Avatar from "../Avatar";
+import Avatar from "./";
 import Row from "../Row";
 
 export const Overview = () => {

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable react/jsx-key */
-import React, { useState } from "react";
+import React from "react";
 import Avatar from "../Avatar";
-
-// FIXME: code and story for `footerContent`
-// FIXME: code and story for render prop trigger
 
 const Template = (args) => <Avatar {...args} />;
 

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -5,6 +5,8 @@ import Avatar from "../Avatar";
 // FIXME: code and story for `footerContent`
 // FIXME: code and story for render prop trigger
 
+const Template = (args) => <Avatar {...args} />;
+
 export const Overview = () => {
   return (
     <div style={{ margin: "8rem" }}>

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -1,14 +1,40 @@
 /* eslint-disable react/jsx-key */
 import React from "react";
 import Avatar from "../Avatar";
-
-const Template = (args) => <Avatar {...args} />;
+import Row from "../Row";
 
 export const Overview = () => {
+  return <Avatar initials="CP" label="Christian Paz" />;
+};
+
+export const WithImage = () => {
   return (
-    <div style={{ margin: "8rem" }}>
-      <Avatar initials="CP" label="Christian Paz" />
-    </div>
+    <Avatar
+      imgurl="https://media.licdn.com/dms/image/v2/D4E0BAQHnVTkZjhvlQg/company-logo_200_200/company-logo_200_200/0/1680295112021?e=2147483647&v=beta&t=-4A2TRSHuDiBT_anhoqTULvjXfzVh7_vZApmdXUVzsc"
+      label="Narmi linked in logo"
+    />
+  );
+};
+
+export const WithLink = () => {
+  return (
+    <Avatar initials="CP" label="Christian Paz" linkurl="https://narmi.com" />
+  );
+};
+
+export const Sizes = () => {
+  return (
+    <Row>
+      <Row.Item>
+        <Avatar initials="xs" label="extra small" size="xs" />
+      </Row.Item>
+      <Row.Item>
+        <Avatar initials="s" label="small" size="s" />
+      </Row.Item>
+      <Row.Item>
+        <Avatar initials="m" label="medium" size="m" />
+      </Row.Item>
+    </Row>
   );
 };
 

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -14,7 +14,6 @@ export interface AvatarProps {
   imgurl?: string;
   // Optional: URL to navigate to when the avatar is clicked
   linkurl?: string;
-  testId?: string;
 }
 
 const Avatar = ({

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -1,0 +1,72 @@
+import React, { PropsWithChildren } from "react";
+import PropTypes from "prop-types";
+import cc from "classcat";
+import AsElement from "../util/AsElement";
+
+/**
+ * Child component of `Row`.
+ * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
+ */
+const Avatar = ({
+  label = "",
+  size = "m",
+  initials = "",
+  imgurl = "",
+  linkurl = "",
+  children,
+  testId,
+}: PropsWithChildren<{
+  label?: string;
+  size?: "xs" | "s" | "m" | "l" | "xl";
+  initials?: string;
+  imgurl?: string;
+  linkurl?: string;
+  testId?: string;
+}>) => {
+  if (initials && imgurl) {
+    console.warn(
+      "Avatar component received both initials and imgurl props. Defaulting to imgurl.",
+    );
+  }
+  if (!initials && !imgurl) {
+    throw new Error(
+      "Avatar component requires either initials or imgurl prop.",
+    );
+  }
+  return (
+    <AsElement
+      elementType={linkurl ? "a" : "div"}
+      className={cc([
+        "nds-typography",
+        "nds-avatar",
+        // `nds-avatar--${size}`,
+        "alignChild--center--center",
+        "bgColor--theme--primary",
+      ])}
+      aria-label={label}
+      data-testid={testId}
+    >
+      <div className="nds-avatar">{initials}</div>
+    </AsElement>
+  );
+};
+
+Avatar.propTypes = {
+  /**
+   * When `true`, the row item shrinks to content size of its children.
+   * Otherwise, the item will expand to fill remaining space in the row.
+   */
+  label: PropTypes.string,
+  /** The html element to render as the root node of `Row` */
+  size: PropTypes.oneOf(["xs", "s", "m", "l", "xl"]),
+  /** Optional: controls className while maintaining default nds-row-item styling if left unspecified */
+  className: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]),
+  /** Optional value for `data-testid` attribute */
+  testId: PropTypes.string,
+};
+
+export default Avatar;

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -4,15 +4,15 @@ import cc from "classcat";
 import AsElement from "../util/AsElement";
 
 export interface AvatarProps {
-  // aria-label for accessibility
+  /** aria-label for accessibility */
   label: string;
-  // Fixed height and width of the avatar. Default: "s".
+  /** Fixed height and width of the avatar. Default: "s". */
   size?: "xs" | "s" | "m";
-  // String to display in the avatar. If imgurl is provided, this will be ignored.
+  /** String to display in the avatar. If imgurl is provided, this will be ignored. */
   initials?: string;
-  // Optional: URL of the image to display in the avatar. If provided, initials will be ignored.
+  /** Optional: URL of the image to display in the avatar. If provided, initials will be ignored. */
   imgurl?: string;
-  // Optional: URL to navigate to when the avatar is clicked
+  /** Optional: URL to navigate to when the avatar is clicked */
   linkurl?: string;
 }
 
@@ -22,7 +22,6 @@ const Avatar = ({
   initials,
   imgurl,
   linkurl,
-  testId,
 }: AvatarProps) => {
   const backgroundImage = imgurl
     ? { backgroundImage: `url(${imgurl})`, backgroundSize: "cover" }
@@ -46,24 +45,6 @@ const Avatar = ({
       {initials}
     </AsElement>
   );
-};
-
-Avatar.propTypes = {
-  /**
-   * When `true`, the row item shrinks to content size of its children.
-   * Otherwise, the item will expand to fill remaining space in the row.
-   */
-  label: PropTypes.string,
-  /** The html element to render as the root node of `Row` */
-  size: PropTypes.oneOf(["xs", "s", "m", "l", "xl"]),
-  /** Optional: controls className while maintaining default nds-row-item styling if left unspecified */
-  className: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]),
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
 };
 
 export default Avatar;

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -3,45 +3,44 @@ import PropTypes from "prop-types";
 import cc from "classcat";
 import AsElement from "../util/AsElement";
 
-/**
- * Child component of `Row`.
- * When a `Row.Item` has a boolean prop of `shrink`, it will shrink to content width.
- */
-const Avatar = ({
-  label = "",
-  size = "m",
-  initials = "",
-  imgurl = "",
-  linkurl = "",
-  testId,
-}: {
-  label?: string;
-  size?: "xs" | "s" | "m" | "l" | "xl";
+export interface AvatarProps {
+  // aria-label for accessibility
+  label: string;
+  // Fixed height and width of the avatar. Default: "s".
+  size?: "xs" | "s" | "m";
+  // String to display in the avatar. If imgurl is provided, this will be ignored.
   initials?: string;
+  // Optional: URL of the image to display in the avatar. If provided, initials will be ignored.
   imgurl?: string;
+  // Optional: URL to navigate to when the avatar is clicked
   linkurl?: string;
   testId?: string;
-}) => {
-  if (initials && imgurl) {
-    console.warn(
-      "Avatar component received both initials and imgurl props. Defaulting to imgurl.",
-    );
-  }
-  if (!initials && !imgurl) {
-    throw new Error(
-      "Avatar component requires either initials or imgurl prop.",
-    );
-  }
+}
+
+const Avatar = ({
+  label,
+  size = "s",
+  initials,
+  imgurl,
+  linkurl,
+  testId,
+}: AvatarProps) => {
+  const backgroundImage = imgurl
+    ? { backgroundImage: `url(${imgurl})`, backgroundSize: "cover" }
+    : {};
+
   return (
     <AsElement
       elementType={linkurl ? "a" : "div"}
+      href={linkurl}
       className={cc([
         "nds-typography",
         "nds-avatar",
-        // `nds-avatar--${size}`,
+        `nds-avatar--${size}`,
         "alignChild--center--center",
         "bgColor--theme--primary",
       ])}
+      style={backgroundImage}
       aria-label={label}
       data-testid={testId}
     >

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import AsElement from "../util/AsElement";
@@ -13,16 +13,15 @@ const Avatar = ({
   initials = "",
   imgurl = "",
   linkurl = "",
-  children,
   testId,
-}: PropsWithChildren<{
+}: {
   label?: string;
   size?: "xs" | "s" | "m" | "l" | "xl";
   initials?: string;
   imgurl?: string;
   linkurl?: string;
   testId?: string;
-}>) => {
+}) => {
   if (initials && imgurl) {
     console.warn(
       "Avatar component received both initials and imgurl props. Defaulting to imgurl.",

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -40,7 +40,6 @@ const Avatar = ({
       ])}
       style={backgroundImage}
       aria-label={label}
-      data-testid={testId}
     >
       {initials}
     </AsElement>

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cc from "classcat";
 import AsElement from "../util/AsElement";
 

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -46,7 +46,7 @@ const Avatar = ({
       aria-label={label}
       data-testid={testId}
     >
-      <div className="nds-avatar">{initials}</div>
+      {initials}
     </AsElement>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ require("./index.scss");
 
 import AutocompleteModal from "./AutocompleteModal";
 import Alert from "./Alert";
+import Avatar from "./Avatar";
 import Button from "./Button";
 import Checkbox from "./Checkbox";
 import ContentCard from "./ContentCard";
@@ -49,6 +50,7 @@ import formatDate from "./formatters/formatDate";
 export {
   AutocompleteModal,
   Alert,
+  Avatar,
   Button,
   Checkbox,
   ContentCard,

--- a/src/index.scss
+++ b/src/index.scss
@@ -56,6 +56,7 @@
 // Components
 @import "Alert/";
 @import "AutocompleteModal/";
+@import "Avatar/";
 @import "RadioButtons/";
 @import "Input/";
 @import "DateInput/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
  * Typed Components
  */
 import AutocompleteModal from "./AutocompleteModal";
+import Avatar from "./Avatar";
 import DisabledShim from "./DisabledShim";
 import SeparatorList from "./SeparatorList";
 import Slider from "./Slider";
@@ -53,8 +54,9 @@ declare const formatDate;
 
 export * from "./types/Icon.types";
 export {
-  // typed  
+  // typed
   AutocompleteModal,
+  Avatar,
   DisabledShim,
   SeparatorList,
   Slider,


### PR DESCRIPTION
closes https://linear.app/narmi/issue/NDS-638/%5Bavatar%5D-new-nds-component
Initial implementation of `Avatar` component

- Supports 3 sizes xs, s, m
- Supports an optional image background
- Supports an optional link. If you click the avatar button, it will navigate you to that link.