### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -1,5 +1,7 @@
 # Updates snapshots in chromatic, using latest `main` as basleline
 name: 'Chromatic Snapshot Baseline'
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/28](https://github.com/narmi/design_system/security/code-scanning/28)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the job. Since the workflow does not perform any write operations on the repository, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended modifications.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`chromatic_update_baseline`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
