### PR TITLE
fix(Combobox): ensure selecting actions does not change selectedItem

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -233,7 +233,14 @@ const Combobox = ({
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;
+      const { selectedItem: previousSelectedItem } = state;
+      const { selectedItem: newSelectedItem } = changes;
       let inputValue = changes.inputValue;
+
+      // Items not selectable should not cause the `selectedItem` in state to change.
+      if (!isSelectable(newSelectedItem)) {
+        changes.selectedItem = previousSelectedItem;
+      }
 
       // if there's already a selected item when the user revisits the input,
       // wipe away the old input value so they can start typing right away.
@@ -242,7 +249,7 @@ const Combobox = ({
         type === useCombobox.stateChangeTypes.InputChange &&
         clearOnNextInput &&
         hasSelectedItem &&
-        changes.inputValue.length > state.inputValue.length
+        (changes.inputValue || "").length > (state.inputValue || "").length
       ) {
         inputValue = changes.inputValue.slice(-1); // the last character the user typed
         setClearOnNextInput(false);

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -196,4 +196,36 @@ describe("Combobox", () => {
     fireEvent.change(input, { target: { value: "New value" } });
     expect(screen.getByDisplayValue(value)).toBeInTheDocument();
   });
+
+  it("should not clear `selectedItem` when an action is clicked", () => {
+    const LABEL_ACTION = "Add a new state";
+    render(
+      <Combobox label={LABEL}>
+        <Combobox.Item value="New York" />
+        <Combobox.Item value="California" />
+        <Combobox.Action onSelect={() => {}} label={LABEL_ACTION} />
+      </Combobox>,
+    );
+
+    const input = screen.getByPlaceholderText(LABEL);
+
+    // open the dropdown
+    fireEvent.focus(input);
+    const nyItem = screen.getByText("New York");
+    const actionItem = screen.getByText(LABEL_ACTION);
+
+    // Select an item
+    fireEvent.click(nyItem);
+
+    // Blur the input
+    fireEvent.blur(input);
+
+    // On reopneing the input, the selectedItem should still be selected
+    fireEvent.focus(input);
+    expect(input.value).toBe("New York");
+
+    // Now click on an action. The same item should still be selected.
+    fireEvent.click(actionItem);
+    expect(input.value).toBe("New York");
+  });
 });


### PR DESCRIPTION
Closes NDS-1243

We include `Combobox.Action` components passed via props in the list of `items` we pass to the downshift `useCombobox` hook to manage. The default behavior of downshift is to change the `selectedItem` in its state reducer, which was including `Action` subcomponents. Because an `Action` has no `value`, the `selectedItem` would become null and deselect the currently selected item whenever someone selects an `Action`.

### tl;dr
The downshift hooks like `useCombobox` can take a custom state reducer. This PR leverages the state reducer we're already passing in to ensure that the new state object returned by the reducer does not change the `selectedItem`.

