### PR TITLE
fix(Combobox,Select): force a rerender when children change

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import iconSelection from "src/icons/selection.json";
@@ -150,7 +150,10 @@ const Combobox = ({
   testId,
   renderEndContent = defaultRenderEndContent,
 }) => {
-  const allChildren = React.Children.toArray(children);
+  const allChildren = useMemo(
+    () => React.Children.toArray(children),
+    [children],
+  );
   const hasCategories = allChildren.some(
     ({ type }) => type.displayName === ComboboxCategory.displayName,
   );
@@ -159,6 +162,8 @@ const Combobox = ({
     allChildren.length < 1
       ? []
       : allChildren.filter(({ props }) => "value" in props || "text" in props);
+
+  console.info(items);
 
   // If categories are being used, `items` is populated by the children of each category
   if (hasCategories) {
@@ -258,6 +263,14 @@ const Combobox = ({
       return changes;
     },
   });
+
+  // Update displayed items passed to `useCombobox` when `items` change
+  useEffect(() => {
+    const isNotActivelyFiltering = !inputValue || inputValue.length === 0;
+    if (isNotActivelyFiltering) {
+      setDisplayedItems(items);
+    }
+  }, [items, inputValue]);
 
   const hasSelectedItem = !!selectedItem;
 

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -163,7 +163,6 @@ const Combobox = ({
       ? []
       : allChildren.filter(({ props }) => "value" in props || "text" in props);
 
-  console.info(items);
 
   // If categories are being used, `items` is populated by the children of each category
   if (hasCategories) {

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Combobox, { VALID_ICON_NAMES } from "./";
 import ComboboxItem from "./ComboboxItem";
 import ComboboxHeading from "./ComboboxHeading";
+import Row from "../Row";
 import Dialog from "../Dialog";
 import Drawer from "../Drawer";
 import { options_states } from "./util";
@@ -96,6 +97,13 @@ NoChildren.parameters = {
 
 export const FullyControlled = () => {
   const [inputValue, setInputValue] = useState("");
+  const [allItems, setAllItems] = useState([
+    "Primary Checking - 4567",
+    "Secondary Checking - 9876",
+    "Primary Savings - 1234",
+    "Cheese Fund - 5432",
+  ]);
+
   return (
     <div>
       <Combobox
@@ -103,21 +111,34 @@ export const FullyControlled = () => {
         inputValue={inputValue}
         onInputChange={(val) => setInputValue(val)}
       >
-        <Combobox.Heading text="Checking" />
-        <Combobox.Item value="Primary Checking - 4567" />
-        <Combobox.Item value="Secondary Checking - 9876" />
-        <Combobox.Heading text="Savings" />
-        <Combobox.Item value="Primary Savings - 1234" />
-        <Combobox.Item value="Cheese Fund - 5432" />
+        {allItems.map((item, i) => (
+          <Combobox.Item key={`${i}-${item}`} value={item} />
+        ))}
       </Combobox>
-      <button
-        className="margin--top"
-        onClick={() => {
-          setInputValue("");
-        }}
-      >
-        Clear input value
-      </button>
+      <div className="margin--top">
+        <Row>
+          <Row.Item shrink>
+            <button
+              className="margin--top"
+              onClick={() => {
+                setInputValue("");
+              }}
+            >
+              Clear input value
+            </button>
+          </Row.Item>
+          <Row.Item shrink>
+            <button
+              className="margin--top"
+              onClick={() => {
+                setAllItems((items) => ["Extra Item!", ...items]);
+              }}
+            >
+              Add an item to the top of the list
+            </button>
+          </Row.Item>
+        </Row>
+      </div>
     </div>
   );
 };

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
 import { useSelect } from "downshift";
 import { useLayer } from "react-laag";

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useSelect } from "downshift";
 import { useLayer } from "react-laag";
@@ -131,9 +131,11 @@ const Select = ({
 }) => {
   let items = []; // List of all item types to pass to downshift state management
   let categories = []; // Categories extracted from Select.Category children
-  const options = React.Children.toArray(children).filter(
-    (item) => !isAction(item),
-  ); // All Select.Item options
+  const options = useMemo(
+    // All Select.Item options
+    () => React.Children.toArray(children).filter((item) => !isAction(item)),
+    [children],
+  );
   const actions = React.Children.toArray(children).filter(isAction); // All Select.Action items
   const [userInput, setUserInput] = useState(""); // most recent val the user typed while focused on this input
 

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -294,6 +294,10 @@ InAForm.parameters = {
 
 export const Controlled = () => {
   const [value, setValue] = useState(null);
+  const [items, setItems] = useState([
+    { value: "checking1234", label: "Checking (1234)" },
+    { value: "savings4321", label: "Savings (4321)" },
+  ]);
   return (
     <>
       <Select
@@ -302,8 +306,11 @@ export const Controlled = () => {
         value={value}
         onChange={(v) => setValue(v)}
       >
-        <Select.Item value="checking1234">Checking (1234)</Select.Item>
-        <Select.Item value="savings4321">Savings (4321)</Select.Item>
+        {items.map(({ value, label }) => (
+          <Select.Item key={`${value}-${label}`} value={value}>
+            {label}
+          </Select.Item>
+        ))}
       </Select>
       <div className="margin--top">
         <Button
@@ -311,6 +318,18 @@ export const Controlled = () => {
           kind="negative"
           onClick={() => {
             setValue(null);
+          }}
+        />
+      </div>
+      <div className="margin--top">
+        <Button
+          label="Add an item"
+          kind="negative"
+          onClick={() => {
+            setItems((items) => [
+              { value: "extra", label: "Extra Item!" },
+              ...items,
+            ]);
           }}
         />
       </div>


### PR DESCRIPTION
Closes NDS-1350

- memoize children to array processing in `Combobox` and `Select`
- ensure component rerenders the items in the dropdown when `children` change in both components
- add stories as test cases

![Apr-16-2025 17-39-08](https://github.com/user-attachments/assets/9009d11d-2d5d-4913-b165-642efb1b1473)
