### PR TITLE
fix(combobox): resolve infinite re-render issues with combobox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@narmi/design_system",
-  "version": "4.18.10",
+  "version": "4.19.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@narmi/design_system",
-      "version": "4.18.10",
+      "version": "4.19.0-beta.5",
       "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
       "dependencies": {
         "classcat": "^5.0.3",
@@ -48,6 +48,7 @@
         "@storybook/theming": "^8.6.0-alpha.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^27.0.2",
         "@types/react": "^18.2.31",
         "@types/react-dom": "^18.2.14",
@@ -7973,6 +7974,19 @@
         "yarn": ">=1"
       }
     },
+    "node_modules/@storybook/addon-a11y/node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@storybook/addon-a11y/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8944,6 +8958,21 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@storybook/test/node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@storybook/test/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -9260,9 +9289,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.5.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
-      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -39995,6 +40024,13 @@
             "redent": "^3.0.0"
           }
         },
+        "@testing-library/user-event": {
+          "version": "14.5.2",
+          "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+          "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+          "dev": true,
+          "requires": {}
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -40594,6 +40630,15 @@
             }
           }
         },
+        "@testing-library/user-event": {
+          "version": "14.5.2",
+          "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+          "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true,
+          "requires": {}
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -40829,9 +40874,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "14.5.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
-      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@storybook/theming": "^8.6.0-alpha.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^27.0.2",
     "@types/react": "^18.2.31",
     "@types/react-dom": "^18.2.14",

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -266,7 +266,7 @@ const Combobox = ({
   // Update displayed items passed to `useCombobox` when `items` change
   useEffect(() => {
     const isNotActivelyFiltering = !inputValue || inputValue.length === 0;
-    if (isNotActivelyFiltering) {
+    if (isNotActivelyFiltering && items.length !== displayedItems.length) {
       setDisplayedItems(items);
     }
   }, [items, inputValue]);

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -191,6 +191,7 @@ const Combobox = ({
     highlightedIndex,
     inputValue,
     openMenu,
+    closeMenu,
     reset,
   } = useCombobox({
     items: displayedItems,
@@ -220,9 +221,14 @@ const Combobox = ({
       onInputChange(inputValue);
     },
 
+    onSelectedItemChange: ({ selectedItem }) => {
+      onChange(selectedItem.props.value);
+      closeMenu();
+    },
+
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
-      const { type, changes } = actionAndChanges;
+      const { changes } = actionAndChanges;
       const { selectedItem: previousSelectedItem } = state;
       const { selectedItem: newSelectedItem } = changes;
 
@@ -234,27 +240,6 @@ const Combobox = ({
           ...changes,
           selectedItem: previousSelectedItem,
           inputValue: itemToString(previousSelectedItem),
-          isOpen: false,
-        };
-      }
-
-      // Clear input on blur if the user hasn't made a selection
-      if (type === useCombobox.stateChangeTypes.InputBlur) {
-        return {
-          ...changes,
-          inputValue: selectedItem ? itemToString(selectedItem) : "",
-        };
-      }
-
-      // Change callback is invoked when the selectedItem changes.
-      // If multiple is not enabled, close the dropdown onChange.
-      if (
-        isSelectable(newSelectedItem) &&
-        previousSelectedItem !== newSelectedItem
-      ) {
-        onChange(newSelectedItem.props.value);
-        return {
-          ...changes,
           isOpen: false,
         };
       }
@@ -404,6 +389,14 @@ const Combobox = ({
     }
   };
 
+  const handleBlur = () => {
+    if (highlightedIndex === -1) {
+      return
+    }
+    onInputChange( selectedItem ? itemToString(selectedItem) : "" );
+    closeMenu()
+  }
+
   // It is possible that a consumer may have nothing to pass to `children`.
   // For example, if an API response hasn't completed to load in the autocomplete
   // options. In that case, Combobox should render a normal TextInput.
@@ -433,6 +426,7 @@ const Combobox = ({
           startIcon={icon}
           endContent={renderEndContent(isOpen)}
           {...getInputProps({
+            onBlur: handleBlur,
             onFocus: handleMenuToggle,
             onClick: handleMenuToggle,
           })}

--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -217,7 +217,6 @@ const Combobox = ({
         );
         setDisplayedItems([...filteredItems, ...actionItems]);
       }
-
       onInputChange(inputValue);
     },
 
@@ -390,11 +389,10 @@ const Combobox = ({
   };
 
   const handleBlur = () => {
-    if (highlightedIndex === -1) {
-      return
-    }
     onInputChange( selectedItem ? itemToString(selectedItem) : "" );
-    closeMenu()
+    if (highlightedIndex !== -1) {
+      closeMenu()
+    }
   }
 
   // It is possible that a consumer may have nothing to pass to `children`.

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -295,3 +295,62 @@ export default {
     icon: { options: ["", ...VALID_ICON_NAMES] },
   },
 };
+
+export const WithCategoriesInForm = () => {
+
+  const [inputValue, setInputValue] = useState("");
+  const [selectedValue, setSelectedValue] = useState("")
+
+  return (
+    <>
+    <div>selected value {selectedValue}</div>
+    <Combobox
+      label="Select item"
+      inputValue={inputValue}
+      onChange={(selected) => {
+        setSelectedValue(selected)
+      }}
+      filterItemsByInput={(items, inputVal) => {
+        return items.filter((item) => {
+          if (!item) return false;
+          const query = (item.props.searchValue || item.props.value).toLowerCase();
+          return query.includes(inputVal);
+        })
+      }}
+      onInputChange={(selected) => {
+        setInputValue(selected);
+      }}
+    >
+      <Combobox.Category label="Checking">
+        <Combobox.Item searchValue="Business Checking" value="checking1">
+          Business Checking - 11234
+        </Combobox.Item>
+        <Combobox.Item searchValue="Main Checking" value="checking2">
+          Main Checking - 13989
+        </Combobox.Item>
+        <Combobox.Item searchValue="Joint Checking" value="checking3">
+          Joint Checking - 14857
+        </Combobox.Item>
+      </Combobox.Category>
+      <Combobox.Category label="Savings">
+        <Combobox.Item searchValue="Business Checking" value="savings1">
+          Business Savings - 13938
+        </Combobox.Item>
+        <Combobox.Item searchValue="Main Savings" value="savings2">
+          Main Savings - 48274
+        </Combobox.Item>
+        <Combobox.Item searchValue="Joint Savings" value="savings3">
+          Joint Savings - 48284
+        </Combobox.Item>
+      </Combobox.Category>
+      <Combobox.Category label="External Accounts">
+        <Combobox.Item value="Sasha">Sasha - 84839</Combobox.Item>
+        <Combobox.Item value="Joan">Joan - 36183</Combobox.Item>
+        <Combobox.Item value="Benoit">Benoit - 53261</Combobox.Item>
+      </Combobox.Category>
+
+    </Combobox>
+    </>
+  )
+
+};

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Combobox, {
   isSelectable,

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Combobox, {
   isSelectable,
   shouldOpenCategory,
@@ -155,7 +156,7 @@ describe("Combobox", () => {
     expect(screen.getAllByRole("option")).toHaveLength(50);
   });
 
-  it("input should auto-fill last selection on blur", () => {
+  it("input should auto-fill last selection on blur", async () => {
     const handleChange = jest.fn();
     render(
       <Combobox label={LABEL} onChange={handleChange}>
@@ -176,11 +177,12 @@ describe("Combobox", () => {
     expect(handleChange).toHaveBeenCalledWith("New York");
 
     // user backspaces some of the input, but doesn't totally clear selection
-    fireEvent.change(input, { target: { value: "New Y" } });
+    (input, { target: { value: "New Y" } });
 
     // when the user blurs away from the input, it should fill itself with the
     // last selected value (New York)
-    fireEvent.blur(input);
+    userEvent.type(input, "New Y");
+
     expect(screen.getByDisplayValue("New York")).toBeInTheDocument();
   });
 
@@ -220,7 +222,7 @@ describe("Combobox", () => {
     // Blur the input
     fireEvent.blur(input);
 
-    // On reopneing the input, the selectedItem should still be selected
+    // On reopening the input, the selectedItem should still be selected
     fireEvent.focus(input);
     expect(input.value).toBe("New York");
 

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -177,8 +177,6 @@ describe("Combobox", () => {
     expect(handleChange).toHaveBeenCalledWith("New York");
 
     // user backspaces some of the input, but doesn't totally clear selection
-    (input, { target: { value: "New Y" } });
-
     // when the user blurs away from the input, it should fill itself with the
     // last selected value (New York)
     userEvent.type(input, "New Y");


### PR DESCRIPTION
for https://github.com/narmi/design_system/issues/1605

Notably, I don't see this in prod builds - it's not reproducible https://narmi.github.io/design_system/?path=/story/components-combobox--with-categories, but it is reproducible running the same story locally. 

When clearing an input, we see an error in the console detailing that the max update depth has exceeded. 


---

On further testing, there were multiple cases where we would introduce the infinite update exception, mostly oriented around how we did not make the `stateReducer` a pure function. This PR removes the blur handling and selected item change handling out of that function and into other functions provided by downshift