### PR TITLE
fix(Select): allow actions when using categories

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -129,13 +129,12 @@ const Select = ({
   testId,
 }) => {
   let items = []; // List of all item types to pass to downshift state management
-  let options = []; // All Select.Item options
   let categories = []; // Categories extracted from Select.Category children
-  let actions = []; // All Select.Action items
+  const options = React.Children.toArray(children).filter(
+    (item) => !isAction(item),
+  ); // All Select.Item options
+  const actions = React.Children.toArray(children).filter(isAction); // All Select.Action items
   const [userInput, setUserInput] = useState(""); // most recent val the user typed while focused on this input
-
-  options = React.Children.toArray(children).filter((item) => !isAction(item));
-  actions = React.Children.toArray(children).filter(isAction);
 
   // If categories are being used, extract items from categories
   if (options.some(({ type }) => type.displayName === "Select.Category")) {

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -58,9 +58,16 @@ export const getItemByValue = (value, items) => {
  * @param {array} items downshift index `items`
  * @returns {Number} index of item
  */
-export const getItemIndex = ({ props }, items) => {
-  const values = items.map(({ props }) => props.value);
-  return values.indexOf(props.value);
+export const getItemIndex = (item, items) => {
+  let result = 0;
+  if (isAction(item)) {
+    result = items
+      .map(({ props }) => props.onSelect)
+      .indexOf(item.props.onSelect);
+  } else {
+    result = items.map(({ props }) => props.value).indexOf(item.props.value);
+  }
+  return result;
 };
 
 /**
@@ -86,7 +93,7 @@ export const isHighlightedInCategory = (
  * @returns {Boolean} if the selected item is in the given category children
  */
 export const isSelectedItemInCategory = (selectedItem, categoryChildren) => {
-  if (!selectedItem) return false;
+  if (!selectedItem || isAction(selectedItem)) return false;
   const selectedValue = selectedItem.props.value;
   const categoryValues = categoryChildren.map((child) => child.props.value);
   return categoryValues.includes(selectedValue);
@@ -121,18 +128,22 @@ const Select = ({
   errorText,
   testId,
 }) => {
-  let items = [];
-  let categories = [];
+  let items = []; // List of all item types to pass to downshift state management
+  let options = []; // All Select.Item options
+  let categories = []; // Categories extracted from Select.Category children
+  let actions = []; // All Select.Action items
   const [userInput, setUserInput] = useState(""); // most recent val the user typed while focused on this input
 
-  const allChildren = React.Children.toArray(children);
+  options = React.Children.toArray(children).filter((item) => !isAction(item));
+  actions = React.Children.toArray(children).filter(isAction);
 
   // If categories are being used, extract items from categories
-  if (allChildren.some(({ type }) => type.displayName === "Select.Category")) {
-    items = allChildren.flatMap(({ props }) =>
-      React.Children.toArray(props.children),
-    );
-    categories = allChildren.map(({ props }) => ({
+  if (options.some(({ type }) => type.displayName === "Select.Category")) {
+    items = [
+      ...options.flatMap(({ props }) => React.Children.toArray(props.children)),
+      ...actions,
+    ];
+    categories = options.map(({ props }) => ({
       label: props.label,
       categoryChildren: React.Children.toArray(props.children),
       // eslint-disable-next-line react/prop-types
@@ -141,7 +152,7 @@ const Select = ({
       isFlat: props.isFlat,
     }));
   } else {
-    items = allChildren;
+    items = [...options, ...actions];
   }
 
   const downshiftOpts = {
@@ -349,9 +360,15 @@ const Select = ({
                 </details>
               );
             })}
+          {showMenu && hasCategories && (
+            <ul className="list--reset">
+              {actions.map((action) => renderItem(action, items))}
+            </ul>
+          )}
           {showMenu && !hasCategories && (
             <ul className="list--reset">
-              {items.map((item) => renderItem(item, items))}
+              {options.map((option) => renderItem(option, items))}
+              {actions.map((action) => renderItem(action, items))}
             </ul>
           )}
         </div>,

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -156,6 +156,15 @@ FlatCategories.args = {
         <span className="narmi-icon-blob padding--right--xs" /> Blob
       </Select.Item>
     </Select.Category>,
+    <Select.Action
+      onSelect={() => {
+        alert("action taken");
+      }}
+    >
+      <span className="fontColor--pine fontWeight--bold">
+        <span className="narmi-icon-plus padding--right--xs" /> Add new
+      </span>
+    </Select.Action>,
   ],
 };
 FlatCategories.parameters = {


### PR DESCRIPTION
Closes NDS-809

## The bug
When a `Select` with `Select.Category` components present also included a `Select.Action`, the action would create its own empty category.

Example:
![image](https://github.com/user-attachments/assets/ce77081a-7ffa-48a6-88ce-edefb14be429)


## The fix
We now extract children a little differently, treating actions (`Select.Action`) as a different set than selectable options (`Select.Item`). 

Separating these out gives us full control over how each renders, which allows us to ensure the actions always render in a flat list at the bottom of the options list.

`Select.Action` and `Select.Children` are merged into the `items` array that gets passed to the Downshift hook. Downshift uses the `items` array by index to keep track of hover/arrow/selection states.

## Testing
In the storybook preview build, see the "Flat Categories" story of `Select`, which now contains an action.