### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -1,4 +1,6 @@
 name: Jest
+permissions:
+  contents: read
 on: [pull_request]
 jobs:
   Run-jest-tests:


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/34](https://github.com/narmi/design_system/security/code-scanning/34)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. This ensures that the workflow operates securely and adheres to the principle of least privilege.

The `permissions` block should be added immediately after the `name` field in the workflow file. The permissions required for this workflow are minimal, so `contents: read` is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
