### PR TITLE
fix(Button): style fixes for 'plain' kind

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -94,6 +94,10 @@
   @extend %btn-state-loading;
 }
 
+.nds-button--plain {
+  @extend %btn-kind-plain;
+}
+
 /**
 ️* ⚠️ DEPRECATED ⚠️
 * Will be removed in a future release.

--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -5,9 +5,9 @@
 
 .nds-button,
 .nds-button.resetButton {
+  cursor: pointer;
   display: inline-flex;
   position: relative;
-  cursor: pointer;
   line-height: var(--font-lineHeight-bigText);
   text-align: center;
   justify-content: center;
@@ -38,12 +38,6 @@
 }
 
 /* Kind variants */
-.nds-button--primary,
-.nds-button--secondary,
-.nds-button--tonal {
-  @extend %btn-kind-base;
-}
-
 .nds-button--primary,
 .nds-button--primary.resetButton {
   @extend %btn-kind-primary;

--- a/src/Button/sizes.scss
+++ b/src/Button/sizes.scss
@@ -3,6 +3,10 @@
   font-weight: var(--font-weight-semibold);
   min-height: rem(24px);
   border-radius: rem(12px);
+  .nds-button-content {
+    margin: rem(3px) rem(16px);
+    max-width: rem(200px);
+  }
 }
 
 %btn-size-s {
@@ -10,6 +14,10 @@
   font-weight: var(--font-weight-bold);
   min-height: rem(32px);
   border-radius: rem(18px);
+  .nds-button-content {
+    margin: rem(3px) rem(24px);
+    max-width: rem(220px);
+  }
 }
 
 %btn-size-m {
@@ -17,4 +25,8 @@
   font-weight: var(--font-weight-bold);
   min-height: rem(40px);
   border-radius: rem(24px);
+  .nds-button-content {
+    margin: rem(8px) rem(32px);
+    max-width: rem(240px);
+  }
 }

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -86,7 +86,6 @@
   text-align: left;
   color: var(--font-color-primary);
   display: block;
-  font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-l) !important;
 
   .nds-button-content {

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -69,13 +69,8 @@
   }
 }
 
-/**
-️* ⚠️ DEPRECATED ⚠️
-* Will be removed in a future release.
-*/
 %_btn-kind-plain-base {
   color: var(--theme-secondary);
-  font-weight: var(--font-weight-semibold);
   border-radius: 0;
   justify-content: start;
   min-height: unset;
@@ -91,8 +86,10 @@
 %btn-kind-plain {
   @extend %_btn-kind-plain-base;
   cursor: pointer;
-  color: var(--theme-primary);
-  font-weight: var(--font-weight-semibold);
+
+  // Plain button gets a special override to make it semibold.
+  // All other buttons inherit their font weight from `sizes` placeholders.
+  font-weight: var(--font-weight-semibold) !important;
 
   &:hover {
     color: var(--theme-primary);
@@ -110,6 +107,7 @@
   text-align: left;
   color: var(--font-color-primary);
   display: block;
+  font-weight: var(--font-weight-semibold);
   font-size: var(--font-size-l) !important;
 
   .nds-button-content {

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -1,23 +1,3 @@
-%btn-kind-base {
-  .nds-button-content {
-    margin: rem(8px) rem(32px);
-    // label constraint should scale evenly with font size
-    max-width: rem(240px);
-  }
-  &.nds-button--s {
-    .nds-button-content {
-      margin: rem(3px) rem(24px);
-      max-width: rem(220px);
-    }
-  }
-  &.nds-button--xs {
-    .nds-button-content {
-      margin: rem(3px) rem(16px);
-      max-width: rem(200px);
-    }
-  }
-}
-
 %btn-kind-primary {
   color: var(--color-white);
   background-color: var(--theme-primary);
@@ -61,19 +41,15 @@
   }
 }
 
-%btn-kind-negative {
-  @extend %_btn-kind-plain-base;
-  color: var(--theme-primary);
-  &:hover {
-    color: var(--theme-primary);
-  }
-}
-
 %_btn-kind-plain-base {
   color: var(--theme-secondary);
   border-radius: 0;
   justify-content: start;
   min-height: unset;
+
+  // Plain and Negative buttons gets a special override to make it semibold.
+  // All other buttons inherit their font weight from `sizes` placeholders.
+  font-weight: var(--font-weight-semibold) !important;
 
   &:hover {
     color: var(--theme-secondary);
@@ -83,13 +59,16 @@
   }
 }
 
+%btn-kind-negative {
+  @extend %_btn-kind-plain-base;
+  color: var(--theme-primary);
+  &:hover {
+    color: var(--theme-primary);
+  }
+}
+
 %btn-kind-plain {
   @extend %_btn-kind-plain-base;
-  cursor: pointer;
-
-  // Plain button gets a special override to make it semibold.
-  // All other buttons inherit their font weight from `sizes` placeholders.
-  font-weight: var(--font-weight-semibold) !important;
 
   &:hover {
     color: var(--theme-primary);

--- a/src/SplitButton/index.scss
+++ b/src/SplitButton/index.scss
@@ -52,12 +52,6 @@
 }
 
 .nds-splitButton-action--primary,
-.nds-splitButton-action--secondary,
-.nds-splitButton-action--tonal {
-  @extend %btn-kind-base;
-}
-
-.nds-splitButton-action--primary,
 .nds-splitButton-action--primary.resetButton {
   @extend %btn-kind-primary;
 }


### PR DESCRIPTION
Closes NDS-1353

When we merged `SplitButton` in `4.18.0`, the refactoring of button styles in to Sass placeholders missed two important things with the `plain` variant of `Button`...

- I forgot to define the variant class in `Button/index.scss`
- I forgot that `kind="plain"` buttons need an override for font weight instead of inheriting from `sizes` placeholders

This PR addresses both to restore `Button kind="plain"` to it original styling.

### Verifying the fix
You can check this older, pre-regression storybook deployment for the **expected** styles: https://60620d422ffdf100216415b2-vnjujhnpnl.chromatic.com/?path=/docs/components-button--docs

For the **actual** styles in this PR, see the Storybook comment in this conversation thread.

They should match.