### PR TITLE
feat(MenuButton): support footer item in MenuButton

### DIFF
--- a/src/MenuButton/AriaMenuItem.js
+++ b/src/MenuButton/AriaMenuItem.js
@@ -1,0 +1,78 @@
+import React from "react";
+import cc from "classcat";
+import PropTypes from "prop-types";
+import { MenuItem as AriaMenuItem } from "react-aria-components";
+import iconSelection from "src/icons/selection.json";
+import Row from "../Row";
+
+export const VALID_ICON_NAMES = iconSelection.icons.map(
+  (icon) => icon.properties.name,
+);
+
+const MenuItem = ({
+  id,
+  label,
+  startIcon,
+  endIcon,
+  roundedTop,
+  roundedBottom,
+  className,
+}) => (
+  <AriaMenuItem
+    key={id}
+    id={id}
+    value={id}
+    startIcon={startIcon}
+    endIcon={endIcon}
+    /**
+     * react-aria provides a className interface similar
+     * to render props
+     */
+    className={({ isSelected, isFocused, isDisabled }) =>
+      cc([
+        "nds-menubutton-item",
+        "padding--x--s padding--y--xs",
+        {
+          "nds-menubutton-item--highlighted": isSelected || isFocused,
+          "nds-menubutton-item--disabled": isDisabled,
+          "rounded--top": roundedTop,
+          "rounded--bottom": roundedBottom,
+          [className]: className,
+        },
+      ])
+    }
+  >
+    <Row gapSize="s">
+      {startIcon && (
+        <Row.Item shrink>
+          <span className={`narmi-icon-${startIcon}`} />
+        </Row.Item>
+      )}
+      <Row.Item>{label}</Row.Item>
+      {endIcon && (
+        <Row.Item shrink>
+          <span className={`narmi-icon-${endIcon}`} />
+        </Row.Item>
+      )}
+    </Row>
+  </AriaMenuItem>
+);
+
+MenuItem.propTypes = {
+  /** Unique ID for the menu item */
+  id: PropTypes.string.isRequired,
+  /** Display label for menu item */
+  label: PropTypes.string.isRequired,
+  /** Optional start icon for the menu items */
+  startIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** Optional end icon for the menu items */
+  endIcon: PropTypes.oneOf(VALID_ICON_NAMES),
+  /** If true, the item will have a rounded top border */
+  roundedTop: PropTypes.bool,
+  /** If true, the item will have a rounded bottom border */
+  roundedBottom: PropTypes.bool,
+  /** Optional className parameter passed to react-aria component */
+  className: PropTypes.string,
+};
+
+export default MenuItem;

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -2,14 +2,10 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import { useLayer } from "react-laag";
-import {
-  Button as AriaButton,
-  Menu,
-  MenuItem,
-  MenuTrigger,
-} from "react-aria-components";
+import { Button as AriaButton, Menu, MenuTrigger } from "react-aria-components";
 import iconSelection from "src/icons/selection.json";
 import MenuButtonItem from "./MenuButtonItem";
+import MenuItem from "./AriaMenuItem";
 import Row from "../Row";
 import { createUseLayerContainer } from "src/util/dom";
 
