### PR TITLE
refactor(Button): convert Button to typescript

### DIFF
--- a/src/Button/Spinner.tsx
+++ b/src/Button/Spinner.tsx
@@ -1,11 +1,25 @@
 import React from "react";
-import PropTypes from "prop-types";
+
+export interface SpinnerProps {
+  /**
+   * Square size of spinner as unitless number
+   */
+  size?: number;
+  /**
+   * Width of animated stroke
+   */
+  strokeWidth?: number;
+  /**
+   * CSS color value
+   */
+  color?: string | undefined;
+}
 
 const Spinner = ({
   size = 28,
   strokeWidth = 3,
   color = "var(--color-white)",
-}) => (
+}: SpinnerProps) => (
   <div className="nds-spinner" style={{ height: size, width: size }}>
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,20 +42,5 @@ const Spinner = ({
     </svg>
   </div>
 );
-
-Spinner.propTypes = {
-  /**
-   * Square size of spinner as unitless number
-   */
-  size: PropTypes.number,
-  /**
-   * Width of animated stroke
-   */
-  strokeWidth: PropTypes.number,
-  /**
-   * CSS color value
-   */
-  color: PropTypes.string,
-}
 
 export default Spinner;

--- a/src/Button/index.stories.tsx
+++ b/src/Button/index.stories.tsx
@@ -1,6 +1,12 @@
 import React from "react";
-import Button, { VALID_ICON_NAMES } from "./";
+import Button from "./";
+import iconSelection from "../icons/selection.json";
 import Row from "../Row";
+import type { IconName } from "../types/Icon.types";
+
+const VALID_ICON_NAMES = iconSelection.icons.map(
+  (icon) => icon.properties.name,
+);
 
 const Template = (args) => <Button {...args} />;
 
@@ -87,7 +93,7 @@ export default {
   title: "Components/Button",
   component: Button,
   argTypes: {
-    startIcon: { options: ["", ...VALID_ICON_NAMES] },
-    endIcon: { options: ["", ...VALID_ICON_NAMES] },
+    startIcon: { options: ["", ...(VALID_ICON_NAMES as IconName)] },
+    endIcon: { options: ["", ...(VALID_ICON_NAMES as IconName)] },
   },
 };

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -1,14 +1,49 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cc from "classcat";
-import iconSelection from "src/icons/selection.json";
-import AsElement from "src/util/AsElement";
-import Row from "src/Row";
+import AsElement from "../util/AsElement";
+import Row from "../Row";
 import Spinner from "./Spinner";
+import type { IconName } from "../types/Icon.types";
 
-export const VALID_ICON_NAMES = iconSelection?.icons.map(
-  (icon) => icon.properties.name,
-);
+interface ButtonProps {
+  /** Renders the button label */
+  label: string;
+  /** style of button to render */
+  kind: "primary" | "secondary" | "tonal" | "negative" | "menu" | "plain";
+  /** Click callback, with event object passed as argument */
+  onClick?: (e: React.MouseEvent) => void;
+  /**
+   * The html element to render as the root node of `Button`.
+   *
+   * When rendering as an "a" you **MUST** pass an `href` attribute
+   * for the anchor to be valid.
+   */
+  as?: "a" | "button";
+  /** disables the button when set to `true` */
+  disabled?: boolean;
+  /** disables the button and adds a loading spinner when set to `true` */
+  isLoading?: boolean;
+  /** type attribute of button element */
+  type?: "submit" | "button" | "reset";
+  /** size variant of button */
+  size?: "xs" | "s" | "m";
+  /** Name of Narmi icon to place at the start of the label */
+  startIcon?: IconName | null;
+  /** Name of Narmi icon to place at the end of the label */
+  endIcon?: IconName | null;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** Optional value for setting the aria-label. If unset label will be used. */
+  ariaLabel?: string | null;
+  /**
+   * **⚠️ DEPRECATED**
+   *
+   * Passing children to render the button label will be removed
+   * in a future release. Use the `label` prop instead.
+   */
+  children?: React.ReactNode | string | undefined;
+  [x: string]: unknown; // spread props
+}
 
 /**
  * Narmi style action buttons.
@@ -34,16 +69,15 @@ const Button = ({
   as = "button",
   ariaLabel = null,
   ...otherProps
-}) => {
+}: ButtonProps) => {
   const isButtonElement = as === "button";
 
-  // support legacy method of passing label as children
-  let buttonLabel = label;
-  if (!buttonLabel) {
-    buttonLabel = children;
-  }
+  // support legacy method of passing label as children for now
+  const buttonLabel = label || children;
 
-  const Icon = ({ name }) => (
+  console.info(buttonLabel);
+
+  const Icon = ({ name }: { name: string }) => (
     <div className="alignChild--center--center">
       <i
         role="img"
@@ -53,9 +87,11 @@ const Button = ({
     </div>
   );
 
-  Icon.propTypes = {
-    name: PropTypes.string.isRequired,
-  };
+  const gapSizeMap = {
+    xs: "xs",
+    s: "xs",
+    m: "s",
+  } as const;
 
   return (
     <AsElement
@@ -88,16 +124,7 @@ const Button = ({
           </div>
         )}
         <div style={{ visibility: isLoading ? "hidden" : "visible" }}>
-          <Row
-            gapSize={
-              {
-                xs: "xs",
-                s: "xs",
-                m: "s",
-              }[size]
-            }
-            alignItems="center"
-          >
+          <Row gapSize={gapSizeMap[size]} alignItems="center">
             {startIcon && (
               <Row.Item shrink>
                 <Icon name={startIcon} />
@@ -116,52 +143,6 @@ const Button = ({
       </div>
     </AsElement>
   );
-};
-
-Button.propTypes = {
-  /**
-   * The html element to render as the root node of `Button`.
-   *
-   * When rendering as an "a" you **MUST** pass an `href` attribute
-   * for the anchor to be valid.
-   */
-  as: PropTypes.oneOf(["a", "button"]),
-  /** Renders the button label */
-  label: PropTypes.string,
-  /** disables the button when set to `true` */
-  disabled: PropTypes.bool,
-  /** disables the button and adds a loading spinner when set to `true` */
-  isLoading: PropTypes.bool,
-  /** style of button to render */
-  kind: PropTypes.oneOf([
-    "primary",
-    "secondary",
-    "tonal",
-    "negative",
-    "menu",
-    "plain",
-  ]),
-  /** type attribute of button element */
-  type: PropTypes.oneOf(["submit", "button", "reset"]),
-  /** size variant of button */
-  size: PropTypes.oneOf(["xs", "s", "m"]),
-  /** Click callback, with event object passed as argument */
-  onClick: PropTypes.func,
-  /** Name of Narmi icon to place at the start of the label */
-  startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
-  /** Name of Narmi icon to place at the end of the label */
-  endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
-  /** Optional value for setting the aria-label. If unset label will be used. */
-  ariaLabel: PropTypes.string,
-  /**
-   * **⚠️ DEPRECATED**
-   *
-   * Passing children to render the button label will be removed
-   * in a future release. Use the `label` prop instead.
-   */
-  children: PropTypes.node,
 };
 
 export default Button;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 import AutocompleteModal from "./AutocompleteModal";
 import Avatar from "./Avatar";
+import Button from "./Button";
 import ContextMenu from "./ContextMenu";
 import DisabledShim from "./DisabledShim";
 import Row from "./Row";
@@ -14,7 +15,6 @@ import Snackbar from "./Snackbar";
  * Untyped Components
  */
 declare const Alert;
-declare const Button;
 declare const Checkbox;
 declare const ContentCard;
 declare const CollapsibleCard;
@@ -59,6 +59,7 @@ export {
   // typed
   AutocompleteModal,
   Avatar,
+  Button,
   ContextMenu,
   DisabledShim,
   Row,
@@ -68,7 +69,6 @@ export {
 
   // untyped
   Alert,
-  Button,
   Checkbox,
   ContentCard,
   CollapsibleCard,


### PR DESCRIPTION
Closes NDS-872

Convert `Button` to typescript.

Once nice thing I noticed is that typescript hints will in fact carry the JSdoc comments with them in NDS, as we preserve comments in definition files.

Pretty neat:
<img width="715" alt="Screenshot 2025-01-10 at 11 34 54 AM" src="https://github.com/user-attachments/assets/a78a59ee-856a-449c-ad07-cf338d2d8a45" />
