### PR TITLE
fix(Table): make layout config inclusive of XL bp

### DIFF
--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -73,7 +73,11 @@ const Table = ({
 }: TableProps) => {
   const { largestSatisfiedBreakpoint } = useBreakpoints();
   const currentBreakpoint =
-    largestSatisfiedBreakpoint === "none" ? "s" : largestSatisfiedBreakpoint;
+    largestSatisfiedBreakpoint === "none"
+      ? "s"
+      : largestSatisfiedBreakpoint === "xl"
+        ? "l"
+        : largestSatisfiedBreakpoint;
 
   const visibleCols: number = colVisibility.filter(
     (minRequired: ColMinBreakpoint) =>

--- a/src/Table/util/breakpoint.ts
+++ b/src/Table/util/breakpoint.ts
@@ -7,7 +7,6 @@ const BREAKPOINT_ORDER = {
   s: 0,
   m: 1,
   l: 2,
-  xl: 3,
 };
 
 /**


### PR DESCRIPTION
Closes NDS-1789

## Background

In [the bug we observed](https://linear.app/narmi/issue/NDS-1789/potential-table-bug-ach-payment-activity), the Table component was falling back to `repeat(5, 1fr)` for its derived `grid-template-columns` inline style. 

Whenever `Table` sees a mismatch between the number of visible columns and the `colLayout` config for that breakpoint, it falls back to something sensible by making every column `1fr`. **However**, there are only supposed to be 4 visible columns at `m` and `Table` thinks there are 5.

### The fix
As it turns out, there was a mismatch between our breakpoint hook `useBreakpoints` and `Table`. Specifically, `isBreakpointSatisfied`, which Table uses to determine which columns are visible.

The `Table` component only takes "s", "m", and "l" by design, but the hook can return "xl", throwing off the count.
This PR updates the logic in the breakpoint satisfaction check to treat `l` as inclusive of `xl`.


## Beta release test
Testing against release `4.38.0-beta.0`, which contains this fix, the table seems to be working as expected:
<img width="1350" height="277" alt="Screenshot 2025-08-15 at 5 16 21 PM" src="https://github.com/user-attachments/assets/742d3edb-b01c-4952-8648-b4bb9170cded" />
