### PR TITLE
chore: pin actions to hashes code-scanning/24

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -30,7 +30,7 @@ jobs:
         run: npm run build && npm run build-storybook
 
       - name: Auto-accept chromatic snapshots from `main`
-        uses: chromaui/action@latest
+        uses: chromaui/action@3378c92d26c32353e53166beac732e2edc14213c
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           autoAcceptChanges: true

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -39,8 +39,8 @@ jobs:
         run: npm run build && npm run build-storybook
 
       - name: Chromatic
-        uses: chromaui/action@latest
         id: chromatic_step
+        uses: chromaui/action@3378c92d26c32353e53166beac732e2edc14213c
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false # fail workflow if changes detected

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -27,7 +27,7 @@ jobs:
           npm run build-storybook
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.7.3
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8
         with:
           branch: gh-pages
           folder: storybook-static


### PR DESCRIPTION
Closes NDS-1609

- For read/write actions, pin to a specific commit hash per [Unpinned tag for a non-immutable Action in workflow](https://github.com/narmi/design_system/security/code-scanning/22)