### PR TITLE
feat(tokens): update 'system' colors for improved contrast

### DIFF
--- a/tokens/src/color/system.json
+++ b/tokens/src/color/system.json
@@ -1,14 +1,14 @@
 {
   "color": {
     "system": {
-      "successDark": { "value": "#37B374" },
-      "successLight": { "value": "#E3FAE7" },
-      "warnDark": { "value": "#EAC348" },
-      "warnLight": { "value": "#FEF8E3" },
+      "successDark": { "value": "#027A48" },
+      "successLight": { "value": "#ECFDF3" },
+      "warnDark": { "value": "#B54708" },
+      "warnLight": { "value": "#FFFAEB" },
       "infoDark": { "value": "#195274" },
       "infoLight": { "value": "#E8EEF1" },
-      "errorDark": { "value": "#D93B3B" },
-      "errorLight": { "value": "#FDF1F1" }
+      "errorDark": { "value": "#b42318" },
+      "errorLight": { "value": "#fef3f2" }
     }
   }
 }


### PR DESCRIPTION
closes NDS-1101

Updates color tokens for "system colors".

### Before
<img width="1057" alt="Screenshot 2025-04-07 at 4 05 23 PM" src="https://github.com/user-attachments/assets/09cfeae0-ae71-4f4d-a7de-fb71dfb49ba4" />

### After
<img width="1044" alt="Screenshot 2025-04-07 at 4 04 48 PM" src="https://github.com/user-attachments/assets/f99dc2ea-09ee-4b17-adb4-aa01dbc32028" />


**See also:** [Figma file](https://www.figma.com/design/Yvi9XpMVbCH0B6zTIaz374/design-system-audit?node-id=4036-7&t=5wWfrwljgNAUa8ob-0)