### PR TITLE
fix(Dialog): prevent focus trap el from blocking shim clicks

### DIFF
--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -48,10 +48,14 @@
   top: env(safe-area-inset-top, 0px);
   bottom: env(safe-area-inset-bottom, 0px);
 
-  // bottom align the dialog within the available area
+  // bottom align the dialog within the available area on small screens
   display: flex;
   justify-content: center;
   align-items: flex-end;
+
+  // "shrink wrap" the focus trap element to the dialog and center it
+  width: fit-content;
+  margin: 0 auto;
 
   // for tablet or larger, display the modal dialog as a floating box.
   @include atMediaUp("s") {

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -121,8 +121,8 @@ const Dialog = ({
   // the shim has events for mouse users only; does not require a role
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
-    <div className="nds-dialog-root">
-      <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
+    <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
+      <div className="nds-dialog-root">
         <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
           <FocusLock autoFocus={false} className="nds-dialog-focuslock">
             <div
@@ -183,8 +183,8 @@ const Dialog = ({
             </div>
           </FocusLock>
         </div>
-      </CSSTransition>
-    </div>
+      </div>
+    </CSSTransition>
   );
   /* eslint-enable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
 


### PR DESCRIPTION
Closes NDS-1100

As Wenting helpfully pointed out, there's a specific area of the screen where you click the shim and nothing happens.

![dialog_inconsistent_dismissal_releases0](https://github.com/user-attachments/assets/f2b6bf71-836d-4a6b-9791-59afb6d659b4)
![Screenshot 2025-02-21 at 9 42 19 AM](https://github.com/user-attachments/assets/cf1f718e-d589-4ded-a48b-9c2892805021)


As it turns out the `FocusTrap` renders a div that has an `auto` width at screen sizes larger than `s`. 

This PR fixes this issue so that the focus trap element "shrink wraps" to the dialog area so it doesn't cover up the shim and intercept shim clicks.

### Mobile Safari is still good 👍 
<img width="478" alt="Screenshot 2025-02-21 at 2 56 00 PM" src="https://github.com/user-attachments/assets/acf4eabd-edb9-4204-af3a-d033800a09c3" />
<img width="422" alt="Screenshot 2025-02-21 at 2 56 06 PM" src="https://github.com/user-attachments/assets/5ab15d6d-8ee4-4c0c-bc7f-1758ce3fe94b" />

