### PR TITLE
fix(Drawer,Dialog): apply position and z-index on portal outlet

### DIFF
--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -193,6 +193,7 @@ const Dialog = ({
     if (!document.getElementById("outlet")) {
       const outlet = document.createElement("div");
       outlet.setAttribute("id", "outlet");
+      outlet.setAttribute("class", "outlet");
       document.body.appendChild(outlet);
     }
     return ReactDOM.createPortal(dialogJSX, document.getElementById("outlet"));

--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -240,6 +240,7 @@ const Drawer = ({
     if (!document.getElementById("outlet")) {
       const outlet = document.createElement("div");
       outlet.setAttribute("id", "outlet");
+      outlet.setAttribute("class", "outlet");
       document.body.appendChild(outlet);
     }
     return ReactDOM.createPortal(drawerJSX, document.getElementById("outlet"));

--- a/src/base-styles/portal.scss
+++ b/src/base-styles/portal.scss
@@ -1,0 +1,4 @@
+.outlet {
+  position: relative;
+  z-index: 100;
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -41,6 +41,7 @@
 @import "base-styles/defaults";
 @import "base-styles/typography";
 @import "base-styles/grid";
+@import "base-styles/portal";
 @import "base-styles/reach-ui"; // :FIXME: We may be able to remove this
 
 // Helper classes


### PR DESCRIPTION
Previous PR (https://github.com/narmi/design_system/pull/1532) address the z-index issue among a few NDS components. 
This PR includes z-index and position changes to make sure portal outlet element is properly overlay on top of other non-NDS components in the app when they use z-index. 

The following is an example of the issue I'm trying to address. The action bar with header "Applications" has the a z-index of 2.

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/3177f72f-70a4-4715-b1bc-e90df23b26a7" />
