### PR TITLE
fix(Button): make kind prop optional as it has a default val

### DIFF
--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -9,7 +9,7 @@ interface ButtonProps {
   /** Renders the button label */
   label: string;
   /** style of button to render */
-  kind: "primary" | "secondary" | "tonal" | "negative" | "menu" | "plain";
+  kind?: "primary" | "secondary" | "tonal" | "negative" | "menu" | "plain";
   /** Click callback, with event object passed as argument */
   onClick?: (e: React.MouseEvent) => void;
   /**


### PR DESCRIPTION
Prevents type errors on optional prop `kind` in the `Button` component.