### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,4 +1,6 @@
 name: Github Pages
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/35](https://github.com/narmi/design_system/security/code-scanning/35)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code and deploying to GitHub Pages). Therefore, we will set `contents: write` to allow deployment and restrict all other permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
