### PR TITLE
fix(Drawer): enable focus trap; restore focus rings on mobile controls

### DIFF
--- a/src/Drawer/index.js
+++ b/src/Drawer/index.js
@@ -6,6 +6,7 @@ import cc from "classcat";
 import useBreakpoints from "../hooks/useBreakpoints";
 import useMountTransition from "./useMountTransition";
 import useLockBodyScroll from "../hooks/useLockBodyScroll";
+import FocusLock from "react-focus-lock";
 
 const noop = () => {};
 
@@ -168,7 +169,7 @@ const Drawer = ({
             {showControls && (
               <>
                 <button
-                  className="button--reset mobile-navigation-button"
+                  className="button--reset mobile-navigation-button mobile-navigation-button--prev"
                   onClick={onPrev}
                   aria-controls={panelId}
                   aria-label="Previous"
@@ -176,7 +177,7 @@ const Drawer = ({
                   <span className="narmi-icon-chevron-left fontSize--heading3" />
                 </button>
                 <button
-                  className="button--reset mobile-navigation-button"
+                  className="button--reset mobile-navigation-button mobile-navigation-button--next"
                   onClick={onNext}
                   aria-controls={panelId}
                   aria-label="Next"
@@ -186,7 +187,7 @@ const Drawer = ({
               </>
             )}
             <button
-              className="button--reset mobile-navigation-button"
+              className="button--reset mobile-navigation-button mobile-navigation-button--close"
               onClick={onUserDismiss}
             >
               <span className="narmi-icon-x clickable fontSize--heading3" />
@@ -216,22 +217,24 @@ const Drawer = ({
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const drawerJSX = (
     <div className="drawerContainer">
-      <div
-        ref={shimRef}
-        className={cc([
-          "backdrop",
-          { "backdrop--open": isOpen && isTransitioning },
-        ])}
-        onClick={handleShimClick}
-      />
-      {navigationContainerJSX}
-      {!showControls ? (
-        childrenJSX
-      ) : (
-        <div aria-live="polite" role="region" id={panelId}>
-          {childrenJSX}
-        </div>
-      )}
+      <FocusLock>
+        <div
+          ref={shimRef}
+          className={cc([
+            "backdrop",
+            { "backdrop--open": isOpen && isTransitioning },
+          ])}
+          onClick={handleShimClick}
+        />
+        {navigationContainerJSX}
+        {!showControls ? (
+          childrenJSX
+        ) : (
+          <div aria-live="polite" role="region" id={panelId}>
+            {childrenJSX}
+          </div>
+        )}
+      </FocusLock>
     </div>
   );
 

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -66,19 +66,15 @@ because we need to replace the left/right controls with controls that are inside
     padding: 48px var(--space-l);
   }
   .mobile-navigation-button {
-    .narmi-icon-x,
-    .narmi-icon-chevron-left,
-    .narmi-icon-chevron-right {
-      position: absolute;
-      top: var(--space-s);
-    }
-    .narmi-icon-x {
+    position: absolute;
+    top: var(--space-s);
+    &--close {
       right: var(--space-s);
     }
-    .narmi-icon-chevron-left {
+    &--prev {
       left: var(--space-s);
     }
-    .narmi-icon-chevron-right {
+    &--next {
       left: 45px;
     }
   }


### PR DESCRIPTION
Closes NDS-894

Like `Dialog`, we need a focus trap so that focus moves circularly through all focusable elements in Drawer when Drawer is open (including drawer controls).

#### Mobile control buttons changes
I noticed on mobile, the controls don't have a focus ring. This is because we were absolutely positioning the button _contents_ (the spans rendering the icons) rather than the button itself. Absolute positioning takes them out of document flow, causing the actual button elements that are the focusable to have no natural width or height, hiding the focus ring from view.

Fixed by moving positioning rules to the buttons themselves rather than the icons.


##### Note the trigger button behind the shim is not included in the focusable items
![Apr-17-2025 17-02-02](https://github.com/user-attachments/assets/973bf456-323d-4c8e-902d-ae78af1af8ef)
![Apr-17-2025 17-02-32](https://github.com/user-attachments/assets/ab23f152-d2e1-44cf-af2c-5c3c1cf3d9fe)
