### PR TITLE
feat(TruncatedAccount): add option for inline rendering

### DIFF
--- a/src/TruncatedAccount/index.js
+++ b/src/TruncatedAccount/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import cc from "classcat";
 import PropTypes from "prop-types";
 
 /**
@@ -6,8 +7,16 @@ import PropTypes from "prop-types";
  * This component will grow to the width of its parent container.
  * The account name will truncate with ellipsis as needed to fit the space.
  */
-const TruncatedAccount = ({ name, lastFour }) => (
-  <span className="nds-truncatedAccount" title={`${name} - ${lastFour}`}>
+const TruncatedAccount = ({ name, lastFour, isInline }) => (
+  <span
+    className={cc([
+      "nds-truncatedAccount",
+      {
+        "nds-truncatedAccount--inline": isInline,
+      },
+    ])}
+    title={`${name} - ${lastFour}`}
+  >
     <span className="whiteSpace--truncate">{name}</span>
     {lastFour && (
       <span role="img" className="padding--x--xxs">
@@ -25,6 +34,8 @@ TruncatedAccount.propTypes = {
   lastFour: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
+  /** When `true`, the TruncatedAccount root element will display inline instead of block */
+  isInline: PropTypes.bool,
 };
 
 export default TruncatedAccount;

--- a/src/TruncatedAccount/index.scss
+++ b/src/TruncatedAccount/index.scss
@@ -4,3 +4,8 @@
   justify-content: flex-start;
   align-items: center;
 }
+
+.nds-truncatedAccount--inline {
+  display: inline-flex;
+  width: auto;
+}

--- a/src/TruncatedAccount/index.stories.js
+++ b/src/TruncatedAccount/index.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import TruncatedAccount from "./";
-import Select from "../Select"
+import Select from "../Select";
 
 const Template = (args) => <TruncatedAccount {...args} />;
 
@@ -56,14 +56,39 @@ StylingThisComponent.parameters = {
   },
 };
 
+export const InlineLayout = () => (
+  <p>
+    Would you like to transfer money from{" "}
+    <strong>
+      <TruncatedAccount name="Primary Checking" lastFour={7633} isInline />
+    </strong>{" "}
+    to{" "}
+    <strong>
+      <TruncatedAccount name="Secondary Savings" lastFour={3444} isInline />
+    </strong>
+    ?
+  </p>
+);
+InlineLayout.parameters = {
+  docs: {
+    description: {
+      story:
+        "By default, the root element of `TruncatedAccount` displays block. Passing the `isInline` prop sets it to display inline.",
+    },
+  },
+};
+
 export const AccountSelector = () => (
-  <div style={{width:"500px"}}>
-    <Select label="Loan" >
+  <div style={{ width: "500px" }}>
+    <Select label="Loan">
       <Select.Item value="123">
         <TruncatedAccount name="A Loan" lastFour="1234 ($1,234.24)" />
       </Select.Item>
       <Select.Item value="234">
-        <TruncatedAccount name="My Favorite Loan With A Very Long Name" lastFour="33=0008 ($92,050.95)" />
+        <TruncatedAccount
+          name="My Favorite Loan With A Very Long Name"
+          lastFour="33=0008 ($92,050.95)"
+        />
       </Select.Item>
     </Select>
   </div>
@@ -76,7 +101,6 @@ AccountSelector.parameters = {
     },
   },
 };
-
 
 export default {
   title: "Components/TruncatedAccount",


### PR DESCRIPTION
closes NDS-1053

Adds `isInline` prop to allow inline display of `TruncatedAccount`