### PR TITLE
feat(TableAutocomplete): add autocomplete input for tables

### DIFF
--- a/src/TableAutocomplete/Item.tsx
+++ b/src/TableAutocomplete/Item.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export interface TableAutocompleteItemProps {
+  /**
+   * String representation of the option.
+   */
+  value: string;
+  /**
+   * Custom typeahead string. By default, typeahead uses `value`.
+   */
+  searchValue?: string;
+  children?: React.ReactNode;
+}
+
+const TableAutocompleteItem: React.FC<TableAutocompleteItemProps> = ({
+  children,
+  value,
+}) => <>{children || value}</>;
+TableAutocompleteItem.displayName = "TableAutocomplete.Item";
+
+export default TableAutocompleteItem;

--- a/src/TableAutocomplete/index.scss
+++ b/src/TableAutocomplete/index.scss
@@ -1,0 +1,43 @@
+.nds-tableAutocomplete {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.nds-tableAutocomplete-dropdown {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--theme-primary);
+  background-color: var(--color-white);
+  box-shadow: var(--elevation-middle);
+  max-height: rem(312px);
+  margin-top: var(--spacing-xxs);
+
+  // Align dropdown with offset input
+  transform: translateX(calc((var(--space-xs) * -1) - 1px));
+
+  .narmi-icon-check {
+    color: var(--theme-primary);
+  }
+}
+
+.nds-tableAutocomplete-menu {
+  flex-grow: 1;
+  overflow-y: auto;
+}
+
+.nds-tableAutocomplete-footer {
+  flex-grow: 0;
+  flex-basis: min-content;
+}
+
+.nds-tableAutocomplete-item {
+  cursor: pointer;
+  position: relative;
+
+  &:hover,
+  &--highlighted {
+    background: RGBA(var(--theme-rgb-primary), var(--alpha-5));
+  }
+}

--- a/src/TableAutocomplete/index.stories.tsx
+++ b/src/TableAutocomplete/index.stories.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import TableAutocomplete from ".";
+import Button from "../Button";
+
+export default {
+  title: "Components/TableAutocomplete",
+  component: TableAutocomplete,
+};
+
+const mockItems = [
+  "Apple",
+  "Apricot",
+  "Banana",
+  "Blueberry",
+  "Cherry",
+  "Grape",
+  "Grapefruit",
+  "Lemon",
+  "Lime",
+  "Mango",
+  "Orange",
+  "Peach",
+  "Pear",
+];
+
+export const Basic = (args) => {
+  return (
+    <TableAutocomplete
+      onChange={action("onChange")}
+      onInputChange={action("onInputChange")}
+      {...args}
+    >
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  );
+};
+Basic.args = {
+  label: "Select a fruit",
+  placeholder: "Type to search...",
+  isDisabled: false,
+  hasError: false,
+};
+
+export const WithCustomContent = () => {
+  return (
+    <TableAutocomplete
+      label="Select an account"
+      placeholder="Type to search..."
+      onChange={action("onChange")}
+      onInputChange={action("onInputChange")}
+    >
+      <TableAutocomplete.Item
+        value="checking-001"
+        searchValue="Checking - ***001"
+      >
+        <div>
+          <div>Checking Account</div>
+          <div className="fontSize--xs fontColor--secondary">***001</div>
+        </div>
+      </TableAutocomplete.Item>
+      <TableAutocomplete.Item
+        value="savings-001"
+        searchValue="Savings - ***001"
+      >
+        <div>
+          <div>Savings Account</div>
+          <div className="fontSize--xs fontColor--secondary">***001</div>
+        </div>
+      </TableAutocomplete.Item>
+      <TableAutocomplete.Item value="credit-003" searchValue="Credit - ***003">
+        <div>
+          <div>Credit Card</div>
+          <div className="fontSize--xs fontColor--secondary">***003</div>
+        </div>
+      </TableAutocomplete.Item>
+    </TableAutocomplete>
+  );
+};
+
+export const WithFooter = () => {
+  return (
+    <TableAutocomplete
+      label="Select a fruit"
+      placeholder="Type to search..."
+      onChange={action("onChange")}
+      onInputChange={action("onInputChange")}
+      footerContent={
+        <Button
+          size="s"
+          kind="plain"
+          label="Add new item"
+          onClick={action("Add new item")}
+        />
+      }
+    >
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  );
+};
+
+export const Disabled = () => {
+  return (
+    <TableAutocomplete
+      label="Select a fruit"
+      placeholder="Type to search..."
+      isDisabled={true}
+      inputValue="Can't change this"
+      onChange={action("onChange")}
+      onInputChange={action("onInputChange")}
+    >
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  );
+};
+
+export const WithError = () => {
+  return (
+    <TableAutocomplete
+      label="Select a fruit"
+      placeholder="Type to search..."
+      hasError={true}
+      onChange={action("onChange")}
+      onInputChange={action("onInputChange")}
+    >
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  );
+};
+
+export const PreSelectedValue = () => {
+  const [inputValue, setInputValue] = React.useState("Grape");
+
+  return (
+    <TableAutocomplete
+      label="Select a fruit"
+      placeholder="Type to search..."
+      inputValue={inputValue}
+      onChange={action("onChange")}
+      onInputChange={(value) => {
+        action("onInputChange")(value);
+        setInputValue(value);
+      }}
+    >
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  );
+};
+PreSelectedValue.parameters = {
+  docs: {
+    description: {
+      story:
+        "If the `inputValue` matches an item value, that item will be selected.",
+    },
+  },
+};

