### PR TITLE
Create a custom context menu

### DIFF
--- a/src/ContextMenu/ContextMenuItem.tsx
+++ b/src/ContextMenu/ContextMenuItem.tsx
@@ -17,6 +17,7 @@ export const VALID_ICON_NAMES = iconSelection.icons.map(
   (icon) => icon.properties.name,
 );
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used for enforcing type checking
 const ContextMenuItem = (props: ContextMenuItemProps) => <></>;
 
 ContextMenuItem.displayName = "MenuButton.Item";

--- a/src/ContextMenu/ContextMenuItem.tsx
+++ b/src/ContextMenu/ContextMenuItem.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+// @ts-expect-error silence json file import error until JSON module can be resolved
+import iconSelection from "src/icons/selection.json";
+
+export interface ContextMenuItemProps {
+  /** Display label for menu item */
+  label: string;
+  /** ID for menu item */
+  id: string;
+  /** Selection handler */
+  onSelect: (label: string, id: string) => void;
+  /** Optional start icon for menu item */
+  startIcon?: string;
+}
+
+export const VALID_ICON_NAMES = iconSelection.icons.map(
+  (icon) => icon.properties.name,
+);
+
+const ContextMenuItem = (props: ContextMenuItemProps) => <></>;
+
+ContextMenuItem.displayName = "MenuButton.Item";
+
+export default ContextMenuItem;

--- a/src/ContextMenu/index.scss
+++ b/src/ContextMenu/index.scss
@@ -1,0 +1,53 @@
+%trigger-hover {
+  color: var(--theme-primary);
+  background-color: rgba(var(--theme-rgb-primary), var(--alpha-5));
+  text-decoration: none;
+}
+
+.nds-menubutton-trigger {
+  color: var(--font-color-secondary);
+  border-radius: var(--border-radius-s);
+
+  &--useCssHover {
+    &:focus button,
+    &:hover,
+    &:active {
+      @extend %trigger-hover;
+    }
+  }
+
+  // forces hover effect when menu is open
+  &--hovered {
+    @extend %trigger-hover;
+  }
+}
+
+.nds-context-menu-popover {
+  z-index: 4;
+}
+
+.nds-context-menu {
+  white-space: nowrap;
+  background-color: var(--color-white);
+  box-shadow: var(--elevation-high);
+  outline: none;
+}
+
+.nds-context-menu-item {
+  user-select: none;
+  cursor: pointer;
+  display: block;
+  color: inherit;
+  font: inherit;
+  text-decoration: initial;
+  outline: none;
+
+  &--highlighted {
+    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}

--- a/src/ContextMenu/index.stories.tsx
+++ b/src/ContextMenu/index.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import ContextMenu from "./index";
+
+const Template = (args) => <ContextMenu {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  children: (
+    <h1
+      style={{
+        border: "1px dashed black",
+      }}
+    >
+      Context Menu
+    </h1>
+  ),
+  menuItems: [
+    <ContextMenu.Item
+      key="edit"
+      startIcon="edit-2"
+      label="Edit"
+      id="random-edit-uuid"
+      onSelect={(label, id) => {
+        alert(`Label: ${label} - ID: ${id}`);
+      }}
+    />,
+    <ContextMenu.Item
+      key="screenshot"
+      startIcon="camera"
+      label="Screenshot"
+      id="screenshot"
+      onSelect={(label, id) => {
+        alert(`Label: ${label} - ID: ${id}`);
+      }}
+    />,
+    <ContextMenu.Item
+      key="deposit"
+      startIcon="bank"
+      label="Deposit"
+      id="deposit"
+      onSelect={(label, id) => {
+        alert(`Label: ${label} - ID: ${id}`);
+      }}
+    />,
+  ],
+};
+
+export default {
+  title: "Components/ContextMenu",
+  component: ContextMenu,
+};

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect } from "react";
+import { MenuTrigger, Menu, MenuItem } from "react-aria-components";
+import { useLayer, useMousePositionAsTrigger } from "react-laag";
+import cc from "classcat";
+import ContextMenuItem from "./ContextMenuItem";
+import Row from "../Row";
+
+export interface ContextMenuProps {
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** ContextMenu.Item children */
+  menuItems: React.ReactElement[];
+  /** React element for enabling custom context menu */
+  children: React.ReactNode;
+}
+
+/**
+ * ContextMenu is a wrapper component that provides a custom context menu for the children element.
+ *
+ * The menu can be trigger by right-clicking on the element or by pressing Control + F12.
+ */
+function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isMouseOverEventEnabled, setIsMouseOverEventEnabled] =
+    React.useState(true);
+  const { handleMouseEvent, trigger, parentRef } = useMousePositionAsTrigger({
+    enabled: isMouseOverEventEnabled,
+  });
+
+  const { renderLayer, triggerProps, layerProps } = useLayer({
+    isOpen,
+    auto: true,
+    onOutsideClick: () => {
+      setIsOpen(false);
+      setIsMouseOverEventEnabled(true);
+    },
+    preferX: "right",
+    preferY: "bottom",
+    placement: "bottom-start",
+    trigger,
+  });
+
+  function handleContextMenuClick(
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) {
+    event.preventDefault();
+    setIsOpen(true);
+    setIsMouseOverEventEnabled(false);
+  }
+
+  function handleContextMenuKeyDown(
+    event: React.KeyboardEvent<HTMLDivElement>,
+  ) {
+    event.preventDefault();
+    if (event.key === "F12" && event.ctrlKey) {
+      setIsOpen(true);
+      setIsMouseOverEventEnabled(false);
+    }
+  }
+
+  const handleOnSelect = (itemId) => {
+    const selectedItem = menuItems.find((item) => item.props.id === itemId);
+
+    selectedItem.props.onSelect(
+      selectedItem.props.label,
+      selectedItem.props.id,
+    );
+    setIsOpen(false);
+    setIsMouseOverEventEnabled(true);
+  };
+
+  const handleKeyUp = ({ key }) => {
+    if (key === "Escape" && isOpen) {
+      setIsOpen(false);
+      setIsMouseOverEventEnabled(true);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [handleKeyUp]);
+
+  return (
+    <MenuTrigger
+      isOpen={true}
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          setIsOpen(isOpen);
+        }
+      }}
+      data-testid={testId}
+    >
+      <div
+        ref={parentRef}
+        role="button"
+        tabIndex={0}
+        aria-label="Press Control + F12 to open the context menu"
+        onContextMenu={handleContextMenuClick}
+        onKeyDown={handleContextMenuKeyDown}
+        onMouseMove={handleMouseEvent}
+        {...triggerProps}
+      >
+        {children}
+      </div>
+      {isOpen &&
+        renderLayer(
+          <div className="nds-context-menu-popover" {...layerProps}>
+            <Menu
+              onAction={handleOnSelect}
+              className="nds-context-menu rounded--all elevation--high"
+            >
+              {menuItems.map((menuItem, menuItemIndex) => {
+                return (
+                  <MenuItem
+                    key={menuItem.props.id}
+                    id={menuItem.props.id}
+                    value={menuItem.props.id}
+                    className={({ isSelected, isFocused, isDisabled }) =>
+                      cc([
+                        "nds-context-menu-item",
+                        "padding--x--s padding--y--xs",
+                        {
+                          "nds-context-menu-item--highlighted":
+                            isSelected || isFocused,
+                          "nds-context-menu-item--disabled": isDisabled,
+                          "rounded--top": menuItemIndex === 0,
+                          "rounded--bottom":
+                            menuItemIndex === menuItems.length - 1,
+                        },
+                      ])
+                    }
+                  >
+                    <Row gapSize="s">
+                      {menuItem.props.startIcon && (
+                        <Row.Item shrink>
+                          <span
+                            className={`narmi-icon-${menuItem.props.startIcon}`}
+                          />
+                        </Row.Item>
+                      )}
+                      <Row.Item>{menuItem.props.label}</Row.Item>
+                    </Row>
+                  </MenuItem>
+                );
+              })}
+            </Menu>
+          </div>,
+        )}
+    </MenuTrigger>
+  );
+}
+
+ContextMenu.Item = ContextMenuItem;
+
+export default ContextMenu;

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -76,13 +76,23 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     }
   };
 
