### PR TITLE
fix(DateInput): Ignore globally set `input` CSS rules for `portalDisabled` `<DateInput/>` components

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -123,7 +123,7 @@
 
   input[type="text"],
   input[type="tel"],
-  input[type="number"],
+  input[type="number"]:not(.flatpickr-calendar input),
   input[type="email"],
   input[type="date"],
   input[type="password"],


### PR DESCRIPTION
- [NDS-1745: (web): calendar picker on payment activity](https://linear.app/narmi/issue/NDS-1745/web-calendar-picker-on-payment-activity)

When the `portalDisabled` prop is set on `<DateInput />`, it renders the component next to the parent input, as opposed to at the bottom of the DOM. The parent input is wrapped by a `.nds-input` div, which adheres to global CSS rules that interfere with the styling of the `flatpickr` date component. The solution was to exclude any `input` components rendered by the `flatpickr` date component within the global CSS rule using the `:not()` selector.

Before|After
--|--
<img width="553" height="615" alt="image" src="https://github.com/user-attachments/assets/d3ebbac3-c770-4f47-bbff-6a502fd9725c" />|<img width="565" height="648" alt="image" src="https://github.com/user-attachments/assets/2c0e6183-faba-45da-aa73-6fdba037b75b" />
