### PR TITLE
fix(Radios): restore focus ring

### DIFF
--- a/src/Radio/index.scss
+++ b/src/Radio/index.scss
@@ -42,6 +42,10 @@
   border: 1px solid var(--theme-primary);
 }
 
+.nds-singleRadio:focus-within .nds-singleRadio-radio {
+  outline: 3px solid RGBA(var(--theme-rgb-primary), var(--alpha-10));
+}
+
 .nds-singleRadio input:checked + .nds-singleRadio-radio:after {
   display: block;
 }

--- a/src/RadioButtons/index.scss
+++ b/src/RadioButtons/index.scss
@@ -70,6 +70,10 @@
       border: 1px solid var(--theme-primary);
     }
 
+    &.nds-radiobuttons-option--focused .nds-radio {
+      outline: 3px solid RGBA(var(--theme-rgb-primary), var(--alpha-10));
+    }
+
     &.nds-radiobuttons-option--error .nds-radio {
       border-color: var(--color-errorDark);
     }


### PR DESCRIPTION
Closes NDS-799

### The problem
While we do have a `:focus` style for radio buttons, the only thing it does is darken the outline of the faux radio. When a radio set already has a selection (see below), there is no visual change to indicate the element is focused.
<img width="213" alt="Screenshot 2025-02-19 at 1 59 44 PM" src="https://github.com/user-attachments/assets/cb2c172d-dfd6-4dfe-b63a-dfbe7887b0ed" />
☝️ The user is focused on the second radio in this set, but you'd never know it by looking at it.


### The fix
To indicate focus, we can use the same visual treatment we use in `Checkbox`:
<img width="298" alt="Screenshot 2025-02-19 at 3 15 54 PM" src="https://github.com/user-attachments/assets/2d958fe8-82aa-4028-8529-f4e192b275cd" />

### After
<img width="267" alt="Screenshot 2025-02-19 at 3 19 04 PM" src="https://github.com/user-attachments/assets/2cb34263-868f-434e-8286-d89e58d3f3a5" />
<img width="127" alt="Screenshot 2025-02-19 at 3 19 29 PM" src="https://github.com/user-attachments/assets/574a2cea-9c18-49b9-bd2a-b8eac47e4d3f" />


