### PR TITLE
fix(Combobox): minimize selector upon selection

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -247,7 +247,7 @@ const Combobox = ({
       }
 
       // Change callback is invoked when the selectedItem changes.
-      // Leave the dropdown open until user blurs the input.
+      // If multiple is not enabled, close the dropdown onChange.
       if (
         isSelectable(newSelectedItem) &&
         previousSelectedItem !== newSelectedItem
@@ -255,7 +255,7 @@ const Combobox = ({
         onChange(newSelectedItem.props.value);
         return {
           ...changes,
-          isOpen: true,
+          isOpen: false,
         };
       }
 
@@ -436,6 +436,7 @@ const Combobox = ({
             onFocus: handleMenuToggle,
             onClick: handleMenuToggle,
           })}
+          onClick={handleMenuToggle}
         />
         {renderLayer(
           <ul


### PR DESCRIPTION
from https://linear.app/narmi/issue/BDB-896/recipient-select-menu-stays-open-after-selection

A slight behaviour change: when making a selection on Combobox, close the selector.
![select](https://github.com/user-attachments/assets/188bc7b8-c6c1-4f5f-b910-cecbff2dbcc0)

This matches the behaviour on the `<Select>` component. When either of these components supports `multiple` we should leave the selector open until blur, but until that happens we should default to closing the selector.

Also noticed that clicks on the down-chevron weren't expanding the selector, so added an onClick to handle