### PR TITLE
fix(Button): fix secondary background overflow

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -10,6 +10,7 @@
   justify-content: center;
   align-items: center;
   border-radius: rem(24px);
+  overflow: hidden;
 
   /* mobile buttons have slightly taller padding for ease of tapping */
   @media (max-width: #{map.get($breakpoints, "s")}) {


### PR DESCRIPTION

Fix https://linear.app/narmi/issue/NDS-1076/[nds]-background-overflows-on-secondary-button

### Before
<img width="308" alt="image" src="https://github.com/user-attachments/assets/bf6f72d2-0fc7-4e27-8ee9-37515fdb787c" />


### After

<img width="249" alt="image" src="https://github.com/user-attachments/assets/998e121b-238a-4313-9cf3-6deea0cedc9a" />
