### PR TITLE
fix(Select): actions count as empty strings for typeahead

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -99,6 +99,7 @@ export const isSelectedItemInCategory = (selectedItem, categoryChildren) => {
  */
 // eslint-disable-next-line no-unused-vars
 const defaultGetTypeAheadString = (userInput = "", selectItem) => {
+  if (isAction(selectItem)) return "";
   return selectItem.props.searchValue || selectItem.props.value;
 };
 
@@ -276,7 +277,7 @@ const Select = ({
               "rounded--bottom": layerSide === "bottom",
               "rounded--top": layerSide === "top",
               [`nds-select-list--active--${layerSide}`]: showMenu,
-              "nds-select-list--error": !!errorText
+              "nds-select-list--error": !!errorText,
             },
           ])}
           {...getMenuProps(layerProps)}


### PR DESCRIPTION
Closes NDS-787

When a `Select.Action` is present in a `Select`, typeahead behavior can cause a critical error where we try to call a `toLowerCase` on `undefined`.

`Select.Action` subcomponents are present in the list of `items` we pass to the downshift state management library in order to make them navigable and selectable in the menu, however, they do not have a `value` or `searchValue` prop to search against. 

This PR excludes Action subcomponents from our default typeahead function in order to ensure that function _always_ returns a string.

And yes, this would have never happened if the component was authored in Typescript.