### PR TITLE
Fix/nds 834 dialog ios keyboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8138,14 +8138,14 @@
       }
     },
     "node_modules/@semantic-release/changelog": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
-      "integrity": "sha512-FT+tAGdWHr0RCM3EpWegWnvXJ05LQtBkQUaQRIExONoXjVjLuOILNm4DEKNaV+GAQyJjbLRVs57ti//GypH6PA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
       },
       "engines": {
@@ -8156,18 +8156,17 @@
       }
     },
     "node_modules/@semantic-release/changelog/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -14977,15 +14976,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -43548,24 +43538,23 @@
       }
     },
     "@semantic-release/changelog": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
-      "integrity": "sha512-FT+tAGdWHr0RCM3EpWegWnvXJ05LQtBkQUaQRIExONoXjVjLuOILNm4DEKNaV+GAQyJjbLRVs57ti//GypH6PA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
           "dev": true,
           "requires": {
-            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
@@ -48596,12 +48585,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -96,7 +96,7 @@ const Dialog = ({
   const dialogJSX = (
     <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
       <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
-        <FocusLock autoFocus={false}>
+        <FocusLock autoFocus={false} className="nds-dialog-focuslock">
           <div
             role="dialog"
             aria-labelledby="aria-dialog-label"

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -3,16 +3,13 @@
 }
 
 .nds-shim--dark {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  position: absolute;
+  top: env(safe-area-inset-top, 0px);
+  right: env(safe-area-inset-right, 0px);
+  bottom: env(safe-area-inset-bottom, 0px);
+  left: env(safe-area-inset-left, 0px);
   background-color: var(--bgColor-scrimDark);
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
-  min-height: 100vh;
+  min-height: 100dvh;
   z-index: 3;
 
   // create spaces around viewport edges for tablet or larger
@@ -41,6 +38,23 @@
   transition: opacity 200ms;
 }
 
+.nds-dialog-focuslock {
+  position: absolute;
+  top: env(safe-area-inset-top, 0px);
+  bottom: env(safe-area-inset-bottom, 0px);
+
+  // bottom align the dialog within the available area
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  // for tablet or larger, display the modal dialog as a floating box.
+  @include atMediaUp("s") {
+    position: static;
+    height: auto !important;
+  }
+}
+
 .nds-dialog {
   position: relative;
   background-color: var(--bgColor-white);
@@ -51,15 +65,10 @@
   border-top-right-radius: var(--border-radius-m);
   border-top-left-radius: var(--border-radius-m);
 
-  // the modal dialog takes over the whole screen by default
-  // (small viewports)
-  height: 96vh; // fall back to 196vh for older mobile browsers
-  height: 96dvh; // prevents toolbar overlap in modern mobile browsers
-  width: 100vw;
+  max-height: 96%; // relative to parent, .nds-dialog-focuslock
 
   // for tablet or larger, display the modal dialog as a floating box.
   @include atMediaUp("s") {
-    height: auto !important;
     border-radius: var(--border-radius-m);
     max-height: 80vh; // prevent modal from being taller than the shim content box
     min-width: 240px; // should be no narrower than this on larger viewports

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -139,6 +139,27 @@ ScrollingContent.args = {
         sequi placeat. Non voluptatem molestiae et explicabo voluptas ut facilis
         quia?
       </p>
+      <p>
+        Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+        eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+        voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt qui
+        sequi placeat. Non voluptatem molestiae et explicabo voluptas ut facilis
+        quia?
+      </p>
+      <p>
+        Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+        eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+        voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt qui
+        sequi placeat. Non voluptatem molestiae et explicabo voluptas ut facilis
+        quia?
+      </p>
+      <p>
+        Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
+        eveniet deleniti qui sapiente quia At repellendus veritatis. Qui
+        voluptatem culpa et fugit debitis ut fugit quidem sit omnis deserunt qui
+        sequi placeat. Non voluptatem molestiae et explicabo voluptas ut facilis
+        quia?
+      </p>
     </>
   ),
 };


### PR DESCRIPTION
Closes NDS-834

Fixes ios Safari issue where the footer is cut off by the bottom of the viewport or keyboard.

This also brings `Dialog` within design specs for how height should behave on mobile sized screens - the Dialog should only be tall enough to accommodate its content. The height of the dialog should max out just below the top of the screen so that a little bit of shim is always visible.


### Before
<img width="399" alt="Screenshot 2024-12-30 at 7 18 03 PM" src="https://github.com/user-attachments/assets/668c4701-0a11-47b6-89f1-ac1693d65090" />


### After
<img width="443" alt="Screenshot 2024-12-30 at 7 19 25 PM" src="https://github.com/user-attachments/assets/64e4f5f7-109f-4800-aff8-43d7c511d41c" />
![Dec-30-2024 19-21-44](https://github.com/user-attachments/assets/00fd45a4-d243-4992-8d81-132998535817)


## How / Why

The original bug was due to the `FocusLock` component adding a div between the shim and the dialog. 

The FocusLock div became the implicit flex child of the shim. We were setting constraints on the `nds-dialog` element when we should have been setting constraints on the shim, which creates a more reliable cross browser layout.

#### Shim layout responsibilities (`.nds-shim`)
- cover the entire viewport, within the mobile "safe area". The `env()` functions in CSS take a second argument as a fallback. We set them to inset `0px`.

#### FocusLock div layout responsibilities (`.nds-dialog-focuslock`)
- Absolutely positions itself to the full height of the "safe area" via `env()` functions for top and bottom position
- Set a flex column so that the Dialog is always justified to the bottom of the FocusLock div

#### Dialog div layout responsibilities (`.nds-dialog`)
- Allow the entire dialog to grow in height, but **only up to 96% of its parent container, the FocusLock div**