### PR TITLE
ci: Adjust chromatic workflow to early exit on NA changes

### DIFF
--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -7,17 +7,39 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'src/**'
-      - 'tokens/**'
 
 jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_relevant_changes: ${{ steps.changes.outputs.has_changes }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Check for relevant changes
+        id: changes
+        run: |
+          # Get the base branch (main) and check for changes in src/ and tokens/
+          git fetch origin main:main
+          if git diff --name-only main...HEAD | grep -E '^(src/|tokens/)'; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Found relevant changes in src/ or tokens/"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No relevant changes found in src/ or tokens/"
+          fi
+
   run_chromatic:
+    needs: check_changes
     outputs:
       changeCount: ${{ steps.chromatic_step.outputs.changeCount }}
       buildUrl: ${{ steps.chromatic_step.outputs.buildUrl }}
       storybookUrl: ${{ steps.chromatic_step.outputs.storybookUrl }}
-    if: github.actor != 'dependabot[bot]'
+    if: needs.check_changes.outputs.has_relevant_changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
@@ -53,8 +75,8 @@ jobs:
   post_chromatic_comment:
     name: Post Chromatic Comment
     runs-on: ubuntu-latest
-    needs: run_chromatic
-    if: always()
+    needs: [check_changes, run_chromatic]
+    if: needs.check_changes.outputs.has_relevant_changes == 'true'
     steps:
       - name: Log run_chromatic job outputs
         run: echo "${{ toJson(needs.run_chromatic.outputs) }}"
@@ -75,3 +97,24 @@ jobs:
 
             ---
             <sub>This PR is posted and updated automatically by the `Chromatic` action</sub>
+
+  chromatic_status:
+    name: Chromatic Status
+    runs-on: ubuntu-latest
+    needs: [check_changes, run_chromatic]
+    if: always()
+    steps:
+      - name: Set status based on changes
+        run: |
+          if [ "${{ needs.check_changes.outputs.has_relevant_changes }}" = "true" ]; then
+            if [ "${{ needs.run_chromatic.result }}" = "success" ]; then
+              echo "Chromatic checks passed"
+              exit 0
+            else
+              echo "Chromatic checks failed"
+              exit 1
+            fi
+          else
+            echo "No relevant changes detected, skipping Chromatic checks"
+            exit 0
+          fi


### PR DESCRIPTION
The chromatic PR check will never run on pull requests that do not contain changes in the `src` or `tokens` directories. However, the check is a required workflow and will prevent merging. For example, see https://github.com/narmi/design_system/pull/1701

This updates the workflow to early exit if changes in `src` or `tokens` do not exist