### PR TITLE
chore: remove deprecation plugin from release process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "sass": "^1.45.0",
         "sass-loader": "^12.1.0",
         "semantic-release": "^19.0.0",
-        "semantic-release-npm-deprecate": "^1.0.34",
         "storybook": "^8.6.0-alpha.0",
         "style-dictionary": "^3.9.2",
         "style-loader": "^0.23.1",
@@ -30997,18 +30996,6 @@
         "node": ">=16 || ^14.17"
       }
     },
-    "node_modules/semantic-release-npm-deprecate": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/semantic-release-npm-deprecate/-/semantic-release-npm-deprecate-1.0.34.tgz",
-      "integrity": "sha512-bYXdPDbKqP6ey4SCnUeEtVJYyT5XftaIzkUy2aDByQiac3JNywPbh/oP9qyOKUMaOgGSRRX5/EKVsT+9D2n/7g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@semantic-release/npm": "^9.0.0",
-        "lodash": "^4.17.21",
-        "tempy": "<2.0.0"
-      }
-    },
     "node_modules/semantic-release/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -57087,17 +57074,6 @@
             "yargs-parser": "^20.2.2"
           }
         }
-      }
-    },
-    "semantic-release-npm-deprecate": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/semantic-release-npm-deprecate/-/semantic-release-npm-deprecate-1.0.34.tgz",
-      "integrity": "sha512-bYXdPDbKqP6ey4SCnUeEtVJYyT5XftaIzkUy2aDByQiac3JNywPbh/oP9qyOKUMaOgGSRRX5/EKVsT+9D2n/7g==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/npm": "^9.0.0",
-        "lodash": "^4.17.21",
-        "tempy": "<2.0.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "sass": "^1.45.0",
     "sass-loader": "^12.1.0",
     "semantic-release": "^19.0.0",
-    "semantic-release-npm-deprecate": "^1.0.34",
     "storybook": "^8.6.0-alpha.0",
     "style-dictionary": "^3.9.2",
     "style-loader": "^0.23.1",

--- a/release.config.js
+++ b/release.config.js
@@ -34,17 +34,6 @@ const config = {
       },
     ],
     [
-      "semantic-release-npm-deprecate",
-      {
-        "deprecations": [
-          {
-            "version": "4.18.0 - 4.18.2",
-            "message": "Contains Button component style regression. Please use version 4.18.3 or higher."
-          }
-        ]
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         tarballDir: "pack/*.tgz",


### PR DESCRIPTION
Disables release deprecation in `semantic-release` so we can unblock some failed actions