### PR TITLE
fix(DropdownTrigger): prevent width overflow by allowing value to wrap

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -1,6 +1,7 @@
 .nds-dropdownTrigger {
   position: relative;
   min-height: rem(48px);
+  max-width: 100%;
   display: flex;
   align-items: center;
 }
@@ -45,9 +46,6 @@
 .nds-dropdownTrigger-value {
   color: var(--font-color-primary);
   max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   padding-right: rem(24px);
 }
 


### PR DESCRIPTION
Closes NDS-1734

The original bug report noted that when `AccountSelector` in banking is used in an NDS dialog, it pushes the width of the container past the edge of the viewport on mobile sizes. The `AccountSelector` implements `Select`, which uses `DropdownTrigger` to mimic an input.

I was able to reproduce the bug in isolation in NDS. The fix is to remove text overflow rules that weren't actually working and allow the value of a dropdown trigger to wrap if necessary.

### Before
<img width="505" height="306" alt="Screenshot 2025-08-04 at 5 38 34 PM" src="https://github.com/user-attachments/assets/ee1b8b6b-17a6-4f9a-8c7e-080ca22633a0" />

### After
(red outline for debugging)
<img width="576" height="318" alt="Screenshot 2025-08-04 at 5 40 38 PM" src="https://github.com/user-attachments/assets/362a6ba2-b368-498b-a4a8-064c8dee96ac" />
