### PR TITLE
chore: build storybook with stats

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -23,9 +23,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --loglevel=warn
 
+      - name: Build
+        run: npm run build && npm run build-storybook
+
       - name: Auto-accept chromatic snapshots from `main`
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          autoAcceptChanges: 'main'
+          autoAcceptChanges: true
           exitZeroOnChanges: false
+          buildScriptName: ''
+          storybookBuildDir: './storybook-static'

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -27,16 +27,19 @@ jobs:
       - name: Install dependencies
         run: npm ci --loglevel=warn
 
+      - name: Build
+        run: npm run build && npm run build-storybook
+
       - name: Chromatic
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false # fail workflow if changes detected
           autoAcceptChanges: false
-          onlyChanged: true
+          buildScriptName: ''
+          storybookBuildDir: './storybook-static'
         env:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref }} # Helps Chromatic identify the correct branch
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}     # Helps Chromatic identify the correct commit
 
   post_chromatic_comment:
     name: Post Chromatic Comment

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint \"./src/**\" \"./scripts/**\" \"./tokens/**\" --no-error-on-unmatched-pattern",
     "release": "semantic-release",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "storybook build --stats-json",
     "chromatic": "npx chromatic --project-token $CHROMATIC_PROJECT_TOKEN --exit-zero-on-changes",
     "stats:components": "node ./scripts/component-adoption.mjs",
     "stats:classes": "node ./scripts/class-adoption.mjs",


### PR DESCRIPTION
- Always build storybook with JSON stats for chromatic. 
- Update chromatic workflows to manually build storybook, using our full NDS build
