### PR TITLE
fix(Combobox): persist selection when users select an action

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -203,18 +203,8 @@ const Combobox = ({
         return;
       }
 
-      const itemMatchingInput = items.find(
-        (item) =>
-          inputValue === item.props.searchValue ||
-          inputValue === item.props.value,
-      );
-
-      // once a selection is made, show all options in the dropdown
-      if (itemMatchingInput) {
-        setDisplayedItems(items);
-
-        // filter by input value if filtering is enabled
-      } else if (!disableFiltering) {
+      // Filtering based on inputValue
+      if (!disableFiltering) {
         const actionItems = items.filter(isAction);
         const filteredItems = filterItemsByInput(
           items.filter((item) => !isAction(item) && isSelectable(item)),
@@ -225,6 +215,7 @@ const Combobox = ({
 
       onInputChange(inputValue);
     },
+
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import iconSelection from "src/icons/selection.json";

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -150,7 +150,6 @@ const Combobox = ({
   testId,
   renderEndContent = defaultRenderEndContent,
 }) => {
-  const inputRef = useRef(null);
   const allChildren = React.Children.toArray(children);
   const hasCategories = allChildren.some(
     ({ type }) => type.displayName === ComboboxCategory.displayName,
@@ -175,7 +174,9 @@ const Combobox = ({
   }
 
   const [displayedItems, setDisplayedItems] = useState(items);
-  const [clearOnNextInput, setClearOnNextInput] = useState(false);
+
+  const itemToString = (item) =>
+    item?.props?.searchValue || item?.props?.value || "";
 
   const {
     isOpen,
@@ -185,80 +186,85 @@ const Combobox = ({
     getItemProps,
     highlightedIndex,
     inputValue,
-    setInputValue,
     openMenu,
-    closeMenu,
     reset,
   } = useCombobox({
     items: displayedItems,
     inputValue: inputValueProp,
-    itemToString: (item) => item.props.searchValue || item.props.value,
+    itemToString,
+
+    // typeahead behavior is managed by this event callback
     onInputValueChange: ({ inputValue }) => {
-      // Typeahead behavior - we adjust the list of available options passed
-      // into `useCombobox` by filtering the initial items list from input value
-      if (!disableFiltering) {
+      // If the user has cleared the input reset selection and state.
+      if (inputValue.length === 0) {
+        setDisplayedItems(items);
+        reset();
+        onInputChange("");
+        return;
+      }
+
+      const itemMatchingInput = items.find(
+        (item) =>
+          inputValue === item.props.searchValue ||
+          inputValue === item.props.value,
+      );
+
+      // once a selection is made, show all options in the dropdown
+      if (itemMatchingInput) {
+        setDisplayedItems(items);
+
+        // filter by input value if filtering is enabled
+      } else if (!disableFiltering) {
         const actionItems = items.filter(isAction);
         const filteredItems = filterItemsByInput(
-          items.filter((item) => !isAction(item)).filter(isSelectable),
+          items.filter((item) => !isAction(item) && isSelectable(item)),
           inputValue.toLowerCase(),
         );
         setDisplayedItems([...filteredItems, ...actionItems]);
       }
 
-      // reset all downshift state when the input is cleared
-      if (inputValue.length === 0) {
-        setDisplayedItems(items); // restore original list in dropdown
-        reset(); // clear any active selections
-      }
-
       onInputChange(inputValue);
-    },
-    onSelectedItemChange: ({ selectedItem }) => {
-      if (isAction(selectedItem)) {
-        selectedItem.props.onSelect();
-        closeMenu();
-        if (inputRef.current) {
-          // always blur input when an action is selected.
-          inputRef.current.blur();
-        }
-      } else {
-        let newSelection = "";
-        if (selectedItem) {
-          newSelection = selectedItem.props.value;
-        }
-        onChange(newSelection);
-        onInputChange(newSelection);
-      }
     },
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;
       const { selectedItem: previousSelectedItem } = state;
       const { selectedItem: newSelectedItem } = changes;
-      let inputValue = changes.inputValue;
 
-      // Items not selectable should not cause the `selectedItem` in state to change.
-      if (!isSelectable(newSelectedItem)) {
-        changes.selectedItem = previousSelectedItem;
+      // When users select an action, the selectedItem should not update.
+      // The dropdown should close and any existing selection should be preserved.
+      if (isAction(newSelectedItem)) {
+        newSelectedItem.props.onSelect();
+        return {
+          ...changes,
+          selectedItem: previousSelectedItem,
+          inputValue: itemToString(previousSelectedItem),
+          isOpen: false,
+        };
       }
 
-      // if there's already a selected item when the user revisits the input,
-      // wipe away the old input value so they can start typing right away.
-      // (selection is preserved until user picks another item)
+      // Clear input on blur if the user hasn't made a selection
+      if (type === useCombobox.stateChangeTypes.InputBlur) {
+        return {
+          ...changes,
+          inputValue: selectedItem ? itemToString(selectedItem) : "",
+        };
+      }
+
+      // Change callback is invoked when the selectedItem changes.
+      // Leave the dropdown open until user blurs the input.
       if (
-        type === useCombobox.stateChangeTypes.InputChange &&
-        clearOnNextInput &&
-        hasSelectedItem &&
-        (changes.inputValue || "").length > (state.inputValue || "").length
+        isSelectable(newSelectedItem) &&
+        previousSelectedItem !== newSelectedItem
       ) {
-        inputValue = changes.inputValue.slice(-1); // the last character the user typed
-        setClearOnNextInput(false);
+        onChange(newSelectedItem.props.value);
+        return {
+          ...changes,
+          isOpen: true,
+        };
       }
 
-      return {
-        ...changes,
-        inputValue,
-      };
+      return changes;
     },
   });
 
@@ -424,36 +430,8 @@ const Combobox = ({
           startIcon={icon}
           endContent={renderEndContent(isOpen)}
           {...getInputProps({
-            onFocus: () => {
-              if (hasSelectedItem) {
-                setClearOnNextInput(true);
-              }
-              handleMenuToggle();
-            },
+            onFocus: handleMenuToggle,
             onClick: handleMenuToggle,
-            onBlur: () => {
-              // If the user has selected an option, we should
-              // always set that as the input value when they leave the input
-              if (hasSelectedItem) {
-                setInputValue(
-                  selectedItem.props.searchValue || selectedItem.props.value,
-                );
-              }
-            },
-            ref: (node) => {
-              // we must capture the ref for the input to blur it
-              // when users select an action
-              inputRef.current = node;
-
-              // merge with downshift ref
-              const { downshiftRef } = getInputProps();
-              if (typeof downshiftRef === "function") {
-                downshiftRef(node);
-              }
-              if (downshiftRef && typeof downshiftRef === "object") {
-                downshiftRef.current = node;
-              }
-            },
           })}
         />
         {renderLayer(

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -250,6 +250,8 @@ export const WithActions = () => {
       >
         <Combobox.Item value="Primary Checking - 4567" />
         <Combobox.Item value="Cheese Fund - 5432" />
+        <Combobox.Item value="Primary Savings - 1234" />
+        <Combobox.Item value="Secondary Checking - 7892" />
         <Combobox.Action
           onSelect={() => {
             setIsOpen(true);


### PR DESCRIPTION
Closes NDS-1243

The [recent fix we merged for this issue](https://github.com/narmi/design_system/pull/1581) didn't completely work. I found that the enhancements we have added over time sort of painted us into a corner with complexity around managing downshift events.

This PR shifts most of the logic we need to accomplish the desired behaviors (unit tests pass) to the `stateReducer` we pass into the `useCombobox` config. 

This not only makes the code easier to work with, but resolves some of the chicken/egg problems that were inherent with the approach of using event hooks in addition to the state reducer to manage some of the same behaviors (e.g. blur).

### Code changes
- simplify and change order of things in downshift's `onInputValueChange` event hook
- move all other logic about combobox state to the state reducer

### How to review this
1. Help me make the code better if there are any opportunities (_side by side diff will be easier to check_)
2. Open the storybook preview that gets commented on this PR. Really kick the tires. Does this act like what you think a combobox acts like? Any frustrations or awkwardness in interaction?
3. Test the `WithActions` story of `Combobox`. This is a perfect test case for the original bug we aimed to solve - if the user has selected an item, that item should stay selected after clicking an action item.