### PR TITLE
feat(TableInput): add maxLength prop with char counter

### DIFF
--- a/src/TableInput/index.scss
+++ b/src/TableInput/index.scss
@@ -1,40 +1,40 @@
 /** TableInput */
 .nds-tableField-input {
   border-width: 0;
-  width: 100%;
+  display: inline-flex;
+  border-radius: rem(4px);
+  padding: var(--space-xs);
+
+  // The 1px of border should always be present, so the
+  // input doesn't "bounce" the layout 2px on focus
+  border: 1px solid transparent;
+
+  // Offset the input to align text to its column, compensating
+  // for the internal padding and 1px border of the input
+  transform: translateX(calc((var(--space-xs) * -1) - 1px));
 
   input {
-    border-radius: rem(4px);
-    padding: var(--space-xs);
-    background: transparent;
+    padding: 0;
+    margin: 0;
+    outline: none;
+    border-width: 0;
     color: var(--font-color-primary);
     font-size: inherit;
     font-weight: inherit;
     text-rendering: geometricprecision;
-
-    // The 1px of border should always be present, so the
-    // input doesn't "bounce" the layout 2px on focus
-    border: 1px solid transparent;
-
-    // Offset the input to align text to its column, compensating
-    // for the internal padding and 1px border of the input
-    transform: translateX(calc((var(--space-xs) * -1) - 1px));
-
     &::placeholder {
       font-style: italic;
       color: var(--font-color-secondary);
     }
+  }
 
-    &:focus {
-      outline: none;
-      border: 1px solid var(--theme-primary);
-      background: var(--color-white);
-    }
+  &:has(input:focus) {
+    outline: none;
+    border: 1px solid var(--theme-primary);
+    background: var(--color-white);
   }
 
   &--hasError {
-    input {
-      border-color: var(--color-errorDark) !important;
-    }
+    border-color: var(--color-errorDark) !important;
   }
 }

--- a/src/TableInput/index.stories.tsx
+++ b/src/TableInput/index.stories.tsx
@@ -28,6 +28,17 @@ Overview.args = {
   isDisabled: false,
 };
 
+export const WithMaxLength = Template.bind({});
+WithMaxLength.args = {
+  value: "",
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+    console.log("Value changed:", event.target.value),
+  label: "Editable field",
+  placeholder: "Enter text here...",
+  isDisabled: false,
+  maxLength: 12,
+};
+
 export const InATable = () => {
   const [values, setValues] = useState({
     name1: "John Doe",

--- a/src/TableInput/index.stories.tsx
+++ b/src/TableInput/index.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import TableInput from "./";
 import Table from "../Table";
 import type { TableInputProps } from "./";
+import { action } from "@storybook/addon-actions";
 
 const Template = (args: TableInputProps) => {
   const [value, setValue] = useState(args.value || "");
@@ -22,7 +23,7 @@ export const Overview = Template.bind({});
 Overview.args = {
   value: "Sample value",
   onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
-    console.log("Value changed:", event.target.value),
+    action("Value changed")(event.target.value),
   label: "Editable field",
   placeholder: "Enter text here...",
   isDisabled: false,
@@ -32,7 +33,7 @@ export const WithMaxLength = Template.bind({});
 WithMaxLength.args = {
   value: "",
   onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
-    console.log("Value changed:", event.target.value),
+    action("Value changed")(event.target.value),
   label: "Editable field",
   placeholder: "Enter text here...",
   isDisabled: false,

--- a/src/TableInput/index.tsx
+++ b/src/TableInput/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import cc from "classcat";
+import Row from "../Row";
 
 export interface TableInputProps {
   /** Current value of the input */
@@ -14,6 +15,8 @@ export interface TableInputProps {
   isDisabled?: boolean;
   /** Whether the input has an error */
   hasError?: boolean;
+  /** Max length for input. When passed, a character counter will display */
+  maxLength?: number;
 }
 
 /**
@@ -29,32 +32,58 @@ const TableInput = React.forwardRef<HTMLInputElement, TableInputProps>(
       isDisabled = false,
       placeholder,
       hasError = false,
+      maxLength,
       ...other
     },
     ref,
-  ) => (
-    <div
-      className={cc([
-        "nds-tableField-input",
-        {
-          "nds-tableField-input--disabled": isDisabled,
-          "nds-tableField-input--hasError": hasError,
-        },
-      ])}
-    >
-      <input
-        ref={ref}
-        type="text"
-        aria-label={label}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        disabled={isDisabled}
-        aria-invalid={hasError}
-        {...other}
-      />
-    </div>
-  ),
+  ) => {
+    const characterCount = (value || "").length;
+    const showCharacterCounter =
+      maxLength !== undefined && maxLength > 0 && characterCount >= 1;
+    const hasCountError = showCharacterCounter && characterCount > maxLength;
+    return (
+      <div
+        className={cc([
+          "nds-tableField-input",
+          {
+            "nds-tableField-input--disabled": isDisabled,
+            "nds-tableField-input--hasError": hasError || hasCountError,
+          },
+        ])}
+      >
+        <Row gapSize="xs" alignItems="center">
+          <Row.Item>
+            <input
+              ref={ref}
+              type="text"
+              aria-label={label}
+              value={value}
+              onChange={onChange}
+              placeholder={placeholder}
+              disabled={isDisabled}
+              aria-invalid={hasError}
+              {...other}
+            />
+          </Row.Item>
+          {showCharacterCounter && (
+            <Row.Item shrink>
+              <div
+                className={cc([
+                  "nds-tableInput-counter",
+                  "fontSize--s",
+                  {
+                    "fontColor--error": hasError || hasCountError,
+                  },
+                ])}
+              >
+                {characterCount}/{maxLength}
+              </div>
+            </Row.Item>
+          )}
+        </Row>
+      </div>
+    );
+  },
 );
 
 TableInput.displayName = "TableInput";


### PR DESCRIPTION
Closes NDS-1791

- Move border and spacing styles to root element instead of the input itself
- Add character counter and `maxLength` prop
- Place input and character counter in a flex, preventing overlap with user-entered text

<img width="377" height="275" alt="Screenshot 2025-08-20 at 4 12 48 PM" src="https://github.com/user-attachments/assets/ca8ecada-ec37-446b-989b-46ff9b7d9d33" />
<img width="283" height="78" alt="Screenshot 2025-08-20 at 4 14 43 PM" src="https://github.com/user-attachments/assets/19761e18-7980-4a41-a0ea-e400e380df86" />
<img width="310" height="72" alt="Screenshot 2025-08-20 at 4 14 51 PM" src="https://github.com/user-attachments/assets/49096bd3-4355-47fd-958a-1104826cdc9b" />
