### PR TITLE
feat(Avatar): add 'tonal' style variant

### DIFF
--- a/src/Avatar/index.scss
+++ b/src/Avatar/index.scss
@@ -1,5 +1,4 @@
 .nds-avatar {
-  color: white;
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -23,4 +22,14 @@
   height: rem(40px);
   width: rem(40px);
   font-size: var(--font-size-l);
+}
+
+.nds-avatar--primary {
+  color: white;
+  background-color: var(--theme-primary);
+}
+
+.nds-avatar--tonal {
+  color: var(--theme-primary);
+  background-color: rgba(var(--theme-rgb-primary), var(--alpha-10));
 }

--- a/src/Avatar/index.stories.tsx
+++ b/src/Avatar/index.stories.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import Avatar from "./";
 import Row from "../Row";
 
-export const Overview = () => {
-  return <Avatar initials="CP" label="Christian Paz" />;
+export const Overview = ({ initials = "CP", label = "Christian Paz" }) => {
+  return <Avatar initials={initials} label={label} />;
 };
 
 export const WithImage = () => {
@@ -17,6 +18,17 @@ export const WithImage = () => {
 
 export const WithLink = () => {
   return <Avatar initials="NM" label="Narmi" linkurl="https://narmi.com" />;
+};
+
+export const Tonal = () => {
+  return (
+    <Avatar
+      kind="tonal"
+      initials="NM"
+      label="Narmi"
+      linkurl="https://narmi.com"
+    />
+  );
 };
 
 export const WithFallbackIcon = () => {
@@ -33,17 +45,30 @@ WithFallbackIcon.parameters = {
 
 export const Sizes = () => {
   return (
-    <Row>
-      <Row.Item>
-        <Avatar initials="xs" label="extra small" size="xs" />
-      </Row.Item>
-      <Row.Item>
-        <Avatar initials="s" label="small" size="s" />
-      </Row.Item>
-      <Row.Item>
-        <Avatar initials="m" label="medium" size="m" />
-      </Row.Item>
-    </Row>
+    <>
+      <Row>
+        <Row.Item>
+          <Avatar initials="xs" label="extra small" size="xs" />
+        </Row.Item>
+        <Row.Item>
+          <Avatar initials="s" label="small" size="s" />
+        </Row.Item>
+        <Row.Item>
+          <Avatar initials="m" label="medium" size="m" />
+        </Row.Item>
+      </Row>
+      <Row className="margin--top">
+        <Row.Item>
+          <Avatar kind="tonal" initials="xs" label="extra small" size="xs" />
+        </Row.Item>
+        <Row.Item>
+          <Avatar kind="tonal" initials="s" label="small" size="s" />
+        </Row.Item>
+        <Row.Item>
+          <Avatar kind="tonal" initials="m" label="medium" size="m" />
+        </Row.Item>
+      </Row>
+    </>
   );
 };
 

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -7,6 +7,8 @@ export interface AvatarProps {
   label: string;
   /** Fixed height and width of the avatar. Default: "s". */
   size?: "xs" | "s" | "m";
+  /** Style variant of avatar */
+  kind?: "primary" | "tonal";
   /** String to display in the avatar. If imgurl is provided, this will be ignored. */
   initials?: string;
   /** Optional: URL of the image to display in the avatar. If provided, initials will be ignored. */
@@ -18,6 +20,7 @@ export interface AvatarProps {
 const Avatar = ({
   label,
   size = "s",
+  kind = "primary",
   initials,
   imgurl,
   linkurl,
@@ -35,8 +38,8 @@ const Avatar = ({
       className={cc([
         "nds-avatar",
         `nds-avatar--${size}`,
+        `nds-avatar--${kind}`,
         "alignChild--center--center",
-        "bgColor--theme--primary",
       ])}
       style={backgroundImage}
       aria-label={label}


### PR DESCRIPTION
Closes NDS-1331

Adds `tonal` variant of `Avatar`

[Figma](https://www.figma.com/design/Yvi9XpMVbCH0B6zTIaz374/design-system-audit?node-id=3314-1960&t=1wyvpvNd4kEUocc3-4)


<img width="559" alt="Screenshot 2025-05-08 at 3 31 01 PM" src="https://github.com/user-attachments/assets/c4f3c202-da48-42d5-bbd4-090cb1f3c51b" />
<img width="372" alt="Screenshot 2025-05-08 at 3 32 16 PM" src="https://github.com/user-attachments/assets/0200f3fb-cd32-44f2-8aa4-4117b09b2cd8" />
