### PR TITLE
fix(Select): increase cateogry header style specificity

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -338,7 +338,7 @@ const Select = ({
                   <summary
                     className={cc([
                       "alignChild--left--center",
-                      "padding--x--s padding--y--xs",
+                      "padding--x--s",
                       {
                         [`select-category-title--label`]: kind === "label",
                         [`select-category-title--heading`]:

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -76,12 +76,12 @@
 }
 
 .select-category-title--heading {
-  font-weight: var(--font-weight-bold);
-  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-bold) !important;
+  font-size: var(--font-size-default) !important;
 }
 
 .select-category-title--label {
-  font-weight: var(--font-weight-normal);
-  font-size: var(--font-size-xs);
-  color: var(--color-mediumGrey);
+  font-weight: var(--font-weight-normal) !important;
+  font-size: var(--font-size-xs) !important;
+  color: var(--color-mediumGrey) !important;
 }


### PR DESCRIPTION
closes NDS-849

## The bug
Category headers render as `h4` html elements. There are some places in `banking` that still rely on the `nds-typography` class, which includes `font-size` and `font-weight` rules for all heading tags, causing awkwardly big category headers:
<img width="551" alt="Screenshot 2025-01-07 at 5 03 59 PM" src="https://github.com/user-attachments/assets/32fa0fc1-ca37-4a44-ba38-54c7c659f54b" />

## The fix

- Increase specificity of Select category label styles
- Remove vertical padding from collapsible categories

<img width="918" alt="Screenshot 2025-01-07 at 5 10 16 PM" src="https://github.com/user-attachments/assets/f4e9f956-4896-4a9d-a9e4-abedcc875049" />


