### PR TITLE
fix(TextInput): show char counter at 0 chars

### DIFF
--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -51,7 +51,7 @@ const TextInput = React.forwardRef((props, forwardedRef) => {
   }
 
   const charCount = (nativeElementProps?.value || inputValue).length;
-  const showCharacterCounter = maxLength && charCount > 0;
+  const showCharacterCounter = maxLength;
   const characterCounter = showCharacterCounter ? (
     <div className="nds-input-character-counter">
       {charCount}/{maxLength}


### PR DESCRIPTION
Closes NDS-1143

Per design, change `TextInput` char counter behavior to _always_ show the counter, even at 0.