### PR TITLE
fix(SplitButton): don't require props that have a default

### DIFF
--- a/src/SplitButton/index.stories.js
+++ b/src/SplitButton/index.stories.js
@@ -67,7 +67,7 @@ export const KindsAndSizes = () => {
     </SplitButton>
   );
 
-  const exmaples = [
+  const examples = [
     ["primary", "m"],
     ["primary", "s"],
     ["primary", "xs"],
@@ -87,7 +87,7 @@ export const KindsAndSizes = () => {
         gap: "var(--space-default)",
       }}
     >
-      {exmaples.map(([kind, size]) => (
+      {examples.map(([kind, size]) => (
         <div key={`${kind}-${size}`}>{renderSplitButton(kind, size)}</div>
       ))}
     </div>

--- a/src/SplitButton/index.tsx
+++ b/src/SplitButton/index.tsx
@@ -25,8 +25,8 @@ interface SplitButtonProps extends ButtonProps {
   children:
     | React.ReactElement<SplitButtonPopoverProps>
     | React.ReactElement<SplitButtonMenuProps>;
-  kind: "primary" | "secondary" | "tonal";
-  size: "xs" | "s" | "m";
+  kind?: "primary" | "secondary" | "tonal";
+  size?: "xs" | "s" | "m";
 }
 
 /**

--- a/src/SplitButton/index.tsx
+++ b/src/SplitButton/index.tsx
@@ -6,7 +6,7 @@ import MenuButton from "../MenuButton";
 
 // SplitButton-specific positioning options
 // passed to `MenuButton` and `Popover`
-const POPOPOVER_POSITION_PROPS = {
+const POPOVER_POSITION_PROPS = {
   side: "top",
   alignment: "start",
   offset: 6,
@@ -103,7 +103,7 @@ const SplitButton = ({
             onUserDismiss={() => setIsOpen(false)}
             onUserEnable={() => setIsOpen(true)}
             content={popoverComponent.props.children}
-            {...POPOPOVER_POSITION_PROPS}
+            {...POPOVER_POSITION_PROPS}
           />
         )}
 
@@ -111,10 +111,7 @@ const SplitButton = ({
       {!renderStaticTrigger &&
         menuComponent &&
         React.isValidElement(menuComponent) && (
-          <MenuButton
-            renderTrigger={renderTrigger}
-            {...POPOPOVER_POSITION_PROPS}
-          >
+          <MenuButton renderTrigger={renderTrigger} {...POPOVER_POSITION_PROPS}>
             {React.Children.toArray(menuComponent.props.children).map(
               (item, i) =>
                 React.isValidElement(item) ? (


### PR DESCRIPTION
I noticed in NDS 4.18.4 that I need to supply `kind="primary"` and `size="m"` for SplitButton, despite these props having defaults.

If that's intentional, feel free to close this PR.

As a drive-by, I also cleaned up two typos in these files.