### PR TITLE
fix(Button): consistently align 'menu' variant

### DIFF
--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -102,9 +102,16 @@
 %btn-kind-menu {
   text-align: left;
   color: var(--font-color-primary);
-  display: block;
   font-size: var(--font-size-l) !important;
   overflow: visible !important; // prevent rounded edge cutoff
+  border-radius: 0;
+
+  // We use this button variant in one place, the OLB header.
+  // Legacy styles are also targeting these elements, so the following
+  // flex rules ensure that `a` and `button` buttons are consistent.
+  display: flex !important;
+  align-items: center !important;
+  justify-content: start !important;
 
   .nds-button-content {
     margin: 0;


### PR DESCRIPTION
closes NDS-1503

The long deprecated `menu` variant of `Button` is still being used in the OLB header, and some CSS in banking is also targeting these elements. This is a bad situation, so we will remove the `menu` kind in the next major release.

The changes here ensure menu buttons are properly aligned regardless of what element they render via `as`, or what other banking styles are targeting these elements.

#### With our overrides
<img width="572" alt="Screenshot 2025-05-12 at 3 27 32 PM" src="https://github.com/user-attachments/assets/20651a87-c4e7-44d3-8ee6-efa7ba1b494b" />

#### Current
<img width="604" alt="Screenshot 2025-05-12 at 3 27 39 PM" src="https://github.com/user-attachments/assets/a9b2152d-4721-43d0-93b0-faf1143bef4e" />
