### PR TITLE
Combobox: fix `onSelectedItem` handler for user-cleared inputs

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -163,7 +163,6 @@ const Combobox = ({
       ? []
       : allChildren.filter(({ props }) => "value" in props || "text" in props);
 
-
   // If categories are being used, `items` is populated by the children of each category
   if (hasCategories) {
     items = allChildren.flatMap(({ props }) =>
@@ -221,7 +220,7 @@ const Combobox = ({
     },
 
     onSelectedItemChange: ({ selectedItem }) => {
-      onChange(selectedItem.props.value);
+      onChange(selectedItem ? selectedItem.props.value : "");
       closeMenu();
     },
 
@@ -389,11 +388,11 @@ const Combobox = ({
   };
 
   const handleBlur = () => {
-    onInputChange( selectedItem ? itemToString(selectedItem) : "" );
+    onInputChange(selectedItem ? itemToString(selectedItem) : "");
     if (highlightedIndex !== -1) {
-      closeMenu()
+      closeMenu();
     }
-  }
+  };
 
   // It is possible that a consumer may have nothing to pass to `children`.
   // For example, if an API response hasn't completed to load in the autocomplete
@@ -468,7 +467,10 @@ Combobox.propTypes = {
   ]).isRequired,
   /** Label for the input */
   label: PropTypes.string.isRequired,
-  /** Change callback. Called when an item is selected, with the `value` of the selected item */
+  /** Change callback.
+   * Called when an item is selected, with the `value` of the selected item.
+   * Called with empty string when the user clears the input.
+   */
   onChange: PropTypes.func,
   /**
    * Sets value of the input in a controlled manner.

--- a/src/Combobox/index.test.js
+++ b/src/Combobox/index.test.js
@@ -228,4 +228,26 @@ describe("Combobox", () => {
     fireEvent.click(actionItem);
     expect(input.value).toBe("New York");
   });
+
+  it("should call onChange with empty string when input is cleared", async () => {
+    const handleChange = jest.fn();
+    render(
+      <Combobox label={LABEL} onChange={handleChange}>
+        {STATE_ITEMS}
+      </Combobox>,
+    );
+
+    // open the dropdown and select New York
+    const input = screen.getByPlaceholderText(LABEL);
+    fireEvent.focus(input);
+    const nyItem = screen.getByText("New York");
+    fireEvent.click(nyItem);
+    expect(handleChange).toHaveBeenLastCalledWith("New York");
+
+    // Clear the input (simulating backspace)
+    await userEvent.clear(input);
+
+    // onChange should be called with empty string
+    expect(handleChange).toHaveBeenLastCalledWith("");
+  });
 });


### PR DESCRIPTION
Closes NDS-1628

Updates `onSelectedItem` downshift event handler to call the `props.onChange` function of Combobox with an empty string (instead of erroring) when a user clears the value of the input.