--- a/src/TableAutocomplete/index.tsx
+++ b/src/TableAutocomplete/index.tsx
@@ -1,0 +1,210 @@
+/* eslint-disable jsx-a11y/no-autofocus */
+import React, { useMemo } from "react";
+import cc from "classcat";
+import { useCombobox } from "downshift";
+import { useLayer } from "react-laag";
+import Row from "../Row";
+import TableInput from "../TableInput";
+import Item from "./Item";
+export type { TableAutocompleteItemProps } from "./Item";
+import { createUseLayerContainer } from "../util/dom";
+
+export type TableAutocompleteItem = React.ReactElement;
+
+export interface TableAutocompleteProps {
+  /** Input label for accessibility */
+  label: string;
+  /**
+   * TableAutocomplete.Item children
+   * Children must be an array of TableAutocomplete.Item components.
+   */
+  children: TableAutocompleteItem[];
+  /** Selection change event callback - called with value of selected item */
+  onChange?: (value: string) => void;
+  /** Input change event callback */
+  onInputChange?: (value: string) => void;
+  /** Optional pinned footer content; use for action buttons */
+  footerContent?: React.ReactNode;
+  /** Input placeholder text */
+  placeholder?: string;
+  /** Whether the input is disabled */
+  isDisabled?: boolean;
+  /** Optional controlled input value */
+  inputValue?: string;
+  /** Whether the input has an error */
+  hasError?: boolean;
+}
+
+export const itemToString = (item: TableAutocompleteItem | null) =>
+  item?.props.searchValue || item?.props.value || "";
+
+export const filterItems = (
+  items: TableAutocompleteItem[],
+  inputValue: string,
+) =>
+  items.filter((item) =>
+    itemToString(item).toLowerCase().startsWith(inputValue.toLowerCase()),
+  );
+
+/**
+ * A simplified Combobox component for table inline editing.
+ * Useful for inline editing of table items where we want to
+ * provide an autocomplete of possible values with a native input.
+ *
+ * Allows single selection only.
+ */
+const TableAutocomplete = ({
+  label,
+  children,
+  onChange = () => {},
+  onInputChange = () => {},
+  footerContent,
+  placeholder,
+  isDisabled = false,
+  hasError = false,
+  inputValue,
+}: TableAutocompleteProps) => {
+  const isControlled = inputValue !== undefined;
+
+  const allItems = useMemo(
+    () => React.Children.toArray(children) as TableAutocompleteItem[],
+    [children],
+  );
+
+  // For controlled mode, compute displayed items from inputValue
+  // For uncontrolled mode, let downshift manage the filtering via stateReducer
+  const [filteredItems, setFilteredItems] = React.useState(() => allItems);
+
+  const itemsToDisplay = isControlled
+    ? inputValue?.length > 0
+      ? filterItems(allItems, inputValue)
+      : allItems
+    : filteredItems;
+
+  // Compute selected item from inputValue if controlled
+  const selectedItem = useMemo(() => {
+    if (!isControlled || !inputValue) return null;
+    return allItems.find((item) => itemToString(item) === inputValue) || null;
+  }, [inputValue, allItems, isControlled]);
+
+  /** @see https://www.downshift-js.com/use-combobox */
+  const {
+    highlightedIndex,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+    isOpen,
+  } = useCombobox({
+    items: itemsToDisplay,
+    selectedItem,
+    inputValue,
+    onInputValueChange({ inputValue: downshiftInputValue }) {
+      // For uncontrolled mode, handle filtering here
+      if (!isControlled) {
+        setFilteredItems(
+          downshiftInputValue?.length > 0
+            ? filterItems(allItems, downshiftInputValue)
+            : allItems,
+        );
+      }
+      onInputChange(downshiftInputValue || "");
+    },
+    onSelectedItemChange({ selectedItem: newSelectedItem }) {
+      if (newSelectedItem) {
+        onChange(newSelectedItem.props.value);
+      }
+    },
+    itemToString(item: React.ReactNode) {
+      if (React.isValidElement(item)) {
+        return itemToString(item as TableAutocompleteItem);
+      }
+      return "";
+    },
+  });
+
+  /** @see https://github.com/everweij/react-laag#api-docs */
+  const { renderLayer, triggerProps, layerProps, triggerBounds } = useLayer({
+    isOpen,
+    overflowContainer: true,
+    auto: true,
+    snap: true,
+    placement: "bottom-start",
+    possiblePlacements: ["top-start", "bottom-start"],
+    preferY: "bottom",
+    triggerOffset: 2,
+    container: createUseLayerContainer,
+  });
+
+  return (
+    <div className="nds-tableAutocomplete">
+      <div {...triggerProps} style={{ display: "inline-block" }}>
+        <TableInput
+          label={label}
+          placeholder={!isDisabled ? placeholder : undefined}
+          isDisabled={isDisabled}
+          hasError={hasError}
+          {...getInputProps({
+            "aria-labelledby": undefined, // use underlying aria-label
+          })}
+        />
+      </div>
+      {isOpen &&
+        renderLayer(
+          <div
+            className={cc(["nds-tableAutocomplete-dropdown", "rounded--all"])}
+            {...layerProps}
+            style={{
+              ...layerProps.style,
+              width: triggerBounds?.width || "max-content",
+            }}
+          >
+            <ul
+              className="nds-tableAutocomplete-menu list--reset rounded--all"
+              {...getMenuProps()}
+            >
+              {itemsToDisplay.length === 0 && !selectedItem && (
+                <li
+                  className="nds-tableAutocomplete-item padding--x--s padding--y--xs"
+                  role="status"
+                  aria-live="polite"
+                >
+                  No results found
+                </li>
+              )}
+              {itemsToDisplay.map((item, index) => (
+                <li
+                  className={cc([
+                    "nds-tableAutocomplete-item",
+                    "padding--x--s padding--y--xs",
+                    {
+                      "nds-tableAutocomplete-item--highlighted":
+                        highlightedIndex === index,
+                    },
+                  ])}
+                  key={`${item?.props.value}-${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  <Row>
+                    <Row.Item>{item}</Row.Item>
+                    {selectedItem &&
+                      selectedItem.props.value === item.props.value && (
+                        <Row.Item as="span" shrink>
+                          <span className="narmi-icon-check fontSize--l fontWeight--bold" />
+                        </Row.Item>
+                      )}
+                  </Row>
+                </li>
+              ))}
+            </ul>
+            {footerContent && (
+              <div className="nds-tableAutocomplete-footer padding--x--s padding--y--xs border--top">
+                {footerContent}
+              </div>
+            )}
+          </div>,
+        )}
+    </div>
+  );
+};
+TableAutocomplete.Item = Item;
+export default TableAutocomplete;

--- a/src/index.scss
+++ b/src/index.scss
@@ -96,6 +96,7 @@
 @import "TimelineEvent/";
 @import "Tabs/";
 @import "Table/";
+@import "TableAutocomplete/";
 @import "TableInput/";
 @import "Tag/";
 @import "Error/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import Spinner from "./Spinner";
 import SplitButton from "./SplitButton";
 import LoadingSkeleton from "./LoadingSkeleton";
 import Table from "./Table";
+import TableAutocomplete from "./TableAutocomplete";
 import TableInput from "./TableInput";
 import Tabs from "./Tabs";
 import Tooltip from "./Tooltip";
@@ -105,6 +106,7 @@ export {
   Spinner,
   SplitButton,
   Table,
+  TableAutocomplete,
   TableInput,
   Tabs,
   Tag,


### PR DESCRIPTION
closes NDS-157

Adds `TableAutocomplete` input.

Composes `TableInput` with a dropdown menu using `useCombobox` downshift hook for state and event management with `react-laag` (`useLayer`) for positioning of the dropdown.

#### Listening for selected items (uncontrolled)
We're typically only interested in the `value` once an item is actually selected via the `onChange` event:

`<TableAutocomplete onChange={/* handle value of selected item */} .../>`

Here we don't need to worry about what's going on in the `input` internally, only the item selection.

#### Setting a default (controlled)

Pass a string matching the `value` of one of the autocomplete items to `inputValue`. When passing an `inputValue`, the component becomes fully controlled and 

`const [val, setVal] = useState("someItemValue")`
`<TableAutocomplete inputValue={val} onInputChange={({ target}) => setVal(target.value) ... />`

--------


<img width="243" height="93" alt="Screenshot 2025-08-13 at 6 07 03 PM" src="https://github.com/user-attachments/assets/c59d69ff-3659-4b86-8b6f-1264793489be" />
<img width="278" height="239" alt="Screenshot 2025-08-13 at 6 07 09 PM" src="https://github.com/user-attachments/assets/be609494-e302-429d-85d3-1950d204c608" />
<img width="241" height="136" alt="Screenshot 2025-08-13 at 6 07 14 PM" src="https://github.com/user-attachments/assets/d5017c03-e6dc-4897-90a6-9e7acdf2c5ec" />
<img width="162" height="85" alt="Screenshot 2025-08-13 at 6 07 31 PM" src="https://github.com/user-attachments/assets/b6e29ccb-e19f-4f95-9de6-de4f38f63b07" />

