### PR TITLE
feat(TimelineEvent): add support for custom node rendering

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,9 +59,10 @@ We use a BEM-like naming convention in our CSS. Single hyphens refer to a parent
 - Styling customization should be done via the `kind` prop only. NDS should retain full control over the appearance and behavior of components.
 - Use "additive" CSS classes. For example, `.message` would be an ever-present base className, with optional modifiers like `.message--error` applied
 - We use "prop collector" style subcomponents in NDS to create a cleaner interface for consumers. E.g. `Tabs.Tab`
+- We use "render<Thing>" props to customize rendering of certain parts of a component. This provides flexibility without introducing new props for content slots or variation.
 - Avoid complex data structures in props. Use simple types like `string`, `number`, `boolean`, or arrays of these types.
 - Use `ReactNode` for props that accept React elements, e.g. `children`, `label`, `icon`.
-- Never accept `classNames` or `style` props. NDS must maintain full rendering control.
+- Never accept `classNames` or `style` props. NDS must maintain full rendering control (with `render<Thing>` props as the only exception).
 - Prefer helper classes when possible, e.g. `className="alignChild--left"` instead of adding new scss where possible.
 - Do NOT allow spread props in any component interface. Only a few exceptions to this rule exist, and no new components should allow this.
 - Components MUST NOT accept `ref` props. Use `forwardRef` to create a ref forwarding component if necessary.

--- a/src/TimelineEvent/index.js
+++ b/src/TimelineEvent/index.js
@@ -2,13 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 import iconSelection from "src/icons/selection.json";
 import cc from "classcat";
-import ToolTip from "../Tooltip"
+import ToolTip from "../Tooltip";
 
 export const VALID_ICON_NAMES = iconSelection.icons.map(
-  (icon) => icon.properties.name
+  (icon) => icon.properties.name,
 );
 
-const TimelineEvent = ({ kind = "node", icon, imgUrl, initial, tooltip, children }) => {
+const TimelineEvent = ({
+  kind = "node",
+  icon,
+  imgUrl,
+  initial,
+  tooltip,
+  children,
+  renderNode,
+}) => {
   const useInitial = !icon && !imgUrl && initial;
   return (
     <div
@@ -20,18 +28,36 @@ const TimelineEvent = ({ kind = "node", icon, imgUrl, initial, tooltip, children
       ])}
     >
       <div className="nds-timeline-track">
-        <div
-          className={cc([
-            "nds-timeline-node",
-            {
-              "nds-timeline-node--hasAvatar": Boolean(imgUrl),
-            },
-          ])}
-          style={{ backgroundImage: imgUrl ? `url(${imgUrl})` : "none" }}
-        >
-          {useInitial && (tooltip ? <ToolTip text={tooltip}><span>{initial}</span></ToolTip> : <span>{initial}</span>)}
-          {icon && (tooltip ? <ToolTip text={tooltip}><span className={`narmi-icon-${icon}`} /></ToolTip> : <span className={`narmi-icon-${icon}`} />)}
-        </div>
+        {typeof renderNode === "function" ? (
+          <div className="nds-timeline-node--custom">{renderNode()}</div>
+        ) : (
+          <div
+            className={cc([
+              "nds-timeline-node",
+              {
+                "nds-timeline-node--hasAvatar": Boolean(imgUrl),
+              },
+            ])}
+            style={{ backgroundImage: imgUrl ? `url(${imgUrl})` : "none" }}
+          >
+            {useInitial &&
+              (tooltip ? (
+                <ToolTip text={tooltip}>
+                  <span>{initial}</span>
+                </ToolTip>
+              ) : (
+                <span>{initial}</span>
+              ))}
+            {icon &&
+              (tooltip ? (
+                <ToolTip text={tooltip}>
+                  <span className={`narmi-icon-${icon}`} />
+                </ToolTip>
+              ) : (
+                <span className={`narmi-icon-${icon}`} />
+              ))}
+          </div>
+        )}
         {kind !== "start" && (
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -80,14 +106,16 @@ TimelineEvent.propTypes = {
   /**
    * Timeline event content (any JSX)
    */
-  /**
-   * Hover tooltip content for the icon
-   */
-  tooltip: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]),
+  /**
+   * Hover tooltip content for the icon
+   */
+  tooltip: PropTypes.string,
+  /** Render a custom circle node on the line */
+  renderNode: PropTypes.func,
 };
 
 export default TimelineEvent;

--- a/src/TimelineEvent/index.scss
+++ b/src/TimelineEvent/index.scss
@@ -33,26 +33,32 @@
   height: calc(100% + var(--space-l));
 }
 
-.nds-timeline-node {
+%_node-layout {
   box-sizing: border-box;
   z-index: 2;
   margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  line-height: var(--space-l);
+}
+
+.nds-timeline-node--custom {
+  @extend %_node-layout;
+}
+
+.nds-timeline-node {
+  @extend %_node-layout;
   width: var(--space-l);
   height: var(--space-l);
   border-radius: 50%;
+  overflow: hidden;
   background-color: var(--theme-primary);
   border: 1px solid var(--color-lightGrey);
-  display: flex;
-  overflow: hidden;
-  justify-content: center;
-  align-items: center;
 
   // support for icons
   color: var(--color-white);
   font-size: var(--font-size-s);
-
-  // support for initial
-  line-height: var(--space-l);
 
   // support for avatar images
   background-size: cover;

--- a/src/TimelineEvent/index.stories.js
+++ b/src/TimelineEvent/index.stories.js
@@ -38,6 +38,20 @@ export const StackingTimelineEvents = () => (
   </>
 );
 
+export const CustomNode = () => (
+  <>
+    <TimelineEvent kind="pending">
+      We are still waiting on this one
+    </TimelineEvent>
+    <TimelineEvent renderNode={() => <div className="fontSize--l">❤️</div>}>
+      This event has a custom node
+    </TimelineEvent>
+    <TimelineEvent kind="start">
+      Something kicked off this whole process
+    </TimelineEvent>
+  </>
+);
+
 export default {
   title: "Components/TimelineEvent",
   component: TimelineEvent,


### PR DESCRIPTION
Closes NDS-1605

After taking a look at all existing components, I determined that `TimelineEvent` was the biggest offender for collecting complexity without a `render<Thing>` prop.

- Adds `renderNode` custom node renderer to TimelineEvent
- Update copilot instructions

<img width="401" height="166" alt="Screenshot 2025-07-11 at 2 45 55 PM" src="https://github.com/user-attachments/assets/669fbaa7-b4d5-4d8e-9a47-285cf0a8ffab" />

