### PR TITLE
fix(collapsibleCard): title color should be theme primary

### DIFF
--- a/src/CollapsibleCard/index.js
+++ b/src/CollapsibleCard/index.js
@@ -92,6 +92,7 @@ const CollapsibleCard = ({
                   "fontSize--l",
                   "padding--top--l",
                   "fontFamily--body",
+                  "fontColor--theme--primary",
                   {
                     "padding--left--l": trigger !== "caret-start",
                   },


### PR DESCRIPTION
https://linear.app/narmi/issue/DEP-2471/update-colors-in-staff-led

The difference is subtle with the Moss green set as primary theme color:

Now:
<img width="336" alt="image" src="https://github.com/user-attachments/assets/fc0f99d3-1396-4986-bdcc-48252837e4b8" />

Previously:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/7acbfca1-5aad-4ed9-b008-846852280ecc" />
