### PR TITLE
fix(Button): remove extra negative button spacing

### DIFF
--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -62,6 +62,12 @@
 %btn-kind-negative {
   @extend %_btn-kind-plain-base;
   color: var(--theme-primary);
+
+  &.nds-button,
+  &.nds-button .nds-button-content {
+    margin: 0 !important;
+  }
+
   &:hover {
     color: var(--theme-primary);
   }


### PR DESCRIPTION
Closes NDS-1477

When making fixes to the `plain` button variant, I missed that the `negative` button shares a common rule to reset margin to `0`.

This fix restores the expected spacing when a negative button is placed in a `Row` next to a primary button. This pattern is typically used in dialogs and is covered by the "cancel and confirm" story of Button.

### Verifying the fix
See the storybook preview published to this PR below. Visit the "cancel and confirm" story under `Button`.