### PR TITLE
feat(ContentCard): add error prop

### DIFF
--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -18,6 +18,7 @@
 .nds-contentCard--button,
 .nds-contentCard--toggle {
   border: 1px solid var(--color-lightGrey) !important;
+
   &:hover,
   &:active,
   &[aria-pressed="true"] {
@@ -31,5 +32,10 @@
       inset: 0;
       background-color: RGBA(var(--theme-rgb-primary), var(--alpha-5));
     }
+  }
+
+  &.nds-contentCard--error {
+    border: 1px solid var(--color-errorDark) !important;
+    cursor: not-allowed;
   }
 }

--- a/src/ContentCard/index.stories.js
+++ b/src/ContentCard/index.stories.js
@@ -71,6 +71,29 @@ ToggleCard.parameters = {
   },
 };
 
+export const ButtonCardWithError = () => (
+  <ContentCard
+    kind="button"
+    onClick={() => {
+      alert("button card clicked");
+    }}
+    error="Something else is required before you can continue"
+  >
+    <h3 className="fontSize--heading4 padding--bottom--xs">Button card</h3>
+    <div className="fontSize--s fontColor--secondary">
+      This card behaves like an html <code>button</code>.
+    </div>
+  </ContentCard>
+);
+ButtonCard.parameters = {
+  docs: {
+    description: {
+      story:
+        "Cards of kind `toggle` support a selected state that can be controlled with the `isSelected` prop.",
+    },
+  },
+};
+
 export default {
   title: "Components/ContentCard",
   component: ContentCard,

--- a/src/ContentCard/index.tsx
+++ b/src/ContentCard/index.tsx
@@ -1,6 +1,8 @@
 import cc from "classcat";
 import React from "react";
 
+import Error from "../Error";
+
 interface ContentCardProps {
   /** Accepts any content as children */
   children: React.ReactNode;
@@ -45,6 +47,10 @@ interface ContentCardProps {
    * Renders card in visually selected state with appropriate attributes.
    */
   testId?: string;
+  /**
+   * Error state for `toggle` and `button` variants
+   */
+  error?: string;
 }
 
 /**
@@ -58,6 +64,7 @@ const ContentCard = ({
   children,
   testId,
   radiusSize = "s",
+  error,
 }: ContentCardProps) => {
   const isInteractive = ["interactive", "toggle", "button"].some(
     (interactiveKinds) => kind === interactiveKinds,
@@ -68,16 +75,19 @@ const ContentCard = ({
     const props: Record<string, unknown> = {};
     if (isInteractive) {
       props.role = "button";
-      props.onClick = onClick;
       props.tabIndex = "0";
-      props.onKeyUp = (e) => {
-        const { key } = e;
-        // space and Enter should be accepted for both
-        // toggle and button types
-        if (key === "Enter" || key === " ") {
-          onClick(e);
-        }
-      };
+
+      if (!error) {
+        props.onClick = onClick;
+        props.onKeyUp = (e) => {
+          const { key } = e;
+          // space and Enter should be accepted for both
+          // toggle and button types
+          if (key === "Enter" || key === " ") {
+            onClick(e);
+          }
+        };
+      }
     }
     if (isToggle) {
       props["aria-pressed"] = isSelected;
@@ -86,19 +96,25 @@ const ContentCard = ({
   };
 
   return (
-    <div
-      data-testid={testId || "ndsContentCard"}
-      className={cc([
-        "nds-contentCard",
-        `nds-contentCard--${kind}`,
-        `padding--all--${paddingSize}`,
-        `rounded--all--${radiusSize} bgColor--white`,
-        { "button--reset": isInteractive },
-      ])}
-      {...getInteractiveProps()}
-    >
-      {children}
-    </div>
+    <>
+      <div
+        data-testid={testId || "ndsContentCard"}
+        className={cc([
+          "nds-contentCard",
+          `nds-contentCard--${kind}`,
+          `padding--all--${paddingSize}`,
+          `rounded--all--${radiusSize} bgColor--white`,
+          {
+            "button--reset": isInteractive,
+            "nds-contentCard--error": isInteractive && error,
+          },
+        ])}
+        {...getInteractiveProps()}
+      >
+        {children}
+      </div>
+      {error && <Error error={error} marginTop="s" />}
+    </>
   );
 };
 


### PR DESCRIPTION
closes NDS-1367

- Add `error` prop to `ContentCard` that takes a string
- Render error and disable click events on interactive `ContentCard` variants when there is an `error` passed.

<img width="1076" alt="Screenshot 2025-04-30 at 5 00 02 PM" src="https://github.com/user-attachments/assets/9cf5ef4b-b8f9-4089-8e2d-e63649cfaea9" />
