### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/38](https://github.com/narmi/design_system/security/code-scanning/38)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily interacts with the repository contents and requires write access for the release process. Therefore, we will set `contents: write` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
