### PR TITLE
fix(Button): allow overflow in plain and negative buttons

### DIFF
--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -46,6 +46,7 @@
   border-radius: 0;
   justify-content: start;
   min-height: unset;
+  overflow: visible !important; // prevent rounded edge cutoff
 
   // Plain and Negative buttons gets a special override to make it semibold.
   // All other buttons inherit their font weight from `sizes` placeholders.

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -104,6 +104,7 @@
   color: var(--font-color-primary);
   display: block;
   font-size: var(--font-size-l) !important;
+  overflow: visible !important; // prevent rounded edge cutoff
 
   .nds-button-content {
     margin: 0;


### PR DESCRIPTION
Relates to NDS-1400

https://linear.app/narmi/issue/NDS-1400/[design-system]-plain-button-variant-minor-regression#comment-c13abbb3

Prevents base `overflow: hidden` rule on buttons from cutting off long text in plain and negative buttons.