### PR TITLE
feat(AutocompleteModal): allow use of searchValue prop for filtering items

### DIFF
--- a/src/AutocompleteModal/AutoComplete.tsx
+++ b/src/AutocompleteModal/AutoComplete.tsx
@@ -17,11 +17,12 @@ export interface AutoCompleteProps {
   onChange?: (item: AutoCompleteItem) => void;
   /** Input change event callback */
   onInputChange?: (e: string) => void;
-  /** Optional pinned footer conent; use for action buttons */
+  /** Optional pinned footer content; use for action buttons */
   footerContent?: React.ReactNode;
 }
 
-export const itemToString = (item: AutoCompleteItem) => item.props.value || "";
+export const itemToString = (item: AutoCompleteItem) =>
+  item.props.searchValue || item.props.value || "";
 
 export const filterItems = (items: AutoCompleteItem[], inputValue: string) =>
   items.filter((item) =>

--- a/src/AutocompleteModal/index.stories.js
+++ b/src/AutocompleteModal/index.stories.js
@@ -34,6 +34,49 @@ export const Overview = () => {
   );
 };
 
+export const WithSearchValue = () => {
+  return (
+    <div style={{ margin: "8rem" }}>
+      <AutocompleteModal
+        inputLabel="Search"
+        trigger={<Button label="Assign to" />}
+        onChange={(val) => alert(`POST request with UUID ${val}`)}
+      >
+        <AutocompleteModal.Item
+          value="dd0bb6a2-af23-4d5e-a2ae-8c57ecd6bc07"
+          searchValue="Adam D."
+        >
+          Adam D.
+        </AutocompleteModal.Item>
+        <AutocompleteModal.Item
+          value="ac6d94fc-fab2-4670-ae30-a8756955f563"
+          searchValue="Adam U."
+        >
+          Adam U.
+        </AutocompleteModal.Item>
+        <AutocompleteModal.Item
+          value="f24b720d-681d-40e9-bdfc-52a7e807aea5"
+          searchValue="Ayesha"
+        >
+          Ayesha
+        </AutocompleteModal.Item>
+        <AutocompleteModal.Item
+          value="d9f428ee-6287-4ac1-8e05-e7b5874a568d"
+          searchValue="James"
+        >
+          James
+        </AutocompleteModal.Item>
+        <AutocompleteModal.Item
+          value="aad8f0a4-2b2a-4540-8976-54c75e6b23d8"
+          searchValue="Martin"
+        >
+          Martin
+        </AutocompleteModal.Item>
+      </AutocompleteModal>
+    </div>
+  );
+};
+
 export const WithAction = () => {
   const [selectedValue, setSelectedValue] = useState("Unassigned");
   const [items, setItems] = useState([

--- a/src/AutocompleteModal/index.tsx
+++ b/src/AutocompleteModal/index.tsx
@@ -15,7 +15,7 @@ export interface AutocompleteModalProps {
   onChange?: (value: string) => void;
   /** Input change event callback - called with value of selected item */
   onInputChange?: (value: string) => void;
-  /** Optional pinned footer conent; use for action buttons */
+  /** Optional pinned footer content; use for action buttons */
   footerContent?: React.ReactNode;
 }
 


### PR DESCRIPTION
I noticed that the `AutocompleteModalItem` component accepts a `searchValue` prop, but it wasn't being used anywhere:

https://github.com/narmi/design_system/blob/d2ae373c5ea59ff39507d5070d0824671201477f/src/AutocompleteModal/Item.tsx#L17-L22

I assume this was just an oversight?

In any case, I want to be able to distinguish between the value passed into the `AutocompleteModal`'s `onChange` handler and the typeahead value used for searching. The classic scenario for this is searching for users by display name but using the selected user's UUID to make some API call, which is what I depict in the story I added.

As a drive-by: two typo fixes.