### PR TITLE
build: add timing to webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:jsdoc": "node ./scripts/jsDoc.mjs",
     "build:classdoc": "node ./scripts/classManifest.mjs",
     "build:tokens": "style-dictionary build --config=./tokens/config.js",
-    "build:components": "webpack --mode=production",
+    "build:components": "/usr/bin/time -h webpack --mode=production",
     "build": "npx tsc && npm run build:tokens && npm run build:jsdoc && npm run build:classdoc && npm run build:components",
     "build:clean": "rm -rf dist/ && npm run build",
     "prepublish": "npm run build",


### PR DESCRIPTION
closes #1413 

Uses linux `time` command to print timing of full webpack compile whenever the webpack CLI is called.


#### Example output

```
webpack 5.96.1 compiled with 3 warnings in 5647 ms
	6.23s real		11.89s user		0.69s sys
```