@@ -35,9 +31,11 @@ const MenuButton = ({
   alignment = "start",
   offset = 2,
   children,
+  footerItem,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuItems = React.Children.toArray(children);
+  const allItems = footerItem ? menuItems.concat(footerItem) : menuItems;
   const canToggleCloseRef = useRef(isOpen);
 
   const closeMenu = useCallback(() => {
@@ -73,7 +71,7 @@ const MenuButton = ({
    * relevant `MenuButton.Item` and calls it.
    */
   const handleOnSelect = (itemId) => {
-    const selectedItem = menuItems.find(
+    const selectedItem = allItems.find(
       (item) => labelToItemId(item.props.label) === itemId,
     );
     selectedItem.props.onSelect();
@@ -156,47 +154,29 @@ const MenuButton = ({
                     key={itemId}
                     id={itemId}
                     value={itemId}
+                    label={child.props.label}
                     startIcon={child.props.startIcon}
                     endIcon={child.props.endIcon}
-                    /**
-                     * react-aria provides a className interface similar
-                     * to render props
-                     */
-                    className={({ isSelected, isFocused, isDisabled }) =>
-                      cc([
-                        "nds-menubutton-item",
-                        "padding--x--s padding--y--xs",
-                        {
-                          "nds-menubutton-item--highlighted":
-                            isSelected || isFocused,
-                          "nds-menubutton-item--disabled": isDisabled,
-                          "rounded--top": childIndex === 0,
-                          "rounded--bottom":
-                            childIndex === menuItems.length - 1,
-                        },
-                      ])
+                    roundedTop={childIndex === 0}
+                    roundedBottom={
+                      childIndex === menuItems.length - 1 && !footerItem
                     }
-                  >
-                    <Row gapSize="s">
-                      {child.props.startIcon && (
-                        <Row.Item shrink>
-                          <span
-                            className={`narmi-icon-${child.props.startIcon}`}
-                          />
-                        </Row.Item>
-                      )}
-                      <Row.Item>{child.props.label}</Row.Item>
-                      {child.props.endIcon && (
-                        <Row.Item shrink>
-                          <span
-                            className={`narmi-icon-${child.props.endIcon}`}
-                          />
-                        </Row.Item>
-                      )}
-                    </Row>
-                  </MenuItem>
+                  />
                 );
               })}
+              {footerItem && (
+                <MenuItem
+                  className="padding--all--s border--top"
+                  id={labelToItemId(footerItem.props.label)}
+                  value={labelToItemId(footerItem.props.label)}
+                  label={footerItem.props.label}
+                  startIcon={footerItem.props.startIcon}
+                  endIcon={footerItem.props.endIcon}
+                  roundedBottom
+                >
+                  {footerItem}
+                </MenuItem>
+              )}
             </Menu>
           </div>,
         )}
@@ -235,6 +215,8 @@ MenuButton.propTypes = {
   alignment: PropTypes.oneOf(["start", "center", "end"]),
   /** Distance of Popover from trigger element in number of pixels */
   offset: PropTypes.number,
+  /** Optional footer content to render below the menu items */
+  footerItem: PropTypes.node,
 };
 
 MenuButton.Item = MenuButtonItem;

--- a/src/MenuButton/index.stories.js
+++ b/src/MenuButton/index.stories.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import MenuButton, { VALID_ICON_NAMES } from "./";
 import Dialog from "../Dialog";
+import IconButton from "../IconButton";
 
 const Template = (args) => <MenuButton {...args} />;
 export const Overview = Template.bind({});
@@ -179,6 +180,26 @@ export const WithEndIcons = () => (
     />
   </MenuButton>
 );
+
+export const WithFooterContent = () => {
+  return (
+    <MenuButton
+      side="right"
+      renderTrigger={() => <IconButton kind="action" name="sparkle" />}
+      footerItem={
+        <MenuButton.Item
+          label="Help me write"
+          onSelect={() => alert("Footer!")}
+        />
+      }
+    >
+      <MenuButton.Item label="Polish" onSelect={() => alert("Polish!")} />
+      <MenuButton.Item label="Formalize" onSelect={() => alert("Formalize!")} />
+      <MenuButton.Item label="Elaborate" onSelect={() => alert("Elaborate!")} />
+      <MenuButton.Item label="Shorten" onSelect={() => alert("Shorten!")} />
+    </MenuButton>
+  );
+};
 
 export default {
   title: "Components/MenuButton",


### PR DESCRIPTION
Designs for the AI prompt call for a menu button with a footer:

<img width="515" alt="image" src="https://github.com/user-attachments/assets/ffd08c00-1d4b-41f2-8452-efb93107a6c6" />

This PR is one attempt at making this possible. It's probably not the _right_ way, so I'm open very open to feedback/suggestions. My goal was to show the desired look/behavior.

Technical details:
- Moves our handling of React-Aria `MenuItem` into its own file to make it reusable for both the main content and the footer.
- Adds logic to render a `footerItem` using `MenuItem` with small style adjustment (e.g. top border)
- Adds story

https://github.com/user-attachments/assets/b6bfb895-5c51-4cb0-a883-cbc5b8efa78e

