### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,7 @@
 name: Lint
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/narmi/design_system/security/code-scanning/36](https://github.com/narmi/design_system/security/code-scanning/36)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents to perform linting, we will set `contents: read`. This ensures that the workflow has the minimum required permissions and adheres to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
