### PR TITLE
feat(ContentCard): add 'button' and 'toggle' kinds

### DIFF
--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -14,7 +14,9 @@
   border: 1px solid var(--color-lightGrey) !important;
 }
 
-.nds-contentCard--interactive {
+.nds-contentCard--interactive, // DEPRECATED
+.nds-contentCard--button,
+.nds-contentCard--toggle {
   border: 1px solid var(--color-lightGrey) !important;
   &:hover,
   &:active,

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -19,7 +19,29 @@ Overview.args = {
   ),
 };
 
-export const SelectableCard = () => {
+export const ButtonCard = () => (
+  <ContentCard
+    kind="button"
+    onClick={() => {
+      alert("button card clicked");
+    }}
+  >
+    <h3 className="fontSize--heading4 padding--bottom--xs">Button card</h3>
+    <div className="fontSize--s fontColor--secondary">
+      This card behaves like an html <code>button</code>.
+    </div>
+  </ContentCard>
+);
+ButtonCard.parameters = {
+  docs: {
+    description: {
+      story:
+        "Cards of kind `toggle` support a selected state that can be controlled with the `isSelected` prop.",
+    },
+  },
+};
+
+export const ToggleCard = () => {
   const [isCardSelected, setIsCardSelected] = useState(false);
 
   const handleClick = () => {
@@ -28,13 +50,11 @@ export const SelectableCard = () => {
 
   return (
     <ContentCard
-      kind="interactive"
+      kind="toggle"
       onClick={handleClick}
       isSelected={isCardSelected}
     >
-      <h3 className="fontSize--heading4 padding--bottom--xs">
-        Selectable card
-      </h3>
+      <h3 className="fontSize--heading4 padding--bottom--xs">Toggle card</h3>
       <div className="fontSize--s fontColor--secondary">
         This card is currently{" "}
         <em>{isCardSelected ? "selected" : "not selected"}</em>
@@ -42,11 +62,11 @@ export const SelectableCard = () => {
     </ContentCard>
   );
 };
-SelectableCard.parameters = {
+ToggleCard.parameters = {
   docs: {
     description: {
       story:
-        "Cards of kind `interactive` support a selected state that can be controlled with the `isSelected` prop.",
+        "Cards of kind `toggle` support a selected state that can be controlled with the `isSelected` prop.",
     },
   },
 };


### PR DESCRIPTION
Closes NDS-755

We use `ContentCard` in both Transfer menu cards (acting as buttons) and product selection cards in AO (acting as toggles).

The problem is that the `interactive` variant of `ContentCard` was being used in both places when that variant was originally only designed for the toggle behavior in AO.

## The fix
This PR adds more granular `kind` props and deprecates `interactive` (in a non-breaking way).
- `toggle` - behaves like a toggle button (old `interactive` prop maps to this)
- `button` - behaves like an HTML button, without selected state

<img width="1127" alt="Screenshot 2024-12-03 at 5 07 08 PM" src="https://github.com/user-attachments/assets/3a83bd69-23ca-4a0a-9bd2-38133a349802">


