### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,8 @@
 name: Release
 permissions:
   contents: write
+  pull-requests: write
+  id-token: write
 on:
   push:
     branches:


### PR DESCRIPTION
Closes NDS-1660

Adjust permission scope for release workflow.