### PR TITLE
fix(TextInput): add error data attr for e2e tests

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -92,6 +92,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
             placeholder={props.label}
             aria-label={props.label}
             data-testid={testId}
+            data-error={inputError}
             {...nativeElementProps}
           />
         </div>
@@ -107,6 +108,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
           aria-label={props.label}
           placeholder={props.label}
           data-testid={testId}
+          data-error={inputError}
           {...nativeElementProps}
         />
       )}


### PR DESCRIPTION
closes NDS-839

In NDS version 4.1.0, the `error` attribute we've been adding to the underlying input elements of `TextInput` were removed because it is not a valid HTML attribute.

This however, [broke end to end tests](https://github.com/narmi/banking/actions/runs/12550357532/job/34992989179?pr=55087#step:22:170), as we relied on that attribute to make assertions.

This PR reintroduces the attribute as a data attribute, `data-error`. After this change merges we can update our e2e test assertion helper to use the data attribute in [the PR that upgrades NDS for all web products](https://github.com/narmi/banking/pull/55087)