### PR TITLE
feat(Avatar): add fallback user icon

### DIFF
--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -19,6 +19,18 @@ export const WithLink = () => {
   return <Avatar initials="NM" label="Narmi" linkurl="https://narmi.com" />;
 };
 
+export const WithFallbackIcon = () => {
+  return <Avatar label="Narmi" />;
+};
+WithFallbackIcon.parameters = {
+  docs: {
+    description: {
+      story:
+        "Avatar will render a fallback user icon when `initials` or `imgurl` are not passed.",
+    },
+  },
+};
+
 export const Sizes = () => {
   return (
     <Row>

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -25,6 +25,8 @@ const Avatar = ({
   const backgroundImage = imgurl
     ? { backgroundImage: `url(${imgurl})`, backgroundSize: "cover" }
     : {};
+  const hasInitials = !imgurl && initials;
+  const hasIcon = !imgurl && !initials;
 
   return (
     <AsElement
@@ -39,7 +41,8 @@ const Avatar = ({
       style={backgroundImage}
       aria-label={label}
     >
-      {initials}
+      {hasInitials && initials}
+      {hasIcon && <span className="narmi-icon-user fontSize--heading3" />}
     </AsElement>
   );
 };


### PR DESCRIPTION
closes NDS-753

When `initials` and `imgurl` are both unpopulated, the Avatar will now render a fallback user icon:

<img width="607" alt="Screenshot 2025-01-03 at 11 33 42 AM" src="https://github.com/user-attachments/assets/00031f63-c148-4433-a1ce-240f9f9b0a1d" />
