### PR TITLE
fix(SeparatorList): align pseudo elements with fixed height items

### DIFF
--- a/src/SeparatorList/index.scss
+++ b/src/SeparatorList/index.scss
@@ -5,7 +5,7 @@
 
   li {
     display: inline-flex;
-    align-self: center;
+    align-items: center;
   }
 
   li[data-separator]::after {

--- a/src/SeparatorList/index.stories.js
+++ b/src/SeparatorList/index.stories.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React from "react";
 import SeparatorList from "./";
+import Button from "../Button";
 
 const Template = (args) => <SeparatorList {...args} />;
 
@@ -65,6 +66,16 @@ export const NoWrap = () => (
     ]}
   />
 );
+
+export const WithPlainButtons = Template.bind({});
+WithPlainButtons.args = {
+  separator: "|",
+  items: [
+    <Button kind="plain" label="Account" />,
+    <Button kind="plain" label="Settings" />,
+    <Button kind="plain" label="Email Preferences" />,
+  ],
+};
 
 export default {
   title: "Components/SeparatorList",


### PR DESCRIPTION
Closes NDS-1622

Changes CSS rule on `li` in `SeparatorList` to include pseudo elements in centering alignment.


#### Before:
<img width="328" alt="Screenshot 2025-07-01 at 2 07 26 PM" src="https://github.com/user-attachments/assets/7951a327-68a0-4840-afad-f427a7e2d35b" />


#### After:
<img width="340" alt="Screenshot 2025-07-01 at 2 10 39 PM" src="https://github.com/user-attachments/assets/b98d4a26-72e2-4ec2-814c-4bb8dca84edd" />