### PR TITLE
feat(Snackbar): change children type to React.ReactNode

### DIFF
--- a/src/Snackbar/index.tsx
+++ b/src/Snackbar/index.tsx
@@ -45,7 +45,7 @@ const SnackbarButtonGroup = ({ children }: { children: React.ReactNode[] }) => (
 );
 
 export interface SnackbarProps {
-  children: React.ReactNode[];
+  children: React.ReactNode;
   isActive: boolean;
 }
 


### PR DESCRIPTION
In React, it is standard for `children` to accept any React.ReactNode. This component causes a typescript error to be thrown when only passing in a single child, and I do not think it is expected that we do not want to allow a single child to be passed.

Examples of working around this
https://github.com/narmi/banking/blob/cdc64cf424117914bfb636d2240a3aee34d69cbf/staff/src/pages/wire_manager/snackbars/ApproveReject.tsx#L66
https://github.com/narmi/banking/pull/64555