### PR TITLE
fix(Button): menu buttons had gotten extra padding

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -57,6 +57,9 @@
 ️* ⚠️ DEPRECATED ⚠️
 * Will be removed in a future release.
 */
+.nds-button--m.nds-button--menu .nds-button-content {
+  margin: 0;
+}
 .nds-button--menu,
 .nds-button--menu.resetButton {
   @extend %btn-kind-menu;


### PR DESCRIPTION
There was extra margin applied when a button was of kind menu.

|current|this pr|
|---|---|
|<img width="1193" alt="Screenshot 2025-04-24 at 1 34 32 PM" src="https://github.com/user-attachments/assets/24dad7d2-90b2-4590-97d5-a8bc8cdf5cbc" />|<img width="1193" alt="Screenshot 2025-04-24 at 1 46 14 PM" src="https://github.com/user-attachments/assets/739738ec-ecbc-468c-a676-39ffec589049" />|
