### PR TITLE
fix(Button): prevent small buttons from scaling on mobile

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -14,11 +14,6 @@
   align-items: center;
   border-radius: rem(24px);
   overflow: hidden;
-
-  /* mobile buttons have slightly taller padding for ease of tapping */
-  @media (max-width: #{map.get($breakpoints, "s")}) {
-    min-height: rem(48px) !important;
-  }
 }
 
 /* Size variants */

--- a/src/Button/sizes.scss
+++ b/src/Button/sizes.scss
@@ -29,4 +29,8 @@
     margin: rem(8px) rem(32px);
     max-width: rem(240px);
   }
+  // Medium is our default size. As such, we want it to scale up on smaller viewports.
+  @media (max-width: #{map.get($breakpoints, "s")}) {
+    min-height: rem(48px) !important;
+  }
 }


### PR DESCRIPTION
Closes NDS-1746

Allow only the `m` button size to scale its height on mobile viewports. 

### Before
<img width="423" height="253" alt="Screenshot 2025-08-20 at 4 21 42 PM" src="https://github.com/user-attachments/assets/803da2aa-9999-433e-a00c-e29053627b43" />


### After
<img width="459" height="256" alt="Screenshot 2025-08-20 at 4 22 25 PM" src="https://github.com/user-attachments/assets/61ef93e6-f8ed-47f2-a058-4b7680e8f396" />
