### PR TITLE
fix(disabledShim): Add full width to disabledShim

### DIFF
--- a/src/DisabledShim/index.scss
+++ b/src/DisabledShim/index.scss
@@ -1,6 +1,8 @@
 .nds-disabledShim {
   position: relative;
+  width: 100%;
 }
+
 .nds-disabledShim--disabled::after {
   content: "";
   user-select: none;


### PR DESCRIPTION
For [AO-2050](https://linear.app/narmi/issue/AO-2050/staff-led-status-is-misaligned-header-color-incorrect). Add full-width to `disabledShim`