### PR TITLE
fix(Dialog): position shim relative to viewport instead of document

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -2,6 +2,11 @@
   --overflow-gradient-height: 20px;
 }
 
+.nds-dialog-root {
+  position: fixed;
+  inset: 0;
+}
+
 .nds-shim--dark {
   position: absolute;
   top: env(safe-area-inset-top, 0px);
@@ -66,6 +71,7 @@
   border-top-left-radius: var(--border-radius-m);
 
   max-height: 96%; // relative to parent, .nds-dialog-focuslock
+  min-width: 100dvw;
 
   // for tablet or larger, display the modal dialog as a floating box.
   @include atMediaUp("s") {

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -132,6 +132,7 @@ ScrollingContent.args = {
         Et maiores dolores hic nesciunt quibusdam ut laboriosam earum qui quas
         sapiente in molestiae accusantium.
       </p>
+      <input type="text" />
       <p>
         Ut ducimus amet quo deleniti repellendus in illo eaque 33 nihil quis
         eveniet deleniti qui sapiente quia At repellendus veritatis. Qui

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -121,68 +121,70 @@ const Dialog = ({
   // the shim has events for mouse users only; does not require a role
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
-    <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
-      <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
-        <FocusLock autoFocus={false} className="nds-dialog-focuslock">
-          <div
-            role="dialog"
-            aria-labelledby="aria-dialog-label"
-            aria-modal="true"
-            className="nds-dialog"
-            // @ts-expect-error DetailedHTMLProps does not specify arbitrary custom properties
-            style={{ "--dialog-preferred-width": width }}
-            data-testid={testId}
-          >
+    <div className="nds-dialog-root">
+      <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
+        <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
+          <FocusLock autoFocus={false} className="nds-dialog-focuslock">
             <div
-              className={`nds-dialog-header nds-dialog-header--${headerStyle}`}
+              role="dialog"
+              aria-labelledby="aria-dialog-label"
+              aria-modal="true"
+              className="nds-dialog"
+              // @ts-expect-error DetailedHTMLProps does not specify arbitrary custom properties
+              style={{ "--dialog-preferred-width": width }}
+              data-testid={testId}
             >
-              {isBanner ? (
-                <div className="margin--y--s">
-                  <div
-                    className="padding--y--xxs"
-                    id="aria-dialog-label"
-                    style={{ textAlign: "center" }}
-                  >
-                    {title}
-                  </div>
-                  {closeButtonJSX}
-                </div>
-              ) : (
-                <>
-                  <h4 id="aria-dialog-label">{title}</h4>
-                  {closeButtonJSX}
-                </>
-              )}
-            </div>
-            {notification && (
-              <div className="nds-dialog-notification padding--y padding--x--xl">
-                {notification}
-              </div>
-            )}
-            <div
-              // content padding here
-              ref={contentRef}
-              className={cc([
-                "nds-dialog-content nds-typography padding--top--xs",
-                { "padding--bottom--xl": !footer || isContentOverflowing },
-              ])}
-            >
-              {children}
-            </div>
-            {footer && (
               <div
+                className={`nds-dialog-header nds-dialog-header--${headerStyle}`}
+              >
+                {isBanner ? (
+                  <div className="margin--y--s">
+                    <div
+                      className="padding--y--xxs"
+                      id="aria-dialog-label"
+                      style={{ textAlign: "center" }}
+                    >
+                      {title}
+                    </div>
+                    {closeButtonJSX}
+                  </div>
+                ) : (
+                  <>
+                    <h4 id="aria-dialog-label">{title}</h4>
+                    {closeButtonJSX}
+                  </>
+                )}
+              </div>
+              {notification && (
+                <div className="nds-dialog-notification padding--y padding--x--xl">
+                  {notification}
+                </div>
+              )}
+              <div
+                // content padding here
+                ref={contentRef}
                 className={cc([
-                  "nds-dialog-footer",
-                  { "nds-dialog-footer--overflowing": isContentOverflowing },
+                  "nds-dialog-content nds-typography padding--top--xs",
+                  { "padding--bottom--xl": !footer || isContentOverflowing },
                 ])}
               >
-                {footer}
+                {children}
               </div>
-            )}
-          </div>
-        </FocusLock>
-      </div>
-    </CSSTransition>
+              {footer && (
+                <div
+                  className={cc([
+                    "nds-dialog-footer",
+                    { "nds-dialog-footer--overflowing": isContentOverflowing },
+                  ])}
+                >
+                  {footer}
+                </div>
+              )}
+            </div>
+          </FocusLock>
+        </div>
+      </CSSTransition>
+    </div>
   );
   /* eslint-enable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
 


### PR DESCRIPTION
closes NDS-978

## The bug
We recently made a fix for iOS Safari to make Dialog positioning mobile keyboard aware, but we introduced a regression.
The Dialog shim was positioning itself relative to the `_document_` instead of the viewport. This causes layout issues when users are scrolled down a tall document element. as we observed in NDS-977.

## The fix
We always intended the DIalog to position itself relative to the viewport, so I added a root element that is positioned `fixed`.

Any `absolute` children of the root element will use the _nearest positioned parent_ instead of the document as its positioning reference.F

## Does it still work in iOS?
Yes.

![Feb-06-2025 16-41-43](https://github.com/user-attachments/assets/a53f431f-f147-4187-9134-88b5435591c1)
