### PR TITLE
docs: enable storybook strict mode for local dev

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,7 +11,10 @@ module.exports = {
   ],
 
   addons: [
-    "@storybook/addon-essentials",
+    {
+      name: "@storybook/addon-essentials",
+      options: { strict: true },
+    },
     "@storybook/addon-links",
     "@storybook/addon-a11y",
     {


### PR DESCRIPTION
Closes NDS-1225

Enables strict mode for local storybook development. Allows us to see warnings about deprecated react and react-dom features.