### PR TITLE
fix(Dropdowntrigger): On firefox the label blocks the dropdown trigger

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -30,6 +30,7 @@
 }
 
 .nds-dropdownTrigger-label {
+  pointer-events: none;
   color: var(--color-mediumGrey);
   font-weight: var(--font-weight-default);
   text-rendering: geometricPrecision; // match input placeholder weight

--- a/src/FieldToken/index.scss
+++ b/src/FieldToken/index.scss
@@ -18,6 +18,7 @@
   .narmi-icon-x {
     cursor: pointer;
     display: inline-flex;
+    pointer-events: all;
     justify-content: center;
     align-items: center;
     height: var(--space-s);


### PR DESCRIPTION
On firefox the label for the dropdown trigger blocks the block down trigger.
If you add `pointer-events: none` it allows the click to pass through. Then one must reapply the `pointer-event` for the `FieldToken`.

### Fixed
![2025-04-28 10 28 56](https://github.com/user-attachments/assets/943c1c99-4c92-4f3a-84c3-b1a1957daf2a)
### Broken on Firefox
![2025-04-28 10 17 19](https://github.com/user-attachments/assets/4328afb6-e335-42e2-91a5-92f62e22a78e)
