### PR TITLE
fix(TypeScript): add a `json.d.ts` file to remove @ts-expect-error when importing JSON file

### DIFF
--- a/src/ContextMenu/ContextMenuItem.tsx
+++ b/src/ContextMenu/ContextMenuItem.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-// @ts-expect-error silence json file import error until JSON module can be resolved
 import iconSelection from "src/icons/selection.json";
 
 export interface ContextMenuItemProps {

--- a/src/json.d.ts
+++ b/src/json.d.ts
@@ -1,0 +1,5 @@
+declare module "*.json" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const value: any;
+  export default value;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,10 @@
     "jsx": "react-jsx",
     "emitDeclarationOnly": true,
     "outDir": "./dist/types",
+    "resolveJsonModule": true
   },
   "files": [
-    "src/index.ts"
+    "src/index.ts",
+    "src/json.d.ts"
   ]
 }


### PR DESCRIPTION
Previously, I suppress the TS error when importing a JSON file. Instead of doing that in all TS files, let's add a JSON module.    

Technically, we don't want to use `any` for JSON values, but I suspect we won't get too much value from making them precisely typed and the amount to work is non-trivial.    

https://linear.app/narmi/issue/NDS-837/[nds]-add-declaration-file-for-json

