### PR TITLE
feat(Alert): expose more padding sizes for Alert

### DIFF
--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -16,8 +16,8 @@ interface AlertProps {
   kind?: "info" | "error" | "success" | "warn";
   /** Override the default icon of the alert */
   icon?: IconName | string | null;
-  /** Size of padding for Alert */
-  paddingSize?: "xs" | "l";
+  /** Size of padding for Alert. */
+  paddingSize?: "xxs" | "xs" | "s" | "l" | "xl" | "xxl";
   /** Message content of the Alert */
   children?: React.ReactNode | string;
 }


### PR DESCRIPTION
In the Organization Profile project for the Staff app, we need to use the padding size "s", but it is not valid from TypeScript point of view. 

I think it is too inconvenient for developers to updating NDS when they need a new size.  We are already supporting all padding sizes, this PR is just going to update the doc and type definitions. 