### PR TITLE
fix(checkbox): align checkbox itself vertically when label is multiline

### DIFF
--- a/src/Checkbox/index.scss
+++ b/src/Checkbox/index.scss
@@ -63,6 +63,7 @@
     // - prevent this flex item from shrinking to checkmark width
     // - visually align checkbox icon baseline with label baseline
     flex-shrink: 0;
+    align-self: center;
     &.error {
       border: 1px solid var(--color-errorDark);
     }

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -80,6 +80,20 @@ Markdown.parameters = {
   },
 };
 
+export const LongLabel = Template.bind({});
+LongLabel.args = {
+  markdownLabel:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+  name: "long_label",
+};
+LongLabel.parameters = {
+  docs: {
+    description: {
+      story: "The checkbox element itself is vertically centered when the label overflows to multiple lines",
+    },
+  },
+};
+
 export default {
   title: "Components/Checkbox",
   component: Checkbox,


### PR DESCRIPTION
resolves https://github.com/narmi/design_system/issues/1551

This bug has been bothering me and is a fairly straightforward fix. I'll double check with design to make sure this is actually  desired. 

![image](https://github.com/user-attachments/assets/5189ddd9-affb-49b6-a7a0-8e5258ae8eea)

