### PR TITLE
fix(AutocompleteModal): make AutocompleteModal height adjust to small amount of items

### DIFF
--- a/src/AutocompleteModal/index.scss
+++ b/src/AutocompleteModal/index.scss
@@ -10,7 +10,8 @@
 .nds-autocompleteModal-positionedEl {
   min-width: rem(248px);
   max-width: rem(352px);
-  height: rem(312px);
+  height: auto;
+  max-height: rem(312px);
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
When the number of auto complete items are not enough to take up all the vertical space, it will show white background. This behavior is caused by using fixed height on `AutocompleteModal`. 

### With fixed height 
![Screenshot 2025-01-08 at 11 10 50 AM](https://github.com/user-attachments/assets/c1f286bc-1c84-4120-865f-a3afae9613bc)

### With height adjusts to the content
![Screenshot 2025-01-08 at 11 11 29 AM](https://github.com/user-attachments/assets/d14d2447-6a52-4ffb-b4f6-f8a9fcb32b47)


Ticket: https://linear.app/narmi/issue/NDS-850/[nds]-make-autocompletemodal-height-adjustable