### PR TITLE
Nds 1757/table date input

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -6,6 +6,10 @@ import flatpickr from "flatpickr";
 
 const noop = () => {};
 
+const defaultRenderInput = (props, input, testId) => (
+  <TextInput ref={input} type="date" required data-testid={testId} {...props} />
+);
+
 /**
  * Single day picker.
  * Composes NDS input with a [flatpickr](http://flatpickrjs.org) calendar UI.
@@ -22,6 +26,7 @@ const DateInput = ({
   disableMobile = false,
   testId,
   disablePortal,
+  renderInput = defaultRenderInput,
   ...props
 }) => {
   const input = useRef();
@@ -74,19 +79,7 @@ const DateInput = ({
     flatpickr(input.current, flatpickrOptions);
   }, [flatpickrOptions, input, disablePortal]);
 
-  return (
-    <>
-      <TextInput
-        {...props}
-        label={props.label}
-        ref={input}
-        type="date"
-        required
-        data-testid={testId}
-        {...props}
-      />
-    </>
-  );
+  return <>{renderInput(props, input, testId)}</>;
 };
 DateInput.propTypes = {
   /** Placeholder of the input */
@@ -118,6 +111,8 @@ DateInput.propTypes = {
   testId: PropTypes.string,
   /** When true, appends the calendar popup to the parent of the input instead of to document body */
   disablePortal: PropTypes.bool,
+  /** Custom render function for the input element (props, input, testId) => <TextInput {...props} /> */
+  renderInput: PropTypes.func,
 };
 DateInput.defaultProps = {
   onChange: () => {},

--- a/src/TableDateInput/index.stories.tsx
+++ b/src/TableDateInput/index.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import TableDateInput from "./";
+import type { TableDateInputProps } from "./";
+
+const Template = (args: TableDateInputProps) => <TableDateInput {...args} />;
+
+export const Overview = Template.bind({});
+Overview.args = {
+  label: "Select date",
+  placeholder: "MM/DD/YYYY",
+};
+
+export const WithDefaultDate = () => {
+  return (
+    <TableDateInput
+      label="Select a date"
+      placeholder="MM/DD/YYYY"
+      defaultDate="2024-01-15"
+    />
+  );
+};
+
+export const WithDisabledDates = Template.bind({});
+WithDisabledDates.args = {
+  label: "Select any date (except today or tomorrow)",
+  placeholder: "MM/DD/YYYY",
+  disableDates: [new Date(), new Date(Date.now() + 24 * 60 * 60 * 1000)],
+};
+
+export default {
+  title: "Components/TableDateInput",
+  component: TableDateInput,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A date input component specifically designed for use within Table.Cell. Composes DateInput with TableInput to provide consistent table styling while maintaining all date picker functionality.",
+      },
+    },
+  },
+};

--- a/src/TableDateInput/index.tsx
+++ b/src/TableDateInput/index.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import DateInput from "../DateInput";
+import TableInput, { TableInputProps } from "../TableInput";
+
+export interface TableDateInputProps {
+  /** Label of the input */
+  label: string;
+  /** Placeholder of the input */
+  placeholder: string;
+  /** Fired with 'YYYY-MM-DD' selected date string when selected date changes */
+  onChange?: (date: string) => void;
+  /** Disables dates. See [flatpickr docs](https://flatpickr.js.org/examples/#disabling-dates) for usage instructions */
+  disableDates?: Array<string | Date | ((date: Date) => boolean)>;
+  /** Sets the minimum selectable date (inclusive) */
+  minDate?: string | Date;
+  /** Alternate date format to show in input when a date is selected (e.g. 'm/d/Y')*/
+  altFormat?: string;
+  /** When true, the input value will follow an alternate format defined by the `altFormat` prop */
+  altInput?: boolean;
+  /** Sets a default selected date. DateInput uses the format 'YYYY-MM-DD' by default. */
+  defaultDate?: string;
+  /** Changes date format used in input. See [flatpickr docs](https://flatpickr.js.org/formatting/) for formatting options */
+  dateFormat?: string;
+  /** If the `onChange` callback should pass the date string in ISO8601 format */
+  useIsoOnChange?: boolean;
+  /** Disable mobile text inputs on mobile web */
+  disableMobile?: boolean;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** When true, appends the calendar popup to the parent of the input instead to document body */
+  disablePortal?: boolean;
+}
+
+/**
+ * A date input component specifically designed for use within Table.Cell.
+ * Composes DateInput with TableInput to provide consistent table styling
+ * while maintaining all date picker functionality.
+ *
+ * See `DateInput` for more detailed stories.
+ */
+const TableDateInput = ({
+  placeholder,
+  label,
+  ...otherProps
+}: TableDateInputProps) => {
+  return (
+    // @ts-expect-error - DateInput is a JS component with loose typing
+    <DateInput
+      {...otherProps}
+      altInput={true}
+      altFormat="m/d/Y"
+      renderInput={(
+        inputProps: Record<string, unknown>,
+        inputRef: React.RefObject<HTMLInputElement>,
+        testId: string,
+      ) => {
+        const { value = "", ...restInputProps } =
+          inputProps as Partial<TableInputProps>;
+        return (
+          <TableInput
+            {...restInputProps}
+            value={value}
+            label={label}
+            placeholder={placeholder}
+            ref={inputRef}
+            data-testid={testId}
+          />
+        );
+      }}
+    />
+  );
+};
+
+TableDateInput.displayName = "TableDateInput";
+
+export default TableDateInput;

--- a/src/TableDateInput/index.tsx
+++ b/src/TableDateInput/index.tsx
@@ -29,6 +29,8 @@ export interface TableDateInputProps {
   testId?: string;
   /** When true, appends the calendar popup to the parent of the input instead to document body */
   disablePortal?: boolean;
+  /** Whether the input has an errorj */
+  hasError?: boolean;
 }
 
 /**
@@ -41,6 +43,7 @@ export interface TableDateInputProps {
 const TableDateInput = ({
   placeholder,
   label,
+  hasError = false,
   ...otherProps
 }: TableDateInputProps) => {
   return (
@@ -64,6 +67,7 @@ const TableDateInput = ({
             placeholder={placeholder}
             ref={inputRef}
             data-testid={testId}
+            hasError={hasError}
           />
         );
       }}


### PR DESCRIPTION
Closes NDS-1756

Adds a new table input type, `TableDateInput`.

- Add render prop for the input element used in `DateInput`
- Use the new `renderInput` prop of `DateInput` to compose in a `TableInput`