### PR TITLE
fix(Snackbar): change children type to React.ReactNode

### DIFF
--- a/src/Snackbar/index.tsx
+++ b/src/Snackbar/index.tsx
@@ -29,31 +29,35 @@ const SnackbarDivider = () => {
 /**
  * Wraps text nodes with a dedicated element.
  */
-const SnackbarText = ({ children }: { children: React.ReactNode[] }) => (
+const SnackbarText = ({ children }: React.PropsWithChildren) => (
   <div className="nds-snackbar-text fontColor--secondary">{children}</div>
 );
 
 /**
  * Renders a semantic grouping of buttons within the Snackbar
  */
-const SnackbarButtonGroup = ({ children }: { children: React.ReactNode[] }) => (
+const SnackbarButtonGroup = ({ children }: React.PropsWithChildren) => (
   <ul className="list--reset nds-snackbar-buttonGroup">
-    {children.map((button, i) => (
-      <li key={i}>{button}</li>
-    ))}
+    {React.Children.map(
+      // React.Children.map safely handles when children is not a list
+      children,
+      (button, i) => (
+        <li key={i}>{button}</li>
+      ),
+    )}
   </ul>
 );
-
-export interface SnackbarProps {
-  children: React.ReactNode[];
-  isActive: boolean;
-}
 
 /**
  * A status toolbar for multiple selection in a table.
  * Intended to be rendered in fixed position over a table.
  */
-const Snackbar = ({ children, isActive = false }: SnackbarProps) => {
+const Snackbar = ({
+  children,
+  isActive = false,
+}: React.PropsWithChildren<{
+  isActive: boolean;
+}>) => {
   return (
     <div aria-live="polite" role="status">
       {isActive && (


### PR DESCRIPTION
In React, it is standard for `children` to accept any `React.ReactNode`. This component causes a typescript error to be thrown when only passing in a single child, and I do not think it is expected that we do not want to allow a single child to be passed.

Examples of working around this
https://github.com/narmi/banking/blob/cdc64cf424117914bfb636d2240a3aee34d69cbf/staff/src/pages/wire_manager/snackbars/ApproveReject.tsx#L66
https://github.com/narmi/banking/pull/64555