### PR TITLE
Add `getTypeaheadString` prop to `MultiSelect`

### DIFF
--- a/src/MultiSelect/MultiSelectItem.js
+++ b/src/MultiSelect/MultiSelectItem.js
@@ -14,6 +14,8 @@ MultiSelectItem.propTypes = {
    * value starting with `n`.
    */
   value: PropTypes.string.isRequired,
+  /** Optional prop that takes a string to use for typeahead behavior */
+  searchValue: PropTypes.string,
   /** JSX representation of item */
   children: PropTypes.oneOfType([
     PropTypes.node,

--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -33,6 +33,16 @@ const getSelectedItems = (values, items) =>
   items.filter((item) => values.includes(item.props.value));
 
 /**
+ * @param {Node} selectItem full react element of a select item
+ * @param {String} userInput most recent thing a user typed while focused on input
+ * @returns {String} the string to use for typeahead for each given `selectItem`
+ */
+// eslint-disable-next-line no-unused-vars
+const defaultGetTypeAheadString = (userInput = "", selectItem) => {
+  return selectItem.props.searchValue || selectItem.props.value;
+};
+
+/**
  * Default summary formatter function.
  *
  * Receives an object with:
@@ -107,6 +117,7 @@ const MultiSelect = ({
    * Must return a React node.
    */
   summaryFormatter = defaultSummaryFormatter,
+  getTypeaheadString = defaultGetTypeAheadString,
 }) => {
   // Convert children to an array for easier processing.
   const items = useMemo(() => Children.toArray(children), [children]);
@@ -165,13 +176,14 @@ const MultiSelect = ({
     getMenuProps,
     highlightedIndex,
     getItemProps,
+    inputValue,
   } = useSelect({
     disabled,
     // Set selectedItem to null because multi-selection is managed separately.
     selectedItem: null,
     id: name || `nds-multiselect-${label}`,
     items,
-    itemToString,
+    itemToString: (item) => getTypeaheadString(inputValue || "", item),
     stateReducer: (state, actionAndChanges) => {
       const { changes: newChanges, type } = actionAndChanges;
       switch (type) {
@@ -408,6 +420,12 @@ MultiSelect.propTypes = {
    * and returns a string summary.
    */
   summaryFormatter: PropTypes.func,
+  /**
+   * Function with signature `(userInputValue, selectItemNode) => {}`,
+   * used to customize typeahead filtering behavior.
+   * See "Changing Typeahead Behavior" story for example.
+   */
+  getTypeaheadString: PropTypes.func,
 };
 
 MultiSelect.Item = MultiSelectItem;

--- a/src/MultiSelect/index.js
+++ b/src/MultiSelect/index.js
@@ -135,25 +135,13 @@ const MultiSelect = ({
   } = useMultipleSelection({
     initialSelectedItems: getSelectedItems(selectedItemsProp || [], items),
     stateReducer: (state, actionAndChanges) => {
-      const { type, changes, selectedItem } = actionAndChanges;
-      let newSelectedItems = [...new Set(changes.selectedItems)];
+      const { type, changes } = actionAndChanges;
 
       switch (type) {
         case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
-          newSelectedItems = newSelectedItems.filter(
-            ({ props: { value } }) => value !== selectedItem.props.value,
-          );
-          onChangeProp(newSelectedItems.map(itemToString));
-          return {
-            ...changes,
-            selectedItems: newSelectedItems,
-          };
         case useMultipleSelection.stateChangeTypes.FunctionAddSelectedItem:
-          onChangeProp(newSelectedItems.map(itemToString));
-          return {
-            ...changes,
-            selectedItems: newSelectedItems,
-          };
+          onChangeProp(changes.selectedItems.map(itemToString));
+          return changes;
         default:
           return changes;
       }
@@ -179,8 +167,6 @@ const MultiSelect = ({
     inputValue,
   } = useSelect({
     disabled,
-    // Set selectedItem to null because multi-selection is managed separately.
-    selectedItem: null,
     id: name || `nds-multiselect-${label}`,
     items,
     itemToString: (item) => getTypeaheadString(inputValue || "", item),
@@ -202,9 +188,9 @@ const MultiSelect = ({
     onStateChange: ({ type, selectedItem: newSelectedItem }) => {
       // Toggle selection when an item is clicked or activated via keyboard.
       switch (type) {
-        case useSelect.stateChangeTypes.MenuBlur:
         case useSelect.stateChangeTypes.MenuKeyDownEnter:
         case useSelect.stateChangeTypes.ItemClick:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
           if (isSelected(selectedItems, newSelectedItem)) {
             removeSelectedItem(newSelectedItem);
           } else if (newSelectedItem) {

--- a/src/MultiSelect/index.stories.js
+++ b/src/MultiSelect/index.stories.js
@@ -227,6 +227,41 @@ CustomSummaryFormatter.parameters = {
   },
 };
 
+export const ChangingTypeaheadBehavior = Template.bind({});
+ChangingTypeaheadBehavior.args = {
+  id: "customTypeaheadBehavior",
+  label: "Select an Industry",
+  getTypeaheadString: (userInput, selectItem) => {
+    let searchString =
+      selectItem.props.searchValue || selectItem.props.value || "";
+
+    // user is searching by code
+    if (/\d/.test(userInput)) {
+      searchString = selectItem.props.value;
+    }
+
+    return searchString;
+  },
+  children: [
+    { name: "Agriculture", code: "12345" },
+    { name: "Manufacturing", code: "55555" },
+    { name: "Logistics", code: "32144" },
+    { name: "Hospitality", code: "22147" },
+  ].map(({ name, code }) => (
+    <MultiSelect.Item value={code} searchValue={name}>
+      {name} - {code}
+    </MultiSelect.Item>
+  )),
+};
+ChangingTypeaheadBehavior.parameters = {
+  docs: {
+    description: {
+      story:
+        "You may provide a function to the `getTypeaheadString` prop to customize which item props/data should be used for autocomplete. In this example, we autocomplete on `value` when the user input is numeric, and autocomplete on `searchValue` (name) when the input is alpha",
+    },
+  },
+};
+
 export default {
   title: "Components/MultiSelect",
   component: MultiSelect,


### PR DESCRIPTION
Closes NDS-1352

**Features**
- `getTypeaheadString` prop added to MultiSelect, using the [same signature and implementation as Select](https://github.com/narmi/design_system/blob/67c82bfdae0f05b1f96c1287b7232b9d75b0abea/src/Select/index.stories.js#L232)

**Fixes**
- Refactored our state management to bring things closer to downshift defaults
- Enabled selection by Enter key to render the token as expected