### PR TITLE
fix(useLayer): render components using useLayer within portal div with id "outlet"

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -11,6 +11,7 @@ import ComboboxAction from "./ComboboxAction";
 import TextInput from "../TextInput";
 import Row from "../Row";
 import { getItemIndex } from "../Select";
+import { createUseLayerContainer } from "src/util/dom";
 
 const noop = () => {};
 
@@ -263,6 +264,7 @@ const Combobox = ({
       preferY: "bottom",
       triggerOffset: -3,
       containerOffset: 16,
+      container: createUseLayerContainer,
     });
 
   // renders a single combobox item

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -4,6 +4,7 @@ import { useLayer, useMousePositionAsTrigger } from "react-laag";
 import cc from "classcat";
 import ContextMenuItem from "./ContextMenuItem";
 import Row from "../Row";
+import { createUseLayerContainer } from "../util/dom";
 
 export interface ContextMenuProps {
   /** Optional value for `data-testid` attribute */
@@ -38,6 +39,7 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     preferY: "bottom",
     placement: "bottom-start",
     trigger,
+    container: createUseLayerContainer,
   });
 
   function handleContextMenuClick(

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -7,6 +7,8 @@ import Row from "../Row";
 import ContextMenu from "../ContextMenu";
 import MenuButton from "../MenuButton";
 import Select from "../Select";
+import Combobox from "../Combobox";
+import Tooltip from "../Tooltip";
 
 const CONTENTS = [
   <>
@@ -287,7 +289,10 @@ export const ContentWithDialog = () => {
             setIsDialogWithSelectOpen(false);
           }}
         >
-          <p>Dialog with Select overlapping a Drawer</p>
+          <Tooltip text="I am a tooltip, which is a tool for tips">
+            <p>Dialog with Select overlapping a Drawer</p>
+          </Tooltip>
+
           <Select id="overviewStory" label="Favorite icon">
             <Select.Item value="coffee">
               <span className="narmi-icon-coffee padding--right--xs" /> Coffee
@@ -302,6 +307,11 @@ export const ContentWithDialog = () => {
               <span className="narmi-icon-blob padding--right--xs" /> Blob
             </Select.Item>
           </Select>
+          <br />
+          <Combobox label="Select your state">
+            <Combobox.Item value="Alabama">Alabama</Combobox.Item>
+            <Combobox.Item value="Alaska">Alaska</Combobox.Item>
+          </Combobox>
         </Dialog>
       </Drawer>
     </>

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -11,6 +11,7 @@ import {
 import iconSelection from "src/icons/selection.json";
 import MenuButtonItem from "./MenuButtonItem";
 import Row from "../Row";
+import { createUseLayerContainer } from "src/util/dom";
 
 export const VALID_ICON_NAMES = iconSelection.icons.map(
   (icon) => icon.properties.name,
@@ -42,6 +43,7 @@ const MenuButton = ({
     preferX: "right",
     preferY: "bottom",
     placement: "bottom-start",
+    container: createUseLayerContainer,
   });
 
   const handleKeyUp = ({ key }) => {

--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -8,6 +8,7 @@ import DropdownTrigger from "../DropdownTrigger";
 import MultiSelectItem from "./MultiSelectItem";
 import FieldToken from "../FieldToken";
 import Row from "../Row";
+import { createUseLayerContainer } from "src/util/dom";
 
 const noop = () => {};
 
@@ -152,6 +153,7 @@ const MultiSelect = ({
       containerOffset: 0,
       placement: "bottom-start",
       possiblePlacements: ["top-start", "bottom-start"],
+      container: createUseLayerContainer,
     });
 
   const renderTokens = () =>

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -4,6 +4,7 @@ import cc from "classcat";
 import PropTypes from "prop-types";
 import { useLayer } from "react-laag";
 import FocusLock from "react-focus-lock";
+import { createUseLayerContainer } from "src/util/dom";
 
 const noop = () => {};
 
@@ -86,7 +87,7 @@ const Popover = ({
     placement: `${side}-${alignment}`,
     preferX: "left",
     preferY: "bottom",
-    container: typeof document !== "undefined" ? document.body : undefined,
+    container: createUseLayerContainer,
     triggerOffset: offset,
   });
 

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -9,6 +9,7 @@ import DropdownTrigger from "../DropdownTrigger";
 import SelectItem from "./SelectItem";
 import SelectAction from "./SelectAction";
 import SelectCategory from "./SelectCategory";
+import { createUseLayerContainer } from "src/util/dom";
 
 const noop = () => {};
 
@@ -223,6 +224,7 @@ const Select = ({
       containerOffset: 0,
       placement: "bottom-start",
       possiblePlacements: ["top-start", "bottom-start"],
+      container: createUseLayerContainer,
     });
 
   const renderItem = (item, items) => {

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useLayer, Arrow } from "react-laag";
+import { createUseLayerContainer } from "../util/dom";
 
 export interface TooltipProps {
   /** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
@@ -63,6 +64,7 @@ const Tooltip = ({
     preferY: "top",
     triggerOffset: 12,
     arrowOffset: 12,
+    container: createUseLayerContainer,
   });
 
   return (

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,0 +1,22 @@
+/**
+ * Create a container for the container for useLayer hook.
+ * If the document is available, it will return the element with the id "outlet".
+ * If the element is not found, create a new div element with the id "outlet"
+ * and append it to the body.
+ */
+export function createUseLayerContainer() {
+  if (typeof document !== "undefined") {
+    const container = document.getElementById("outlet");
+    if (container) {
+      return container;
+    } else {
+      const outlet = document.createElement("div");
+      outlet.setAttribute("id", "outlet");
+      outlet.setAttribute("class", "outlet");
+      document.body.appendChild(outlet);
+      return outlet;
+    }
+  } else {
+    return undefined;
+  }
+}


### PR DESCRIPTION
In the previous version (v4.10.4) of NDS. We created a `<div id="outlet"></div>` for rendering the portal for Drawer and Dialog. It didn't occurred to me that all components that uses "useLayer" hook should use the same outlet. This PR makes sure all components that use portals share the same outlet so they stack properly.


 