### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,5 +1,7 @@
 name: Check License
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   Check-license:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/37](https://github.com/narmi/design_system/security/code-scanning/37)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks licenses and builds the project, it does not require write permissions. The `contents: read` permission is sufficient for this task. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
