### PR TITLE
fix: use correct ProgressBar import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ import MenuButton from "./MenuButton";
 import MultiSelect from "./MultiSelect";
 import Pagination from "./Pagination";
 import PlainButton from "./PlainButton";
-import ProgressBar from "./Pagination";
+import ProgressBar from "./ProgressBar";
 import Popover from "./Popover";
 import Radio from "./Radio";
 import RadioButtons from "./RadioButtons";


### PR DESCRIPTION
In the `index.js`, `ProgressBar` was being imported from `./Pagination`. This PR updates the import to occur from `./ProgressBar`