### PR TITLE
feat(ContentCard): add disabled prop

### DIFF
--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -36,6 +36,16 @@
 
   &.nds-contentCard--error {
     border: 1px solid var(--color-errorDark) !important;
+
+    // When in error state, remove the hover and active styles
+    // but allow click events to pass through normally
+    &::before {
+      display: none !important;
+    }
+  }
+
+  &.nds-contentCard--disabled {
     cursor: not-allowed;
+    pointer-events: none;
   }
 }

--- a/src/ContentCard/index.tsx
+++ b/src/ContentCard/index.tsx
@@ -49,8 +49,13 @@ interface ContentCardProps {
   testId?: string;
   /**
    * Error state for `toggle` and `button` variants
+   * By default, this triggers `disabled` to be true - you may override the disabled property to `false`.
    */
   error?: string;
+  /**
+   * Disables the card, preventing any click events.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -65,6 +70,7 @@ const ContentCard = ({
   testId,
   radiusSize = "s",
   error,
+  disabled = false,
 }: ContentCardProps) => {
   const isInteractive = ["interactive", "toggle", "button"].some(
     (interactiveKinds) => kind === interactiveKinds,
@@ -107,6 +113,7 @@ const ContentCard = ({
           {
             "button--reset": isInteractive,
             "nds-contentCard--error": isInteractive && error,
+            "nds-contentCard--disabled": disabled,
           },
         ])}
         {...getInteractiveProps()}


### PR DESCRIPTION
Closes NDS-1595

Back in April, [I introduced the `error` prop to `ContentCard`](https://github.com/narmi/design_system/pull/1608) and **assumed** we wanted to disable a `button` or `toggle` kind card when it's in an error state.

The assumption was incorrect. This PR:

- Adds a new, separate control to disable a ContentCard
- Removes cursor rule and disabling from the error state
- Disables the hover/press styles when a card is in error state