### PR TITLE
fix(ContextMenu): fix missing export for ContextMenu in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import Avatar from "./Avatar";
 import Button from "./Button";
 import Checkbox from "./Checkbox";
 import ContentCard from "./ContentCard";
-import ContentCard from "./ContentCard";
+import ContextMenu from "./ContextMenu";
 import CollapsibleCard from "./CollapsibleCard";
 import Combobox from "./Combobox";
 import DateInput from "./DateInput";

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export {
   Button,
   Checkbox,
   ContentCard,
+  ContextMenu,
   CollapsibleCard,
   Combobox,
   DateInput,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Avatar from "./Avatar";
 import Button from "./Button";
 import Checkbox from "./Checkbox";
 import ContentCard from "./ContentCard";
+import ContentCard from "./ContentCard";
 import CollapsibleCard from "./CollapsibleCard";
 import Combobox from "./Combobox";
 import DateInput from "./DateInput";


### PR DESCRIPTION
ContextMenu was included in `index.ts` but I didn't realize it also need to be export it in `index.js`. This fix should make sure ContextMenu can be imported properly.

Ticket: https://linear.app/narmi/issue/ADMIN-4066/[frontend]-fix-context-menu-export-issue