### PR TITLE
feat(Select): allow flat categories; add label category kind

### DIFF
--- a/src/Select/SelectCategory.js
+++ b/src/Select/SelectCategory.js
@@ -9,11 +9,17 @@ const SelectCategory = ({ children }) => {
 SelectCategory.displayName = "Select.Category";
 
 SelectCategory.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  /**
+   * heading: default bold heading
+   * label: match input floating label
+   */
+  kind: PropTypes.oneOf(["heading", "label"]),
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]),
+  isFlat: PropTypes.bool,
 };
 
 export default SelectCategory;

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -294,7 +294,6 @@ const Select = ({
           {showMenu &&
             hasCategories &&
             categories.map(({ label, kind, categoryChildren, isFlat }) => {
-              console.info(isFlat);
               return isFlat ? (
                 <>
                   {label && (

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -301,6 +301,7 @@ const Select = ({
                     <h4
                       id={`select-category-${label}`}
                       className={cc([
+                        "fontFamily--default",
                         "padding--x--s padding--y--xs",
                         {
                           [`select-category-title--label`]: kind === "label",

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -305,7 +305,7 @@ const Select = ({
                         {
                           [`select-category-title--label`]: kind === "label",
                           [`select-category-title--heading`]:
-                            kind === "heading" || !kind,
+                            kind === "heading",
                         },
                       ])}
                     >

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -135,6 +135,10 @@ const Select = ({
     categories = allChildren.map(({ props }) => ({
       label: props.label,
       categoryChildren: React.Children.toArray(props.children),
+      // eslint-disable-next-line react/prop-types
+      kind: props.kind,
+      // eslint-disable-next-line react/prop-types
+      isFlat: props.isFlat,
     }));
   } else {
     items = allChildren;
@@ -289,25 +293,62 @@ const Select = ({
         >
           {showMenu &&
             hasCategories &&
-            categories.map(({ label, categoryChildren }) => (
-              <details
-                key={label}
-                className="nds-select-category"
-                {...getDetailsProps(categoryChildren)} // controls open state
-              >
-                <summary className="fontWeight--bold alignChild--left--center padding--x--s padding--y-xs">
-                  <span id={`select-category-${label}`}>{label}</span>
-                  <span className="nds-category-icon narmi-icon-chevron-down" />
-                  <span className="nds-category-icon narmi-icon-chevron-up" />
-                </summary>
-                <ul
-                  className="list--reset"
-                  aria-labelledby={`select-category-${label}`}
+            categories.map(({ label, kind, categoryChildren, isFlat }) => {
+              console.info(isFlat);
+              return isFlat ? (
+                <>
+                  {label && (
+                    <h4
+                      id={`select-category-${label}`}
+                      className={cc([
+                        "padding--x--s padding--y--xs",
+                        {
+                          [`select-category-title--label`]: kind === "label",
+                          [`select-category-title--heading`]:
+                            kind === "heading" || !kind,
+                        },
+                      ])}
+                    >
+                      {label}
+                    </h4>
+                  )}
+                  <ul
+                    className="list--reset"
+                    aria-labelledby={`select-category-${label}`}
+                  >
+                    {categoryChildren.map((item) => renderItem(item, items))}
+                  </ul>
+                </>
+              ) : (
+                <details
+                  key={label}
+                  className="nds-select-category"
+                  {...getDetailsProps(categoryChildren)} // controls open state
                 >
-                  {categoryChildren.map((item) => renderItem(item, items))}
-                </ul>
-              </details>
-            ))}
+                  <summary
+                    className={cc([
+                      "alignChild--left--center",
+                      "padding--x--s padding--y--xs",
+                      {
+                        [`select-category-title--label`]: kind === "label",
+                        [`select-category-title--heading`]:
+                          kind === "heading" || !kind,
+                      },
+                    ])}
+                  >
+                    <span id={`select-category-${label}`}>{label}</span>
+                    <span className="nds-category-icon narmi-icon-chevron-down" />
+                    <span className="nds-category-icon narmi-icon-chevron-up" />
+                  </summary>
+                  <ul
+                    className="list--reset"
+                    aria-labelledby={`select-category-${label}`}
+                  >
+                    {categoryChildren.map((item) => renderItem(item, items))}
+                  </ul>
+                </details>
+              );
+            })}
           {showMenu && !hasCategories && (
             <ul className="list--reset">
               {items.map((item) => renderItem(item, items))}

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -6,12 +6,12 @@
   &:focus {
     outline: none;
   }
-  
+
   &--active--top,
   &--active--bottom {
     border: 1px solid var(--theme-primary);
   }
-  
+
   &--error {
     border: 1px solid var(--color-errorDark);
   }
@@ -73,4 +73,15 @@
     top: 50%;
     transform: translate(rem(1px), -50%);
   }
+}
+
+.select-category-title--heading {
+  font-weight: var(--font-weight-bold);
+}
+
+.select-category-title--label {
+  font-family: var(--font-family-body);
+  font-weight: var(--font-weight-normal);
+  font-size: var(--font-size-xs);
+  color: var(--color-mediumGrey);
 }

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -77,10 +77,10 @@
 
 .select-category-title--heading {
   font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-default);
 }
 
 .select-category-title--label {
-  font-family: var(--font-family-body);
   font-weight: var(--font-weight-normal);
   font-size: var(--font-size-xs);
   color: var(--color-mediumGrey);

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -126,6 +126,72 @@ WithCategories.parameters = {
   },
 };
 
+export const ExpandedCategories = Template.bind({});
+ExpandedCategories.args = {
+  id: "expandedCategories",
+  label: "Select an Icon",
+  children: [
+    <Select.Category label="Transportation" isFlat>
+      <Select.Item value="truck">
+        <span className="narmi-icon-truck padding--right--xs" /> Truck
+      </Select.Item>
+      <Select.Item value="anchor">
+        <span className="narmi-icon-anchor padding--right--xs" /> Anchor
+      </Select.Item>
+      <Select.Item value="car-outline">
+        <span className="narmi-icon-car-outline padding--right--xs" /> Car
+      </Select.Item>
+    </Select.Category>,
+    <Select.Category label="Art" isFlat>
+      <Select.Item value="film">
+        <span className="narmi-icon-film padding--right--xs" /> Film
+      </Select.Item>
+      <Select.Item value="aperture">
+        <span className="narmi-icon-aperture padding--right--xs" /> Aperture
+      </Select.Item>
+      <Select.Item value="pen">
+        <span className="narmi-icon-pen-tool padding--right--xs" /> Pen
+      </Select.Item>
+      <Select.Item value="blob">
+        <span className="narmi-icon-blob padding--right--xs" /> Blob
+      </Select.Item>
+    </Select.Category>,
+  ],
+};
+ExpandedCategories.parameters = {
+  docs: {
+    description: {
+      story: "Categories may be set to always be open with the `expand` prop.",
+    },
+  },
+};
+
+export const CategoryLabels = Template.bind({});
+CategoryLabels.args = {
+  id: "categoryLabels",
+  label: "Select an Icon",
+  children: [
+    <Select.Category label="Recently used" isFlat kind="label">
+      <Select.Item value="truck">
+        <span className="narmi-icon-truck padding--right--xs" /> Truck
+      </Select.Item>
+      <Select.Item value="anchor">
+        <span className="narmi-icon-anchor padding--right--xs" /> Anchor
+      </Select.Item>
+      <Select.Item value="car-outline">
+        <span className="narmi-icon-car-outline padding--right--xs" /> Car
+      </Select.Item>
+    </Select.Category>,
+  ],
+};
+ExpandedCategories.parameters = {
+  docs: {
+    description: {
+      story: "Categories may be set to always be open with the `expand` prop.",
+    },
+  },
+};
+
 export const CustomTypeahead = Template.bind({});
 CustomTypeahead.args = {
   id: "customTypeaheadString",

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -126,8 +126,8 @@ WithCategories.parameters = {
   },
 };
 
-export const ExpandedCategories = Template.bind({});
-ExpandedCategories.args = {
+export const FlatCategories = Template.bind({});
+FlatCategories.args = {
   id: "expandedCategories",
   label: "Select an Icon",
   children: [
@@ -158,10 +158,10 @@ ExpandedCategories.args = {
     </Select.Category>,
   ],
 };
-ExpandedCategories.parameters = {
+FlatCategories.parameters = {
   docs: {
     description: {
-      story: "Categories may be set to always be open with the `expand` prop.",
+      story: "Categories may be set to always be open with the `isFlat` prop.",
     },
   },
 };

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -184,7 +184,7 @@ CategoryLabels.args = {
     </Select.Category>,
   ],
 };
-ExpandedCategories.parameters = {
+FlatCategories.parameters = {
   docs: {
     description: {
       story: "Categories may be set to always be open with the `expand` prop.",


### PR DESCRIPTION
Closes NDS-810

Adds some additional functionality to Category subcomponents in `Select`.

- Categories may be rendered flat and open via the `isFlat` prop
- Categories may be rendered with different label types via the `kind` prop


<img width="725" alt="Screenshot 2024-12-11 at 7 13 14 PM" src="https://github.com/user-attachments/assets/4da61307-c3e8-49e7-9d82-529059c7699b" />
<img width="917" alt="Screenshot 2024-12-11 at 7 36 39 PM" src="https://github.com/user-attachments/assets/39533909-e8bc-4cb9-8c16-2a06e7ca7ba2" />
<img width="443" alt="Screenshot 2024-12-11 at 7 30 52 PM" src="https://github.com/user-attachments/assets/b25d74cd-3e42-474d-b66f-a72e90acc495" />
