### PR TITLE
fix(Row): rm outdated item hight fix for IE

### DIFF
--- a/src/Row/index.scss
+++ b/src/Row/index.scss
@@ -11,7 +11,6 @@
   flex-basis: 0;
   flex-grow: 1;
   width: auto;
-  height: 100%;
   min-height: 0;
   min-width: 0;
 


### PR DESCRIPTION
Closes NDS-1538

[As Elliot discovered](https://linear.app/narmi/issue/NDS-1538/regression-row-alignment-has-broken-potentially-across-multiple#comment-0a1020e2), there's a case where a Row containing items with certain height rules may have incorrect alignment due to the `height: 100%` rule on row items.

This rule was added by me, based on old habits for browsers we no longer need to support.

We should not expect or accept _any_ changes in snapshot tests.