### PR TITLE
Feat/nds 571 drawer sticky footer

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -27,6 +27,7 @@ const Drawer = ({
   position = "right",
   depth = "70%",
   paddingSize = "xxl",
+  footer,
   testId,
 }) => {
   const shimRef = useRef(null);
@@ -162,7 +163,6 @@ const Drawer = ({
       style={depthStyle}
       className={cc([
         "drawer",
-        `padding--all--${paddingSize}`,
         `drawer--${position}`,
         {
           [`drawer--open--${position}`]: isOpen && isTransitioning,
@@ -172,26 +172,40 @@ const Drawer = ({
       role="dialog"
       data-testid={testId}
     >
-      {isVerticalMobileDrawer && (
-        <>
-          {showControls && (
-            <>
-              <div className="mobile-navigation-button" onClick={onPrev}>
-                <span className="narmi-icon-chevron-left fontSize--heading3" />
-              </div>
-              <div className="mobile-navigation-button" onClick={onNext}>
-                <span className="narmi-icon-chevron-right fontSize--heading3" />
-              </div>
-            </>
-          )}
-          <div className="mobile-navigation-button" onClick={onUserDismiss}>
-            <span className="narmi-icon-x clickable fontSize--heading3" />
-          </div>
-        </>
+      <div className={cc(["drawer-content", `padding--all--${paddingSize}`])}>
+        {isVerticalMobileDrawer && (
+          <>
+            {showControls && (
+              <>
+                <div className="mobile-navigation-button" onClick={onPrev}>
+                  <span className="narmi-icon-chevron-left fontSize--heading3" />
+                </div>
+                <div className="mobile-navigation-button" onClick={onNext}>
+                  <span className="narmi-icon-chevron-right fontSize--heading3" />
+                </div>
+              </>
+            )}
+            <div className="mobile-navigation-button" onClick={onUserDismiss}>
+              <span className="narmi-icon-x clickable fontSize--heading3" />
+            </div>
+          </>
+        )}
+        {typeof children === "function"
+          ? children({ isVisible: isTransitioning })
+          : children}
+      </div>
+      {footer && (
+        <div
+          className={cc([
+            "drawer-footer",
+            "border--top",
+            `padding--x--${paddingSize}`,
+            "padding--y--s",
+          ])}
+        >
+          {footer}
+        </div>
       )}
-      {typeof children === "function"
-        ? children({ isVisible: isTransitioning })
-        : children}
     </div>
   );
 
@@ -260,6 +274,8 @@ Drawer.propTypes = {
    * Sets the padding amount, or disable padding by passing "none"
    */
   paddingSize: PropTypes.oneOf(["none", "xs", "s", "m", "l", "xl", "xxl"]),
+  /** Contents of Drawer footer, typically reserved for action buttons */
+  footer: PropTypes.node,
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
 };

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -7,12 +7,22 @@
 .drawer {
   background: var(--bgColor-neutralGrey);
   height: 100%;
-  overflow: auto;
   position: fixed;
+  display: flex;
+  flex-direction: column;
   transition: transform var(--transition-speed-fast) ease;
   border: var(--border-size-s);
   border-color: var(--border-color-light);
   z-index: 3;
+}
+.drawer-content {
+  overflow: auto;
+  flex-grow: 1;
+}
+.drawer-footer {
+  flex-basis: auto;
+  flex-grow: 0;
+  height: initial;
 }
 .drawer--left {
   top: 0;
@@ -51,7 +61,9 @@ this class only applies to mobile drawers that open from the right or left,
 because we need to replace the left/right controls with controls that are inside the drawer
 */
 .drawer--vertical--mobile {
-  padding: 48px var(--space-l);
+  .drawer-content {
+    padding: 48px var(--space-l);
+  }
   .mobile-navigation-button {
     .narmi-icon-x,
     .narmi-icon-chevron-left,

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -3,6 +3,7 @@ import Drawer from "./";
 import Button from "../Button";
 import Popover from "../Popover";
 import Dialog from "../Dialog";
+import Row from "../Row";
 
 const CONTENTS = [
   <>
@@ -238,6 +239,93 @@ export const ContentWithDialog = () => {
         >
           <p>Dialog overlapping a Drawer</p>
         </Dialog>
+      </Drawer>
+    </>
+  );
+};
+
+export const WithFooter = (args) => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setIsDrawerOpen(true)}>Open Drawer</Button>
+      <Drawer
+        isOpen={isDrawerOpen}
+        onUserDismiss={() => setIsDrawerOpen(false)}
+        footer={
+          <Row alignItems="center">
+            <Row.Item shrink>
+              <Button kind="negative" label="Cancel" />
+            </Row.Item>
+            <Row.Item shrink>
+              <Button kind="primary" label="Save" />
+            </Row.Item>
+          </Row>
+        }
+        {...args}
+      >
+        <h3>
+          This content area will become scrollable whenever the content
+          overflows its container
+        </h3>
+        <p>
+          Lorem ipsum dolor sit amet. Ea fugiat dolore quo possimus adipisci est
+          ipsum libero ab dolores minima ut facere rerum? Aut vitae sint ut nemo
+          nisi ut tempore voluptas. Eum adipisci quasi eum praesentium libero
+          est quidem consequatur At voluptatum debitis et laborum ducimus aut
+          eaque eligendi.
+        </p>
+        <p>
+          Ut alias eligendi ut dolorem eius rem consectetur ullam et natus
+          nihil. Et maiores dolores hic nesciunt quibusdam ut laboriosam earum
+          qui quas sapiente in molestiae accusantium.
+        </p>
+        <p>
+          Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+          eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+          voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt
+          qui sequi placeat. Non voluptatem molestiae et explicabo voluptas ut
+          facilis quia?
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet. Ea fugiat dolore quo possimus adipisci est
+          ipsum libero ab dolores minima ut facere rerum? Aut vitae sint ut nemo
+          nisi ut tempore voluptas. Eum adipisci quasi eum praesentium libero
+          est quidem consequatur At voluptatum debitis et laborum ducimus aut
+          eaque eligendi.
+        </p>
+        <p>
+          Ut alias eligendi ut dolorem eius rem consectetur ullam et natus
+          nihil. Et maiores dolores hic nesciunt quibusdam ut laboriosam earum
+          qui quas sapiente in molestiae accusantium.
+        </p>
+        <p>
+          Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+          eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+          voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt
+          qui sequi placeat. Non voluptatem molestiae et explicabo voluptas ut
+          facilis quia?
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet. Ea fugiat dolore quo possimus adipisci est
+          ipsum libero ab dolores minima ut facere rerum? Aut vitae sint ut nemo
+          nisi ut tempore voluptas. Eum adipisci quasi eum praesentium libero
+          est quidem consequatur At voluptatum debitis et laborum ducimus aut
+          eaque eligendi.
+        </p>
+        <p>
+          Ut alias eligendi ut dolorem eius rem consectetur ullam et natus
+          nihil. Et maiores dolores hic nesciunt quibusdam ut laboriosam earum
+          qui quas sapiente in molestiae accusantium.
+        </p>
+        <p>
+          Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+          eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+          voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt
+          qui sequi placeat. Non voluptatem molestiae et explicabo voluptas ut
+          facilis quia?
+        </p>
       </Drawer>
     </>
   );

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -254,7 +254,7 @@ export const WithFooter = (args) => {
         isOpen={isDrawerOpen}
         onUserDismiss={() => setIsDrawerOpen(false)}
         footer={
-          <Row alignItems="center">
+          <Row alignItems="center" justifyContent="space-between">
             <Row.Item shrink>
               <Button kind="negative" label="Cancel" />
             </Row.Item>

--- a/src/Row/index.js
+++ b/src/Row/index.js
@@ -17,6 +17,9 @@ const _getRowStyle = (alignItems, justifyContent, gapSize) => {
   }
   result.alignItems = alignItems === "top" ? "flex-start" : alignItems;
   result.justifyContent = `flex-${justifyContent}`;
+  if (justifyContent === "space-between") {
+    result.justifyContent = justifyContent;
+  }
   return result;
 };
 
@@ -55,7 +58,7 @@ Row.propTypes = {
   /** Controls vertical alignment of items within the row */
   alignItems: PropTypes.oneOf(["top", "center"]),
   /** Controls horizontal flex justification */
-  justifyContent: PropTypes.oneOf(["start", "end"]),
+  justifyContent: PropTypes.oneOf(["start", "end", "space-between"]),
   /** The html element to render as the root node of `Row` */
   as: PropTypes.oneOf(["span", "div", "ul"]),
   /** Optional: controls className while maintaining default nds-row styling if left unspecified */


### PR DESCRIPTION
closes NDS-571

- Adds `footer` prop to `Drawer` that renders a sticky footer, regardless of Drawer `position`
- Adds `space-between` as a valid `justifyContent` prop value of `Row`


<img width="950" alt="Screenshot 2024-11-27 at 6 48 28 PM" src="https://github.com/user-attachments/assets/c9e1d87d-7b45-46fd-95e5-a251810cedc2">
<img width="986" alt="Screenshot 2024-11-27 at 6 48 42 PM" src="https://github.com/user-attachments/assets/f08cfd23-dab4-4ba3-acc7-fbcc8f65e16f">
<img width="984" alt="Screenshot 2024-11-27 at 6 49 04 PM" src="https://github.com/user-attachments/assets/fefdfd2f-61d6-420b-803b-d5ea8d5e45ac">
<img width="808" alt="Screenshot 2024-11-27 at 6 49 13 PM" src="https://github.com/user-attachments/assets/73c10c16-2609-490c-a968-7c43ed4a4d15">
<img width="528" alt="Screenshot 2024-11-27 at 6 49 33 PM" src="https://github.com/user-attachments/assets/507ffbce-1769-49ed-b094-42904f3599aa">
