### PR TITLE
feat(colors): add amethyst, aka AI purple

### DIFF
--- a/tokens/src/color/narmi.json
+++ b/tokens/src/color/narmi.json
@@ -71,6 +71,8 @@
       "sand800": { "value": "#FCF0E9" },
       "sand": { "value": "{color.narmi.sand500.value}" },
 
+      "amethyst": {"value": "#5514B8"},
+
       "black": { "value": "#333333" },
       "grey": { "value": "#4C4C4C" },
       "mediumGrey": { "value": "#8C8C8C" },


### PR DESCRIPTION
Adds the "AI purple" used in various new staff designs to mark AI features:

<img width="689" alt="image" src="https://github.com/user-attachments/assets/8e15680c-dba5-4bbc-a0a6-71ad4ef41253" />

The yellowish color in the gradient here is the existing `var(--color-sand)`.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/9d5a70a2-7c16-49b9-89a6-5f5f8bea7cc6" />
