### PR TITLE
refactor(Storybook): switch reactDocgen option to react-docgen-typescript

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,7 @@ const path = require("path");
 
 module.exports = {
   typescript: {
-    reactDocgen: "react-docgen",
+    reactDocgen: "react-docgen-typescript",
   },
 
   stories: [


### PR DESCRIPTION
Currently Storybook uses `react-docgen` for generating documentations from type definition for components written in TypeScript. Although it is faster than `react-docgen-typescript` but it is incomplete based on the [Storybook Documentation](https://storybook.js.org/docs/api/main-config/main-config-typescript#reactdocgen). It is unable to properly show union of string literals. 

**`react-docgen`**

![Screenshot 2024-12-19 at 10 47 07 AM](https://github.com/user-attachments/assets/a902ebec-5ce3-4268-8691-f8273cb47f7d)


**`react-docgen-typescript`**
![Screenshot 2024-12-19 at 10 45 52 AM](https://github.com/user-attachments/assets/2c5e195c-62d1-435d-a3d0-064418d85c6f)
