### PR TITLE
feat(Alert): add paddingSize prop to control padding

### DIFF
--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -16,6 +16,8 @@ interface AlertProps {
   kind?: "info" | "error" | "success" | "warn";
   /** Override the default icon of the alert */
   icon?: IconName | string | null;
+  /** Size of padding for Alert */
+  paddingSize?: "xs" | "l";
   /** Message content of the Alert */
   children?: React.ReactNode | string;
 }
@@ -32,6 +34,7 @@ const Alert = ({
   onUserDismiss = noop,
   kind = "info",
   icon = null,
+  paddingSize = "l",
   children,
 }: AlertProps) => {
   const iconName = kind === "success" ? "check" : "info";
@@ -44,7 +47,7 @@ const Alert = ({
             "nds-alert",
             `nds-alert--${kind}`,
             "rounded--all",
-            "padding--all",
+            `padding--all--${paddingSize}`,
           ])}
         >
           <Row gapSize="s">


### PR DESCRIPTION
Added `paddingSize` prop to the Alert component for more flexible padding control. The default 20px padding can be excessive in certain cases, like inside a modal.