+  const handleNativeContextMenu = (event: MouseEvent) => {
+    if (!parentRef.current?.contains(event.target as Node)) {
+      setIsOpen(false);
+      setIsMouseOverEventEnabled(true);
+    }
+  };
+
   useEffect(() => {
     window.addEventListener("keyup", handleKeyUp);
+    // Right click event listener
+    window.addEventListener("contextmenu", handleNativeContextMenu);
+
     return () => {
       window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("contextmenu", handleNativeContextMenu);
     };
   }, [handleKeyUp]);
-
   return (
     <MenuTrigger
       isOpen={true}

--- a/src/index.scss
+++ b/src/index.scss
@@ -64,6 +64,7 @@
 @import "Combobox/";
 @import "ContentCard/";
 @import "CollapsibleCard/";
+@import "ContextMenu/";
 @import "IconButton/";
 @import "MenuButton/";
 @import "LoadingShim/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 import AutocompleteModal from "./AutocompleteModal";
 import Avatar from "./Avatar";
+import ContextMenu from "./ContextMenu";
 import DisabledShim from "./DisabledShim";
 import SeparatorList from "./SeparatorList";
 import Slider from "./Slider";
@@ -57,6 +58,7 @@ export {
   // typed
   AutocompleteModal,
   Avatar,
+  ContextMenu,
   DisabledShim,
   SeparatorList,
   Slider,


### PR DESCRIPTION

Implementation of ContextMenu.
- ContextMenu wraps other elements or components to enable a list of menu items. 
- The list of menu items can be open by right clicking on the wrapped element or press "Control + F12" when the wrapper element is focused.
- Since there is no consist way to open context menu from the OS level, instruction for opening context menu is included in aria-label.
- The implementation of this component is influence by MenuButton 


https://linear.app/narmi/issue/ADMIN-4019/[frontend]-add-right-click-menu