### PR TITLE
feat(Popover,MenuButton): add renderTrigger render props

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -28,6 +28,7 @@ const MenuButton = ({
   label = "Menu",
   testId,
   trigger,
+  renderTrigger,
   triggerIcon = "more-vertical",
   showDropdownIndicator = false,
   children,
@@ -88,34 +89,38 @@ const MenuButton = ({
         className="button--reset"
         {...triggerProps}
       >
-        <div
-          className={cc([
-            "nds-menubutton-trigger",
-            {
-              "nds-menubutton-trigger--useCssHover": !trigger,
-              "nds-menubutton-trigger--hovered": !trigger && isOpen,
-            },
-          ])}
-        >
-          <Row gapSize="xxs">
-            <Row.Item>
-              {trigger ? (
-                trigger
-              ) : (
-                <span className={`narmi-icon-${triggerIcon}`} />
-              )}
-            </Row.Item>
-            {showDropdownIndicator && (
-              <Row.Item shrink>
-                {isOpen ? (
-                  <span className={`narmi-icon-chevron-up`} />
+        {typeof renderTrigger === "function" ? (
+          renderTrigger(isOpen)
+        ) : (
+          <div
+            className={cc([
+              "nds-menubutton-trigger",
+              {
+                "nds-menubutton-trigger--useCssHover": !trigger,
+                "nds-menubutton-trigger--hovered": !trigger && isOpen,
+              },
+            ])}
+          >
+            <Row gapSize="xxs">
+              <Row.Item>
+                {trigger ? (
+                  trigger
                 ) : (
-                  <span className={`narmi-icon-chevron-down`} />
+                  <span className={`narmi-icon-${triggerIcon}`} />
                 )}
               </Row.Item>
-            )}
-          </Row>
-        </div>
+              {showDropdownIndicator && (
+                <Row.Item shrink>
+                  {isOpen ? (
+                    <span className={`narmi-icon-chevron-up`} />
+                  ) : (
+                    <span className={`narmi-icon-chevron-down`} />
+                  )}
+                </Row.Item>
+              )}
+            </Row>
+          </div>
+        )}
       </AriaButton>
       {isOpen &&
         renderLayer(
@@ -190,8 +195,16 @@ MenuButton.propTypes = {
   testId: PropTypes.string,
   /** Name of NDS icon to use as a trigger */
   triggerIcon: PropTypes.oneOf(VALID_ICON_NAMES),
-  /** Custom element for trigger */
+  /**
+   * ⚠️ DEPRECATED - will be removed in a future release.
+   * Use `renderTrigger` instead.
+   */
   trigger: PropTypes.node,
+  /**
+   * Render function for rendering a custom trigger element.
+   * Called with `(isOpen)`, the open state of the menu.
+   */
+  renderTrigger: PropTypes.func,
   /** MenuButton.Item children */
   children: PropTypes.arrayOf(PropTypes.node),
   /**

--- a/src/MenuButton/index.stories.js
+++ b/src/MenuButton/index.stories.js
@@ -38,9 +38,12 @@ export const CustomTrigger = Template.bind({});
 CustomTrigger.args = {
   ...Overview.args,
   showDropdownIndicator: true,
-  trigger: (
+  renderTrigger: (isOpen) => (
     <span className="button--reset fontColor--azul fontWeight--semibold">
-      More options...
+      More options...{" "}
+      <span
+        className={`padding--right narmi-icon-corner-${isOpen ? "right-up" : "left-down"}`}
+      />
     </span>
   ),
 };
@@ -48,7 +51,7 @@ CustomTrigger.parameters = {
   docs: {
     description: {
       story:
-        "You may use the `trigger` prop as an alternative to passing in a `triggerIcon`. In this example, we pass in a custom `span` to act as the trigger. The `showDropdownIndicator` prop is enabled, causing `MenuButton` to render the chevron icons indicating menu open state.",
+        "You may use the `renderTrigger` render prop as an alternative to passing in a `triggerIcon`. In this example, we use the `isOpen` argument to conditionally set an icon in the render function.",
     },
   },
 };

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -24,6 +24,7 @@ const Popover = ({
   alignment = "center",
   content,
   children,
+  renderTrigger = () => <></>,
   wrapperDisplay = "inline-flex",
   offset = 2,
   disableAutoPlacement = false,
@@ -37,6 +38,7 @@ const Popover = ({
   onUserEnable = noop,
 }) => {
   const isControlled = isOpen === true || isOpen === false;
+  const hasChildren = React.Children.count(children) > 0;
   const [open, setOpen] = useState(false);
   const shouldRenderPopover = isControlled ? isOpen : open;
   const popoverContent = closeOnContentClick
@@ -119,7 +121,8 @@ const Popover = ({
         aria-haspopup="true"
         aria-expanded={shouldRenderPopover.toString()}
       >
-        {children}
+        {/* Support both legacy (children) and standard (render prop) triggers */}
+        {hasChildren ? children : renderTrigger(isOpen)}
       </div>
       {renderLayer(
         <>
@@ -148,10 +151,18 @@ const Popover = ({
 };
 
 Popover.propTypes = {
-  /** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
-  children: PropTypes.node.isRequired,
   /** Content of popover */
   content: PropTypes.node.isRequired,
+  /**
+   * ⚠️ DEPRECATED - use `renderTrigger` instead.
+   * The root node of JSX passed into Tooltip as children will act as the tooltip trigger
+   */
+  children: PropTypes.node,
+  /**
+   * Render function for a custom trigger aware of the open state of the Popover.
+   * Called with `(isOpen) => {}`, the state of the Popover.
+   */
+  renderTrigger: PropTypes.func,
   /** Sets preferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
   /** Sets preferred alignment of the tooltip relative to the trigger */

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -19,7 +19,7 @@ const Template = (args) => (
 export const Overview = Template.bind({});
 Overview.args = {
   content: <div className="padding--all--m">📦 Any content</div>,
-  children: (
+  renderTrigger: () => (
     <Button type="button" kind="secondary">
       Open Popover
     </Button>
@@ -27,6 +27,28 @@ Overview.args = {
 };
 Overview.argTypes = {
   content: { control: false },
+};
+
+export const LegacyTrigger = () => {
+  return (
+    <>
+      <div className="margin--top--m">
+        <Popover
+          content={<div className="padding--all--m">📦 Any content</div>}
+        >
+          <div>Trigger as children</div>
+        </Popover>
+      </div>
+    </>
+  );
+};
+LegacyTrigger.parameters = {
+  docs: {
+    description: {
+      story:
+        "Popover supports accepting children to use as the trigger element. **This feature will be removed in a feature release;** use `renderTrigger` instead.",
+    },
+  },
 };
 
 export const Positioning = Template.bind({});
@@ -37,7 +59,7 @@ Positioning.args = {
       positioning
     </div>
   ),
-  children: (
+  renderTrigger: () => (
     <Button type="button" kind="secondary">
       Top / Start positioned Popover
     </Button>
@@ -51,7 +73,7 @@ Positioning.argTypes = {
 
 export const FocusManagement = Template.bind({});
 FocusManagement.args = {
-  children: (
+  renderTrigger: () => (
     <Button type="button" kind="secondary">
       Click to show Popover
     </Button>
@@ -86,9 +108,10 @@ export const Controlled = () => {
           isOpen={isOpen}
           onUserDismiss={() => setIsOpen(false)}
           onUserEnable={() => setIsOpen(true)}
-        >
-          <div>Popover trigger and positioning reference</div>
-        </Popover>
+          renderTrigger={() => (
+            <div>Popover trigger and positioning reference</div>
+          )}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
Closes NDS-1229

Adds a `renderTrigger` render prop to `Popover` and `MenuButton` with the signature `(isOpen) => <>jsx</>`.

`Popover` has up to this point accepted `props.children` as the trigger. This PR deprecates that behavior in favor of the improved `renderTrigger`.

`MenuButton` deprecates it's `trigger` prop, which only accepts static JSX, unaware of the open state of the menu.


<img width="676" alt="Screenshot 2025-04-01 at 2 57 03 PM" src="https://github.com/user-attachments/assets/8d1a499f-256c-44bf-aaf0-8804b30d55b8" />
<img width="1031" alt="Screenshot 2025-04-01 at 2 57 44 PM" src="https://github.com/user-attachments/assets/ee085627-7fd7-41e1-82e9-2ae0535e848f" />
<img width="1049" alt="Screenshot 2025-04-01 at 3 05 33 PM" src="https://github.com/user-attachments/assets/5528e5cc-0013-4a28-820b-907906eba0d9" />
