### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,8 @@
 name: Mark stale pull requests
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/39](https://github.com/narmi/design_system/security/code-scanning/39)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the `actions/stale` action to function. Based on the action's functionality, it needs `contents: read`, `issues: write`, and `pull-requests: write` permissions. These permissions allow the action to read repository contents, manage issues, and manage pull requests, which are necessary for marking stale issues and pull requests.

The `permissions` block will be added directly under the `name` field to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
