### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -1,5 +1,8 @@
 # Chromatic visual tests to run on PRs targeting `main`
 name: 'Chromatic PR Checks'
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/30](https://github.com/narmi/design_system/security/code-scanning/30)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` to allow the workflow to read repository contents.
- `pull-requests: write` to allow the workflow to post comments on pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs. In this case, adding it at the root level is more efficient since both jobs (`run_chromatic` and `post_chromatic_comment`) require similar permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
