### PR TITLE
feat(SplitButton): add SplitButton component

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -1,5 +1,4 @@
 @import "../Spinner/index.scss";
-@import "./spinner.scss";
 @import "./variants.scss";
 @import "./sizes.scss";
 @import "./states.scss";

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -1,4 +1,8 @@
 @import "../Spinner/index.scss";
+@import "./spinner.scss";
+@import "./variants.scss";
+@import "./sizes.scss";
+@import "./states.scss";
 
 .nds-button,
 .nds-button.resetButton {
@@ -20,175 +24,75 @@
 
 /* Size variants */
 .nds-button--xs {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  min-height: rem(24px);
-  border-radius: rem(12px);
+  @extend %btn-size-xs;
 }
 .nds-button--s {
-  font-size: var(--font-size-s);
-  font-weight: var(--font-weight-bold);
-  min-height: rem(32px);
-  border-radius: rem(18px);
+  @extend %btn-size-s;
 }
 .nds-button--m {
-  font-size: var(--font-size-default);
-  font-weight: var(--font-weight-bold);
-  min-height: rem(40px);
-  border-radius: rem(24px);
+  @extend %btn-size-m;
 }
 .nds-button--l,
 .nds-button--xl {
   // unimplemented sizes should fall back to "m"
-  @extend .nds-button--m;
+  @extend %btn-size-m;
 }
 
 /* Kind variants */
 .nds-button--primary,
 .nds-button--secondary,
 .nds-button--tonal {
-  .nds-button-content {
-    margin: rem(8px) rem(32px);
-    // label constraint should scale evenly with font size
-    max-width: rem(240px);
-  }
-  &.nds-button--s {
-    .nds-button-content {
-      margin: rem(3px) rem(24px);
-      max-width: rem(220px);
-    }
-  }
-  &.nds-button--xs {
-    .nds-button-content {
-      margin: rem(3px) rem(16px);
-      max-width: rem(200px);
-    }
-  }
+  @extend %btn-kind-base;
 }
 
 .nds-button--primary,
 .nds-button--primary.resetButton {
-  color: var(--color-white);
-  background-color: var(--theme-primary);
-
-  &:hover {
-    color: var(--color-white);
-    text-decoration: none;
-    filter: opacity(80%);
-  }
+  @extend %btn-kind-primary;
 }
 
 .nds-button--secondary,
 .nds-button--secondary.resetButton {
-  position: relative;
-  color: var(--theme-primary);
-  background-color: var(--color-white);
-  border: var(--border-size-s) solid var(--theme-primary);
-
-  // adds a white shim behind the button so that the transparent
-  // hover color appears the same regardless of context
-  &::before {
-    content: "";
-    border-radius: var(--button-radius);
-    background-color: var(--color-white);
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-  }
-
-  &:hover {
-    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
-  }
+  @extend %btn-kind-secondary;
 }
 
 .nds-button--tonal,
 .nds-button--tonal.resetButton {
-  color: var(--theme-primary);
-  background-color: RGBA(var(--theme-rgb-primary), var(--alpha-20));
-
-  &:hover,
-  &:active {
-    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
-  }
+  @extend %btn-kind-tonal;
 }
 
+/**
+️* ⚠️ DEPRECATED ⚠️
+* Will be removed in a future release.
+*/
 .nds-button--menu,
 .nds-button--menu.resetButton {
-  text-align: left;
-  color: var(--font-color-primary);
-  display: block;
-  font-size: var(--font-size-l) !important;
-
-  .nds-button-content {
-    margin: rem(10px) 0;
-  }
-
-  @media (min-width: #{map.get($breakpoints, "l")}) {
-    margin: 0 rem(12px);
-    font-weight: var(--font-weight-semibold);
-    display: inline-block;
-    font-size: var(--font-size-default) !important;
-  }
-}
-
-.nds-button--plain,
-.nds-button--plain.resetButton,
-.nds-button--negative,
-.nds-button--negative.resetButton {
-  color: var(--theme-secondary);
-  font-weight: var(--font-weight-semibold);
-  border-radius: 0;
-  justify-content: start;
-  min-height: unset;
-
-  &:hover {
-    color: var(--theme-secondary);
-    .nds-button-label {
-      text-decoration: underline;
-    }
-  }
+  @extend %btn-kind-menu;
 }
 
 .nds-button--negative,
 .nds-button--negative.resetButton {
-  color: var(--theme-primary);
-  &:hover {
-    color: var(--theme-primary);
-  }
+  @extend %btn-kind-negative;
 }
 
 .nds-button--disabled {
-  pointer-events: none;
-  color: var(--color-white);
-
   &.nds-button--menu,
   &.nds-button--plain,
   &.nds-button--negative {
-    color: var(--font-color-hint);
+    @extend %btn-state-disabled-plain;
   }
   &.nds-button--primary {
-    background-color: var(--color-lightGrey);
+    @extend %btn-state-disabled-primary;
   }
   &.nds-button--secondary {
-    color: var(--color-lightGrey);
-    border-color: var(--color-lightGrey);
+    @extend %btn-state-disabled-secondary;
   }
   &.nds-button--tonal {
-    color: var(--color-lightGrey);
-    background-color: rgba(var(--rgb-lightGrey), var(--alpha-20));
+    @extend %btn-state-disabled-tonal;
   }
 }
 
 .nds-button--loading {
-  .nds-button-content {
-    position: relative;
-  }
-  .nds-button-spinner {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
+  @extend %btn-state-loading;
 }
 
 /**
@@ -196,14 +100,5 @@
 * Will be removed in a future release.
 */
 .nds-plain-button {
-  cursor: pointer;
-  color: var(--theme-primary);
-  font-weight: var(--font-weight-semibold);
-
-  &:hover {
-    color: var(--theme-primary);
-    .nds-button-label {
-      text-decoration: underline;
-    }
-  }
+  @extend %btn-kind-plain;
 }

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -5,7 +5,7 @@ import Row from "../Row";
 import Spinner from "../Spinner";
 import type { IconName } from "../types/Icon.types";
 
-interface ButtonProps {
+export interface ButtonProps {
   /** Renders the button label */
   label?: string; // must be optional until `children` is removed
   /** style of button to render */

--- a/src/Button/sizes.scss
+++ b/src/Button/sizes.scss
@@ -1,0 +1,20 @@
+%btn-size-xs {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  min-height: rem(24px);
+  border-radius: rem(12px);
+}
+
+%btn-size-s {
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-bold);
+  min-height: rem(32px);
+  border-radius: rem(18px);
+}
+
+%btn-size-m {
+  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-bold);
+  min-height: rem(40px);
+  border-radius: rem(24px);
+}

--- a/src/Button/states.scss
+++ b/src/Button/states.scss
@@ -1,0 +1,39 @@
+%_btn-state-disabled-base {
+  pointer-events: none;
+  color: var(--color-white);
+}
+
+// used for all buttons that render without a pill shape
+%btn-state-disabled-plain {
+  @extend %_btn-state-disabled-base;
+  color: var(--font-color-hint);
+}
+
+%btn-state-disabled-primary {
+  @extend %_btn-state-disabled-base;
+  background-color: var(--color-lightGrey);
+}
+
+%btn-state-disabled-secondary {
+  @extend %_btn-state-disabled-base;
+  color: var(--color-lightGrey);
+  border-color: var(--color-lightGrey);
+}
+
+%btn-state-disabled-tonal {
+  @extend %_btn-state-disabled-base;
+  color: var(--color-lightGrey);
+  background-color: rgba(var(--rgb-lightGrey), var(--alpha-20));
+}
+
+%btn-state-loading {
+  .nds-button-content {
+    position: relative;
+  }
+  .nds-button-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -1,0 +1,125 @@
+%btn-kind-base {
+  .nds-button-content {
+    margin: rem(8px) rem(32px);
+    // label constraint should scale evenly with font size
+    max-width: rem(240px);
+  }
+  &.nds-button--s {
+    .nds-button-content {
+      margin: rem(3px) rem(24px);
+      max-width: rem(220px);
+    }
+  }
+  &.nds-button--xs {
+    .nds-button-content {
+      margin: rem(3px) rem(16px);
+      max-width: rem(200px);
+    }
+  }
+}
+
+%btn-kind-primary {
+  color: var(--color-white);
+  background-color: var(--theme-primary);
+
+  &:hover {
+    color: var(--color-white);
+    text-decoration: none;
+    filter: opacity(80%);
+  }
+}
+
+%btn-kind-secondary {
+  position: relative;
+  color: var(--theme-primary);
+  background-color: var(--color-white);
+  border: var(--border-size-s) solid var(--theme-primary);
+
+  // adds a white shim behind the button so that the transparent
+  // hover color appears the same regardless of context
+  &::before {
+    content: "";
+    border-radius: var(--button-radius);
+    background-color: var(--color-white);
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+  }
+
+  &:hover {
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
+  }
+}
+
+%btn-kind-tonal {
+  color: var(--theme-primary);
+  background-color: RGBA(var(--theme-rgb-primary), var(--alpha-20));
+
+  &:hover,
+  &:active {
+    background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
+  }
+}
+
+%btn-kind-negative {
+  @extend %_btn-kind-plain-base;
+  color: var(--theme-primary);
+  &:hover {
+    color: var(--theme-primary);
+  }
+}
+
+/**
+️* ⚠️ DEPRECATED ⚠️
+* Will be removed in a future release.
+*/
+%_btn-kind-plain-base {
+  color: var(--theme-secondary);
+  font-weight: var(--font-weight-semibold);
+  border-radius: 0;
+  justify-content: start;
+  min-height: unset;
+
+  &:hover {
+    color: var(--theme-secondary);
+    .nds-button-label {
+      text-decoration: underline;
+    }
+  }
+}
+
+%btn-kind-plain {
+  @extend %_btn-kind-plain-base;
+  cursor: pointer;
+  color: var(--theme-primary);
+  font-weight: var(--font-weight-semibold);
+
+  &:hover {
+    color: var(--theme-primary);
+    .nds-button-label {
+      text-decoration: underline;
+    }
+  }
+}
+
+/**
+️* ⚠️ DEPRECATED ⚠️
+* Will be removed in a future release.
+*/
+%btn-kind-menu {
+  text-align: left;
+  color: var(--font-color-primary);
+  display: block;
+  font-size: var(--font-size-l) !important;
+
+  .nds-button-content {
+    margin: rem(10px) 0;
+  }
+
+  @media (min-width: #{map.get($breakpoints, "l")}) {
+    margin: 0 rem(12px);
+    font-weight: var(--font-weight-semibold);
+    display: inline-block;
+    font-size: var(--font-size-default) !important;
+  }
+}

--- a/src/MenuButton/MenuButtonItem.js
+++ b/src/MenuButton/MenuButtonItem.js
@@ -7,7 +7,7 @@ export const VALID_ICON_NAMES = iconSelection.icons.map(
   (icon) => icon.properties.name,
 );
 
-const MenuButtonItem = ({ label, startIcon, endIcon }) => <></>;
+const MenuButtonItem = ({ label, startIcon, endIcon, onSelect }) => <></>;
 
 MenuButtonItem.propTypes = {
   /** Display label for menu item */

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -88,7 +88,7 @@ const MenuButton = ({
     >
       <AriaButton
         aria-label={label}
-        className="button--reset"
+        className="button--reset nds-menubutton-ariaButton"
         {...triggerProps}
       >
         {typeof renderTrigger === "function" ? (

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -117,6 +117,7 @@ const Popover = ({
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex="0"
+        className="nds-popover-trigger"
         data-testid="nds-popover-trigger"
         aria-haspopup="true"
         aria-expanded={shouldRenderPopover.toString()}

--- a/src/SplitButton/SplitButtonMenu.tsx
+++ b/src/SplitButton/SplitButtonMenu.tsx
@@ -1,0 +1,19 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from "react";
+
+export interface SplitButtonMenuProps {
+  children: React.ReactElement | React.ReactElement[];
+}
+
+/**
+ * `SplitButton.Menu` subcomponents.
+ * Collects incoming props `SplitButton` may use to render a `MenuButton`.
+ */
+export const SplitButtonMenu = ({ children }) => <></>;
+export const SplitButtonMenuItem = ({
+  label,
+  startIcon,
+  endIcon,
+  onSelect,
+}) => <></>;

--- a/src/SplitButton/SplitButtonPopover.tsx
+++ b/src/SplitButton/SplitButtonPopover.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from "react";
+
+export interface SplitButtonPopoverProps {
+  children: React.ReactElement | React.ReactElement[];
+}
+
+/**
+ * `SplitButton.Popover` subcomponent.
+ * Collects incoming props `SplitButton` may use to render a `Popover`.
+ */
+const SplitButtonPopover = ({ children }: SplitButtonPopoverProps) => <></>;
+
+export default SplitButtonPopover;

--- a/src/SplitButton/index.scss
+++ b/src/SplitButton/index.scss
@@ -1,0 +1,90 @@
+@import "../Button/variants.scss";
+@import "../Button/sizes.scss";
+@import "../Button/states.scss";
+
+.nds-splitButton {
+  display: inline-flex;
+  min-height: fit-content;
+  align-items: stretch;
+
+  .nds-button {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+}
+
+.nds-splitButton-action {
+  cursor: pointer;
+  height: 100%;
+  border-left: 1px solid var(--color-white);
+  width: rem(40px);
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+// Match the dropdown trigger button to the shape and size of the
+// rendered dropdown trigger to ensure focus ring visually matches
+.nds-popover-trigger:has(> .nds-splitButton-action),
+.nds-menubutton-ariaButton:has(> .nds-splitButton-action) {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.nds-popover-trigger:has(> .nds-splitButton-action--xs),
+.nds-menubutton-ariaButton:has(> .nds-splitButton-action--xs),
+.nds-splitButton-action--xs {
+  @extend %btn-size-xs;
+  width: rem(24px);
+}
+
+.nds-popover-trigger:has(> .nds-splitButton-action--s),
+.nds-menubutton-ariaButton:has(> .nds-splitButton-action--s),
+.nds-splitButton-action--s {
+  @extend %btn-size-s;
+  width: rem(32px);
+}
+
+.nds-popover-trigger:has(> .nds-splitButton-action--m),
+.nds-menubutton-ariaButton:has(> .nds-splitButton-action--m),
+.nds-splitButton-action--m {
+  @extend %btn-size-m;
+  width: rem(40px);
+}
+
+.nds-splitButton-action--primary,
+.nds-splitButton-action--secondary,
+.nds-splitButton-action--tonal {
+  @extend %btn-kind-base;
+}
+
+.nds-splitButton-action--primary,
+.nds-splitButton-action--primary.resetButton {
+  @extend %btn-kind-primary;
+}
+
+.nds-splitButton-action--secondary,
+.nds-splitButton-action--secondary.resetButton {
+  @extend %btn-kind-secondary;
+}
+
+.nds-splitButton-action--tonal,
+.nds-splitButton-action--tonal.resetButton {
+  @extend %btn-kind-tonal;
+}
+
+.nds-splitButton-action--loading {
+  @extend %btn-state-loading;
+}
+
+.nds-splitButton-action--disabled {
+  cursor: none;
+  &.nds-splitButton-action--primary {
+    @extend %btn-state-disabled-primary;
+  }
+  &.nds-splitButton-action--secondary {
+    @extend %btn-state-disabled-secondary;
+  }
+  &.nds-splitButton-action--tonal {
+    @extend %btn-state-disabled-tonal;
+  }
+}

--- a/src/SplitButton/index.stories.js
+++ b/src/SplitButton/index.stories.js
@@ -1,0 +1,101 @@
+/* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
+import React from "react";
+import SplitButton from "./";
+import SplitButtonPopover from "./SplitButtonPopover";
+import { SplitButtonMenu, SplitButtonMenuItem } from "./SplitButtonMenu";
+
+const Template = (args) => <SplitButton {...args} />;
+export const Overview = Template.bind({});
+Overview.args = {
+  children: (
+    <SplitButton.Popover>Arbitrary JSX in a popover!</SplitButton.Popover>
+  ),
+  label: "Send",
+};
+
+export const WithPopover = () => (
+  <SplitButton label="Send" onClick={() => alert("Send button clicked")}>
+    <SplitButton.Popover>
+      <div className="padding--all--s bgColor--white rounded--all">
+        This is some arbitrary popover content!
+      </div>
+    </SplitButton.Popover>
+  </SplitButton>
+);
+
+export const WithMenu = () => (
+  <SplitButton label="Send" onClick={() => alert("Send button clicked")}>
+    <SplitButton.Menu>
+      <SplitButton.MenuItem
+        label="Schedule"
+        onSelect={() => {
+          alert("Scheduling");
+        }}
+      />
+      <SplitButton.MenuItem
+        label="Save as draft"
+        onSelect={() => {
+          alert("Saving draft");
+        }}
+      />
+    </SplitButton.Menu>
+  </SplitButton>
+);
+
+export const KindsAndSizes = () => {
+  const renderSplitButton = (kind, size) => (
+    <SplitButton
+      kind={kind}
+      size={size}
+      label="Send"
+      onClick={() => alert("Send button clicked")}
+    >
+      <SplitButton.Menu>
+        <SplitButton.MenuItem
+          label="Schedule"
+          onSelect={() => {
+            alert("Scheduling");
+          }}
+        />
+        <SplitButton.MenuItem
+          label="Save as draft"
+          onSelect={() => {
+            alert("Saving draft");
+          }}
+        />
+      </SplitButton.Menu>
+    </SplitButton>
+  );
+
+  const exmaples = [
+    ["primary", "m"],
+    ["primary", "s"],
+    ["primary", "xs"],
+    ["secondary", "m"],
+    ["secondary", "s"],
+    ["secondary", "xs"],
+    ["tonal", "m"],
+    ["tonal", "s"],
+    ["tonal", "xs"],
+  ];
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(3, 1fr)",
+        gap: "var(--space-default)",
+      }}
+    >
+      {exmaples.map(([kind, size]) => (
+        <div key={`${kind}-${size}`}>{renderSplitButton(kind, size)}</div>
+      ))}
+    </div>
+  );
+};
+
+export default {
+  title: "Components/SplitButton",
+  component: SplitButton,
+  subcomponents: { SplitButtonPopover, SplitButtonMenu, SplitButtonMenuItem },
+};

--- a/src/SplitButton/index.tsx
+++ b/src/SplitButton/index.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import cc from "classcat";
+import Button, { ButtonProps } from "../Button";
+import Popover from "../Popover";
+import MenuButton from "../MenuButton";
+
+// SplitButton-specific positioning options
+// passed to `MenuButton` and `Popover`
+const POPOPOVER_POSITION_PROPS = {
+  side: "top",
+  alignment: "start",
+  offset: 6,
+};
+
+import SplitButtonPopover, {
+  SplitButtonPopoverProps,
+} from "./SplitButtonPopover";
+import {
+  SplitButtonMenu,
+  SplitButtonMenuItem,
+  SplitButtonMenuProps,
+} from "./SplitButtonMenu";
+
+interface SplitButtonProps extends ButtonProps {
+  children:
+    | React.ReactElement<SplitButtonPopoverProps>
+    | React.ReactElement<SplitButtonMenuProps>;
+  kind: "primary" | "secondary" | "tonal";
+  size: "xs" | "s" | "m";
+}
+
+/**
+ * A button group of exactly two buttons - one primary action and a button
+ * that triggers a popover for more options.
+ *
+ * `SplitButton` accepts the same props as `Button`. The popover behavior is
+ * controlled by the `SplitButton.[subcomponent]` component passed as children.
+ */
+const SplitButton = ({
+  kind = "primary",
+  size = "m",
+  label,
+  disabled,
+  isLoading,
+  children,
+  ...otherProps
+}: SplitButtonProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const renderStaticTrigger = disabled || isLoading;
+
+  const popoverComponent = React.Children.toArray(children).find(
+    (child) =>
+      React.isValidElement(child) && child.type === SplitButton.Popover,
+  );
+
+  const menuComponent = React.Children.toArray(children).find(
+    (child) => React.isValidElement(child) && child.type === SplitButton.Menu,
+  );
+
+  const renderTrigger = (isOpen: boolean) => (
+    <div
+      className={cc([
+        "nds-splitButton-action",
+        "alignChild--center--center",
+        `nds-splitButton-action--${kind}`,
+        `nds-splitButton-action--${size}`,
+        {
+          "nds-splitButton-action--disabled": disabled,
+          "nds-splitButton-action--loading": isLoading,
+        },
+      ])}
+    >
+      <span
+        aria-label="More"
+        className={`narmi-icon-chevron-${isOpen ? "up" : "down"}`}
+      />
+    </div>
+  );
+
+  return (
+    <div className="nds-splitButton">
+      {/** Main button */}
+      <Button
+        label={label}
+        disabled={disabled}
+        isLoading={isLoading}
+        size={size}
+        kind={kind}
+        {...otherProps}
+      />
+
+      {renderStaticTrigger && renderTrigger(false)}
+
+      {/** If a SplitButton.Popover is passed as children */}
+      {!renderStaticTrigger &&
+        popoverComponent &&
+        React.isValidElement(popoverComponent) && (
+          <Popover
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            // @ts-expect-error Popover is not TS yet
+            renderTrigger={renderTrigger}
+            isOpen={isOpen}
+            onUserDismiss={() => setIsOpen(false)}
+            onUserEnable={() => setIsOpen(true)}
+            content={popoverComponent.props.children}
+            {...POPOPOVER_POSITION_PROPS}
+          />
+        )}
+
+      {/** If a SplitButton.Menu is passed as children */}
+      {!renderStaticTrigger &&
+        menuComponent &&
+        React.isValidElement(menuComponent) && (
+          <MenuButton
+            renderTrigger={renderTrigger}
+            {...POPOPOVER_POSITION_PROPS}
+          >
+            {React.Children.toArray(menuComponent.props.children).map(
+              (item, i) =>
+                React.isValidElement(item) ? (
+                  <MenuButton.Item key={i} {...item.props} />
+                ) : null,
+            )}
+          </MenuButton>
+        )}
+    </div>
+  );
+};
+
+SplitButton.Popover = SplitButtonPopover;
+SplitButton.Menu = SplitButtonMenu;
+SplitButton.MenuItem = SplitButtonMenuItem;
+export default SplitButton;

--- a/src/index.scss
+++ b/src/index.scss
@@ -88,6 +88,7 @@
 @import "Sidebar/";
 @import "Snackbar/";
 @import "Spinner/";
+@import "SplitButton/";
 @import "Popover/";
 @import "Toggle/";
 @import "TimelineEvent/";


### PR DESCRIPTION
Closes NDS-981

## Changes

### `Button`
- Move state, variant, and size styles for button into [sass placeholders](https://sass-lang.com/documentation/style-rules/placeholder-selectors/) to make them reusable
- Update styles for `nds-button` to use placeholders

### `SplitButton`
- Add component
- Consume `Button` placeholder selectors to style custom trigger to match the main button

## What are Sass placeholders?

Placeholders allow us to share the same style rules we apply to `Button` sizes, variants, and states with `SplitButton`.

Any selector in Sass that starts with `%` is a "placeholder". The rule block defined under a placeholder will **not** be emitted as CSS. Placeholders allow us to share blocks of CSS via the `@extend` directive. 

What's actually happening under the hood is that Sass hoists the selector being extended to a multiple selector that contains the placeholder rule block. 

**scss**
```scss
%warning {
   color: lightpink;
   background: red;
}

.formError {
   @extend %warning;
   font-size: 1rem;
}

.errorSummaryHeading {
   @extend %warning;
   font-size: 3rem;
}
```

**compiles to this CSS**
```css
.errorSummaryHeading,
.formError {
   color: lightpink;
   background: red;
}

.formError {
   font-size: 1rem;
}

.errorSummaryHeading {
   font-size: 3rem;
}
```

## Props interface

`SplitButton` follows our pattern of subcomponents. Here's a good basic usage example:

```jsx
  <SplitButton label="Send" onClick={handleMainButtonClick}>
    <SplitButton.Menu>
      <SplitButton.MenuItem
        label="Schedule"
        onSelect={handleItemSelect}
      />
      <SplitButton.MenuItem
        label="Save as draft"
        onSelect={handleItemSelect}
      />
    </SplitButton.Menu>
  </SplitButton>
  ```
  
My thinking here is that this keeps us open to new behaviors. Should our design team design a split button where the right hand action makes a [unicorn](https://www.cornify.com/) fly across the screen, it would be implemented as a `<SplitButton.Unicorn>` subcomponent.

The root `SplitButton` component manages its children. While a user could technically pass multiple subcomponents, `SplitButton` will only render the first subcomponent it encounters.


<img width="850" alt="Screenshot 2025-04-15 at 1 09 55 PM" src="https://github.com/user-attachments/assets/36b2f45a-a6b3-4051-be69-67537cb4204e" />
