### PR TITLE
chore: Add `ContextMenu` & `Dialog` tests

### DIFF
--- a/src/ContextMenu/ContextMenuItem.tsx
+++ b/src/ContextMenu/ContextMenuItem.tsx
@@ -7,7 +7,7 @@ export interface ContextMenuItemProps {
   /** ID for menu item */
   id: string;
   /** Selection handler */
-  onSelect: (label: string, id: string) => void;
+  onSelect?: (label: string, id: string) => void;
   /** Optional start icon for menu item */
   startIcon?: string;
 }

--- a/src/ContextMenu/index.test.tsx
+++ b/src/ContextMenu/index.test.tsx
@@ -1,0 +1,600 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import ContextMenu, { ContextMenuProps } from "./";
+
+// Mock react-aria-components
+jest.mock("react-aria-components", () => {
+  let mockMenuOnAction: ((value: string) => void) | undefined;
+  
+  return {
+    MenuTrigger: ({ children, "data-testid": testId, ...props }: {
+      children: React.ReactNode;
+      "data-testid"?: string;
+      [key: string]: unknown;
+    }) => {
+      // Filter out React-specific props that shouldn't be passed to DOM
+      const { ...domProps } = props;
+      return (
+        <div data-testid={testId || "menu-trigger"} {...domProps}>{children}</div>
+      );
+    },
+    Menu: ({ children, onAction }: {
+      children: React.ReactNode;
+      onAction?: (value: string) => void;
+    }) => {
+      // Store the onAction so MenuItems can access it
+      mockMenuOnAction = onAction;
+      return (
+        <div data-testid="menu">
+          {children}
+        </div>
+      );
+    },
+    MenuItem: ({ children, id, value, className }: {
+      children: React.ReactNode;
+      id?: string;
+      value?: string;
+      className?: string | ((state: { isSelected: boolean; isFocused: boolean; isDisabled: boolean }) => string);
+    }) => {
+      // Handle className function for react-aria-components
+      const classNameString = typeof className === 'function' 
+        ? className({ isSelected: false, isFocused: false, isDisabled: false })
+        : className;
+      
+      return (
+        <div
+          data-testid={`menu-item-${id || value}`}
+          data-value={value}
+          className={classNameString}
+          onClick={() => mockMenuOnAction && value && mockMenuOnAction(value)}
+          onKeyDown={(e) => {
+            if ((e.key === 'Enter' || e.key === ' ') && value) {
+              mockMenuOnAction && mockMenuOnAction(value);
+            }
+          }}
+          role="menuitem"
+          tabIndex={0}
+        >
+          {children}
+        </div>
+      );
+    },
+  };
+});
+
+// Mock react-laag
+jest.mock("react-laag", () => ({
+  useLayer: jest.fn(() => ({
+    renderLayer: (content) => content,
+    triggerProps: {},
+    layerProps: {},
+  })),
+  useMousePositionAsTrigger: () => ({
+    handleMouseEvent: jest.fn(),
+    trigger: { current: null },
+    parentRef: { current: null },
+  }),
+}));
+
+// Mock DOM utility
+jest.mock("../util/dom", () => ({
+  createUseLayerContainer: jest.fn(),
+}));
+
+const defaultProps: ContextMenuProps = {
+  children: <div>Right-click me</div>,
+  menuItems: [
+    <ContextMenu.Item
+      key="edit"
+      id="edit"
+      label="Edit"
+      startIcon="edit-2"
+      onSelect={jest.fn()}
+    />,
+    <ContextMenu.Item
+      key="delete"
+      id="delete"
+      label="Delete"
+      startIcon="trash"
+      onSelect={jest.fn()}
+    />,
+    <ContextMenu.Item
+      key="copy"
+      id="copy"
+      label="Copy"
+      startIcon="copy"
+      onSelect={jest.fn()}
+    />,
+  ],
+};
+
+const renderContextMenu = (props: Partial<ContextMenuProps> = {}) => {
+  return render(<ContextMenu {...defaultProps} {...props} />);
+};
+
+describe("ContextMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Basic rendering", () => {
+    it("renders children element", () => {
+      renderContextMenu();
+      expect(screen.getByText("Right-click me")).toBeInTheDocument();
+    });
+
+    it("does not show menu initially", () => {
+      renderContextMenu();
+      expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+    });
+
+    it("applies testId when provided", () => {
+      renderContextMenu({ testId: "custom-context-menu" });
+      expect(screen.getByTestId("custom-context-menu")).toBeInTheDocument();
+    });
+
+    it("wraps children in menu trigger", () => {
+      renderContextMenu();
+      expect(screen.getByTestId("menu-trigger")).toBeInTheDocument();
+    });
+  });
+
+  describe("Context menu activation", () => {
+    it("opens menu on right-click", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+    });
+
+    it("opens menu with Control + F12", () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      fireEvent.keyDown(triggerElement, { 
+        key: "F12", 
+        ctrlKey: true,
+        code: "F12" 
+      });
+      
+      expect(screen.getByTestId("menu")).toBeInTheDocument();
+    });
+
+    it("prevents default context menu on right-click", async () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      const rightClickEvent = new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        button: 2,
+      });
+      
+      const preventDefaultSpy = jest.spyOn(rightClickEvent, "preventDefault");
+      fireEvent(triggerElement, rightClickEvent);
+      
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it("does not open menu on regular left-click", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.click(triggerElement);
+      
+      expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+    });
+
+    it("does not open menu on other keyboard keys", () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      fireEvent.keyDown(triggerElement, { key: "Enter" });
+      fireEvent.keyDown(triggerElement, { key: "Space" });
+      fireEvent.keyDown(triggerElement, { key: "Escape" });
+      
+      expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Menu items rendering", () => {
+    beforeEach(async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+    });
+
+    it("renders all menu items", () => {
+      expect(screen.getByTestId("menu-item-edit")).toBeInTheDocument();
+      expect(screen.getByTestId("menu-item-delete")).toBeInTheDocument();
+      expect(screen.getByTestId("menu-item-copy")).toBeInTheDocument();
+    });
+
+    it("renders menu item labels", () => {
+      expect(screen.getByText("Edit")).toBeInTheDocument();
+      expect(screen.getByText("Delete")).toBeInTheDocument();
+      expect(screen.getByText("Copy")).toBeInTheDocument();
+    });
+
+    it("renders menu item icons", () => {
+      expect(document.querySelector(".narmi-icon-edit-2")).toBeInTheDocument();
+      expect(document.querySelector(".narmi-icon-trash")).toBeInTheDocument();
+      expect(document.querySelector(".narmi-icon-copy")).toBeInTheDocument();
+    });
+
+    it("applies correct CSS classes to menu items", () => {
+      const editItem = screen.getByTestId("menu-item-edit");
+      expect(editItem).toHaveClass("nds-context-menu-item");
+      expect(editItem).toHaveClass("padding--x--s");
+      expect(editItem).toHaveClass("padding--y--xs");
+    });
+
+    it("applies rounded corners to first and last items", () => {
+      const editItem = screen.getByTestId("menu-item-edit");
+      const copyItem = screen.getByTestId("menu-item-copy");
+      
+      expect(editItem).toHaveClass("rounded--top");
+      expect(copyItem).toHaveClass("rounded--bottom");
+    });
+  });
+
+  describe("Menu item interactions", () => {
+    it("calls onSelect when menu item is clicked", async () => {
+      const onSelectEdit = jest.fn();
+      const onSelectDelete = jest.fn();
+      const user = userEvent.setup();
+      
+      const customMenuItems = [
+        <ContextMenu.Item
+          key="edit"
+          id="edit"
+          label="Edit"
+          onSelect={onSelectEdit}
+        />,
+        <ContextMenu.Item
+          key="delete"
+          id="delete"
+          label="Delete"
+          onSelect={onSelectDelete}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: customMenuItems });
+      
+      // Open menu
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      // Click edit item
+      const editItem = screen.getByTestId("menu-item-edit");
+      await user.click(editItem);
+      
+      expect(onSelectEdit).toHaveBeenCalledWith("Edit", "edit");
+    });
+
+    it("passes correct parameters to onSelect", async () => {
+      const onSelect = jest.fn();
+      const user = userEvent.setup();
+      
+      const customMenuItems = [
+        <ContextMenu.Item
+          key="custom"
+          id="custom-id"
+          label="Custom Action"
+          onSelect={onSelect}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: customMenuItems });
+      
+      // Open menu and click item
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      const customItem = screen.getByTestId("menu-item-custom-id");
+      await user.click(customItem);
+      
+      expect(onSelect).toHaveBeenCalledWith("Custom Action", "custom-id");
+    });
+
+    it("handles menu items without onSelect gracefully", async () => {
+      const user = userEvent.setup();
+      
+      const customMenuItems = [
+        <ContextMenu.Item
+          key="no-handler"
+          id="no-handler"
+          label="No Handler"
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: customMenuItems });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      const item = screen.getByTestId("menu-item-no-handler");
+      expect(() => user.click(item)).not.toThrow();
+    });
+  });
+
+  describe("Menu state management", () => {
+    it("closes menu when pressing Escape", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      // Open menu
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      // Press Escape
+      fireEvent.keyUp(window, { key: "Escape" });
+      
+      await waitFor(() => {
+        expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+      });
+    });
+
+    it("handles mouse events correctly", () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      
+      // Mouse move should not cause issues
+      fireEvent.mouseMove(triggerElement);
+      expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+    });
+
+    it("enables and disables mouse position tracking", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      
+      // Open menu
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      // Mouse position tracking should be disabled when menu is open
+      // (This is mostly testing the internal state management)
+      expect(screen.getByTestId("menu")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("provides keyboard support for menu activation", () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByRole("button");
+      expect(triggerElement).toHaveAttribute("aria-label", "Press Control + F12 to open the context menu");
+    });
+
+    it("handles focus correctly", () => {
+      renderContextMenu();
+      
+      const triggerElement = screen.getByRole("button");
+      expect(triggerElement).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("maintains proper ARIA structure when menu is open", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        const menu = screen.getByTestId("menu");
+        expect(menu).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Complex menu items", () => {
+    it("handles menu items with various props", async () => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+      
+      const complexMenuItems = [
+        <ContextMenu.Item
+          key="1"
+          id="action-1"
+          label="Action with Icon"
+          startIcon="star"
+          onSelect={onSelect}
+        />,
+        <ContextMenu.Item
+          key="2"
+          id="action-2"
+          label="Another Action"
+          onSelect={onSelect}
+        />,
+        <ContextMenu.Item
+          key="3"
+          id="action-3"
+          label="Third Action"
+          startIcon="heart"
+          onSelect={onSelect}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: complexMenuItems });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByText("Action with Icon")).toBeInTheDocument();
+        expect(screen.getByText("Another Action")).toBeInTheDocument();
+        expect(screen.getByText("Third Action")).toBeInTheDocument();
+      });
+      
+      // Icons should be rendered
+      expect(document.querySelector(".narmi-icon-star")).toBeInTheDocument();
+      expect(document.querySelector(".narmi-icon-heart")).toBeInTheDocument();
+    });
+
+    it("handles empty menu items array", async () => {
+      const user = userEvent.setup();
+      renderContextMenu({ menuItems: [] });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+      
+      // Menu should be empty but not crash
+      expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+
+    it("handles single menu item", async () => {
+      const user = userEvent.setup();
+      const singleItem = [
+        <ContextMenu.Item
+          key="single"
+          id="single"
+          label="Only Action"
+          onSelect={jest.fn()}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: singleItem });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByText("Only Action")).toBeInTheDocument();
+      });
+      
+      // Single item should have both rounded top and bottom
+      const item = screen.getByTestId("menu-item-single");
+      expect(item).toHaveClass("rounded--top");
+      expect(item).toHaveClass("rounded--bottom");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("handles rapid context menu open/close", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+      
+      const triggerElement = screen.getByText("Right-click me");
+      
+      // Rapidly trigger context menu multiple times
+      for (let i = 0; i < 5; i++) {
+        await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+        await user.click(document.body);
+      }
+      
+      // Should not crash
+      expect(screen.getByText("Right-click me")).toBeInTheDocument();
+    });
+
+    it("handles complex children elements", () => {
+      const complexChildren = (
+        <div>
+          <h3>Complex Element</h3>
+          <p>With multiple children</p>
+          <button>And interactive elements</button>
+        </div>
+      );
+      
+      renderContextMenu({ children: complexChildren });
+      
+      expect(screen.getByText("Complex Element")).toBeInTheDocument();
+      expect(screen.getByText("With multiple children")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "And interactive elements" })).toBeInTheDocument();
+    });
+
+    it("handles menu items with long labels", async () => {
+      const user = userEvent.setup();
+      const longLabelItems = [
+        <ContextMenu.Item
+          key="long"
+          id="long"
+          label="This is a very long menu item label that might cause layout issues"
+          onSelect={jest.fn()}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: longLabelItems });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByText("This is a very long menu item label that might cause layout issues")).toBeInTheDocument();
+      });
+    });
+
+    it("handles menu items with special characters in labels", async () => {
+      const user = userEvent.setup();
+      const specialCharItems = [
+        <ContextMenu.Item
+          key="special"
+          id="special"
+          label="Copy & Paste"
+          onSelect={jest.fn()}
+        />,
+        <ContextMenu.Item
+          key="unicode"
+          id="unicode"
+          label="🔥 Hot Action"
+          onSelect={jest.fn()}
+        />,
+      ];
+      
+      renderContextMenu({ menuItems: specialCharItems });
+      
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+      
+      await waitFor(() => {
+        expect(screen.getByText("Copy & Paste")).toBeInTheDocument();
+        expect(screen.getByText("🔥 Hot Action")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Subcomponents", () => {
+    it("exposes ContextMenu.Item", () => {
+      expect(ContextMenu.Item).toBeDefined();
+    });
+  });
+});

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -63,10 +63,12 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   const handleOnSelect = (itemId) => {
     const selectedItem = menuItems.find((item) => item.props.id === itemId);
 
-    selectedItem.props.onSelect(
-      selectedItem.props.label,
-      selectedItem.props.id,
-    );
+    if (selectedItem?.props.onSelect) {
+      selectedItem.props.onSelect(
+        selectedItem.props.label,
+        selectedItem.props.id,
+      );
+    }
     setIsOpen(false);
     setIsMouseOverEventEnabled(true);
   };

--- a/src/Dialog/index.test.tsx
+++ b/src/Dialog/index.test.tsx
@@ -1,0 +1,327 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Dialog from "./";
+
+// Mock ReactDOM.createPortal since Dialog uses portals
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  createPortal: (children) => children,
+}));
+
+// Mock useLockBodyScroll hook
+jest.mock("../hooks/useLockBodyScroll", () => jest.fn());
+
+// Mock rafSchd
+jest.mock("raf-schd", () => (fn) => fn);
+
+const defaultProps = {
+  isOpen: true,
+  title: "Test Dialog",
+  children: <div>Dialog content</div>,
+  onUserDismiss: jest.fn(),
+};
+
+const renderDialog = (props = {}) => {
+  return render(<Dialog {...defaultProps} {...props} />);
+};
+
+describe("Dialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Create outlet div for portal
+    const outlet = document.createElement("div");
+    outlet.setAttribute("id", "outlet");
+    document.body.appendChild(outlet);
+  });
+
+  afterEach(() => {
+    // Clean up outlet
+    const outlet = document.getElementById("outlet");
+    if (outlet) {
+      document.body.removeChild(outlet);
+    }
+  });
+
+  describe("Basic rendering", () => {
+    it("renders when isOpen is true", () => {
+      renderDialog();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("Test Dialog")).toBeInTheDocument();
+      expect(screen.getByText("Dialog content")).toBeInTheDocument();
+    });
+
+    it("does not render when isOpen is false", () => {
+      renderDialog({ isOpen: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("applies correct testId", () => {
+      renderDialog({ testId: "custom-dialog" });
+      expect(screen.getByTestId("custom-dialog")).toBeInTheDocument();
+    });
+
+    it("applies custom width style", () => {
+      renderDialog({ width: "800px" });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveStyle("--dialog-preferred-width: 800px");
+    });
+  });
+
+  describe("Header styles", () => {
+    it("renders bordered header by default", () => {
+      renderDialog();
+      expect(screen.getByText("Test Dialog").closest(".nds-dialog-header")).toHaveClass(
+        "nds-dialog-header--bordered"
+      );
+    });
+
+    it("renders plain header", () => {
+      renderDialog({ headerStyle: "plain" });
+      expect(screen.getByText("Test Dialog").closest(".nds-dialog-header")).toHaveClass(
+        "nds-dialog-header--plain"
+      );
+    });
+
+    it("renders banner header with centered title", () => {
+      renderDialog({ headerStyle: "banner" });
+      const header = screen.getByText("Test Dialog").closest(".nds-dialog-header");
+      expect(header).toHaveClass("nds-dialog-header--banner");
+      expect(screen.getByText("Test Dialog")).toHaveStyle("text-align: center");
+    });
+  });
+
+  describe("Close functionality", () => {
+    it("renders close button", () => {
+      renderDialog();
+      expect(screen.getByRole("button", { name: "close" })).toBeInTheDocument();
+    });
+
+    it("calls onUserDismiss when close button is clicked", async () => {
+      const onUserDismiss = jest.fn();
+      renderDialog({ onUserDismiss });
+      
+      const closeButton = screen.getByRole("button", { name: "close" });
+      await userEvent.click(closeButton);
+      
+      expect(onUserDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onUserDismiss when Escape key is pressed", () => {
+      const onUserDismiss = jest.fn();
+      renderDialog({ onUserDismiss });
+      
+      fireEvent.keyDown(window, { key: "Escape" });
+      
+      expect(onUserDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onUserDismiss when clicking on backdrop", async () => {
+      const onUserDismiss = jest.fn();
+      renderDialog({ onUserDismiss });
+      
+      const backdrop = document.querySelector(".nds-shim--dark");
+      await userEvent.click(backdrop);
+      
+      expect(onUserDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onUserDismiss when clicking on dialog content", async () => {
+      const onUserDismiss = jest.fn();
+      renderDialog({ onUserDismiss });
+      
+      const dialog = screen.getByRole("dialog");
+      await userEvent.click(dialog);
+      
+      expect(onUserDismiss).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Content sections", () => {
+    it("renders notification section when provided", () => {
+      const notification = <div data-testid="notification">Important notice</div>;
+      renderDialog({ notification });
+      
+      expect(screen.getByTestId("notification")).toBeInTheDocument();
+      expect(screen.getByText("Important notice")).toBeInTheDocument();
+    });
+
+    it("renders footer section when provided", () => {
+      const footer = (
+        <div data-testid="footer">
+          <button>Cancel</button>
+          <button>Save</button>
+        </div>
+      );
+      renderDialog({ footer });
+      
+      expect(screen.getByTestId("footer")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    it("applies correct content padding when footer is present", () => {
+      const footer = <div>Footer content</div>;
+      renderDialog({ footer });
+      
+      const content = document.querySelector(".nds-dialog-content");
+      expect(content).not.toHaveClass("padding--bottom--xl");
+    });
+
+    it("applies correct content padding when no footer", () => {
+      renderDialog();
+      
+      const content = document.querySelector(".nds-dialog-content");
+      expect(content).toHaveClass("padding--bottom--xl");
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has correct ARIA attributes", () => {
+      renderDialog();
+      const dialog = screen.getByRole("dialog");
+      
+      expect(dialog).toHaveAttribute("aria-labelledby", "aria-dialog-label");
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("has title linked to dialog via aria-labelledby", () => {
+      renderDialog();
+      const titleElement = document.getElementById("aria-dialog-label");
+      
+      expect(titleElement).toBeInTheDocument();
+      expect(titleElement).toHaveTextContent("Test Dialog");
+    });
+
+    it("focuses the dialog when opened", async () => {
+      renderDialog();
+      
+      await waitFor(() => {
+        expect(document.querySelector(".nds-dialog-focuslock")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Overflow detection", () => {
+    it("applies correct classes when content is not overflowing", async () => {
+      const footer = <div data-testid="footer">Footer content</div>;
+      
+      // Mock scrollHeight and clientHeight to simulate no overflow
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 300,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+        configurable: true,
+        value: 400,
+      });
+      
+      renderDialog({ footer });
+
+      await waitFor(() => {
+        const content = document.querySelector(".nds-dialog-content");
+        const footer = document.querySelector(".nds-dialog-footer");
+
+        // When not overflowing, content should not have bottom padding
+        expect(content).not.toHaveClass("padding--bottom--xl");
+        // Footer should not have overflowing class
+        expect(footer).not.toHaveClass("nds-dialog-footer--overflowing");
+      });
+    });
+
+    it("applies correct classes when content is overflowing", async () => {
+      const footer = <div data-testid="footer">Footer content</div>;
+
+      // Mock scrollHeight and clientHeight to simulate overflow
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 600,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+        configurable: true,
+        value: 400,
+      });
+
+      renderDialog({ footer });
+
+      await waitFor(() => {
+        const content = document.querySelector(".nds-dialog-content");
+        const footer = document.querySelector(".nds-dialog-footer");
+
+        // When overflowing, content should have bottom padding
+        expect(content).toHaveClass("padding--bottom--xl");
+        // Footer should have overflowing class
+        expect(footer).toHaveClass("nds-dialog-footer--overflowing");
+      });
+    });
+
+    it("applies bottom padding when no footer is present", () => {
+      // Mock no overflow scenario
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+        configurable: true,
+        value: 300,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+        configurable: true,
+        value: 400,
+      });
+      
+      renderDialog(); // No footer
+
+      const content = document.querySelector(".nds-dialog-content");
+      // When no footer, content should always have bottom padding
+      expect(content).toHaveClass("padding--bottom--xl");
+    });
+  });
+
+  describe("Event cleanup", () => {
+    it("removes event listeners when unmounted", () => {
+      const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+      const { unmount } = renderDialog();
+      
+      unmount();
+      
+      expect(removeEventListenerSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+      
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("handles missing onUserDismiss gracefully", () => {
+      renderDialog({ onUserDismiss: undefined });
+      
+      const closeButton = screen.getByRole("button", { name: "close" });
+      expect(() => fireEvent.click(closeButton)).not.toThrow();
+    });
+
+    it("handles empty title", () => {
+      renderDialog({ title: "" });
+
+      const titleElement = document.getElementById("aria-dialog-label");
+      expect(titleElement).toHaveTextContent("");
+    });
+
+    it("handles complex children content", () => {
+      const complexChildren = (
+        <div>
+          <h2>Complex Content</h2>
+          <p>Paragraph content</p>
+          <button>Action Button</button>
+          <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+          </ul>
+        </div>
+      );
+      
+      renderDialog({ children: complexChildren });
+
+      expect(screen.getByText("Complex Content")).toBeInTheDocument();
+      expect(screen.getByText("Paragraph content")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Action Button" })).toBeInTheDocument();
+      expect(screen.getByText("List item 1")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -73,6 +73,7 @@ const Dialog = ({
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
   const contentRef = useRef(null);
   const shimRef = useRef(null);
+  const dialogRef = useRef(null);
   const isBanner = headerStyle === "banner";
   useLockBodyScroll(isOpen);
 
@@ -121,8 +122,8 @@ const Dialog = ({
   // the shim has events for mouse users only; does not require a role
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
-    <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in>
-      <div className="nds-dialog-root">
+    <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in nodeRef={dialogRef}>
+      <div className="nds-dialog-root" ref={dialogRef}>
         <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
           <FocusLock autoFocus={false} className="nds-dialog-focuslock">
             <div


### PR DESCRIPTION
- Adds tests for the `ContextMenu` component and updates the null handling for `onSelect`
- Adds tests for the `Dialog` component and addresses a deprecation warning for `findDOMNode`