### PR TITLE
feat(Pagination): use sliding window behavior

### DIFF
--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
-import Row from "../Row";
 import { usePagination } from "./usePagination";
 
 const noop = () => {};
@@ -70,8 +69,8 @@ const Pagination = ({
   const pagination = (
     <div className="nds-typography nds-pagination" data-testid={testId}>
       <nav aria-label="pagination">
-        <Row gapSize="xxs" alignItems="center" as="ul">
-          <Row.Item as="li" shrink>
+        <ul>
+          <li>
             <span
               role="button"
               tabIndex={0}
@@ -93,10 +92,10 @@ const Pagination = ({
             >
               <i role="img" className="narmi-icon-chevron-left fontSize--l"></i>
             </span>
-          </Row.Item>
+          </li>
 
           {showFirstPage && (
-            <Row.Item as="li" shrink>
+            <li>
               <span
                 role="button"
                 tabIndex={0}
@@ -112,16 +111,16 @@ const Pagination = ({
               >
                 1
               </span>
-            </Row.Item>
+            </li>
           )}
           {showFirstPage && (
-            <Row.Item as="li" shrink>
+            <li>
               <div className="nds-pagination-ellipsis">&hellip;</div>
-            </Row.Item>
+            </li>
           )}
 
           {visiblePages.map((page, i) => (
-            <Row.Item as="li" key={page} shrink>
+            <li key={`page-${page}`}>
               <span
                 role="button"
                 tabIndex={0}
@@ -143,16 +142,16 @@ const Pagination = ({
               >
                 {page.toString()}
               </span>
-            </Row.Item>
+            </li>
           ))}
 
           {showLastPage && (
-            <Row.Item as="li" shrink>
+            <li>
               <div className="nds-pagination-ellipsis">&hellip;</div>
-            </Row.Item>
+            </li>
           )}
           {showLastPage && (
-            <Row.Item as="li" shrink>
+            <li>
               <span
                 role="button"
                 tabIndex={0}
@@ -168,10 +167,10 @@ const Pagination = ({
               >
                 {totalPages.toString()}
               </span>
-            </Row.Item>
+            </li>
           )}
 
-          <Row.Item as="li" shrink>
+          <li>
             <span
               role="button"
               tabIndex={0}
@@ -196,8 +195,8 @@ const Pagination = ({
                 className="narmi-icon-chevron-right fontSize--l"
               ></i>
             </span>
-          </Row.Item>
-        </Row>
+          </li>
+        </ul>
       </nav>
     </div>
   );

--- a/src/Pagination/index.js
+++ b/src/Pagination/index.js
@@ -1,61 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 import Row from "../Row";
+import { usePagination } from "./usePagination";
 
 const noop = () => {};
-const MAX_VISIBLE_PAGES = 5;
-
-/**
- * Business logic for pagination; given a total number of pages
- * and the selected page, returns attributes used to render pagination
- *
- * @param {Number} totalPages
- * @param {Number} selectedPage
- * @returns {Object} attributes used to render pagination
- */
-export const _getAttributes = (
-  totalPages,
-  selectedPage,
-  segmentSize = MAX_VISIBLE_PAGES
-) => {
-  // create a list of page segments
-  // each segment is an array of page numbers.
-  const pageSegments = [...new Array(totalPages)]
-    .map((p, i) => i + 1) // [1,2,3,4,5,6,7, ...]
-    .reduce((segments, page, i) => {
-      const segmentIndex = Math.floor(i / segmentSize);
-      if (!segments[segmentIndex]) {
-        segments[segmentIndex] = [];
-      }
-      segments[segmentIndex].push(page);
-      return segments;
-    }, []); // [[1,2,3,4,5], [6,7,8,9,10], ...]
-
-  // Show the segment that has the selected page.
-  // If out of bounds, default to first segment
-  const visiblePages =
-    pageSegments.filter((segment) => segment.includes(selectedPage))[0] ||
-    pageSegments[0];
-  const selectedIndex = visiblePages.indexOf(selectedPage);
-
-  // show prev/next arrows unless we are in the first or last segment
-  const showPrev = !visiblePages.includes(1);
-  const showNext = !visiblePages.includes(totalPages);
-
-  // only populate first/last pages when they are outside the visible segment
-  const firstPage = !visiblePages.includes(1) && 1;
-  const lastPage = !visiblePages.includes(totalPages) && totalPages;
-
-  return {
-    visiblePages,
-    selectedIndex: selectedIndex >= 0 ? selectedIndex : 0,
-    firstPage,
-    lastPage,
-    showPrev,
-    showNext,
-  };
-};
 
 /**
  * Component that allows users to navigate between pages of information.
@@ -75,54 +24,47 @@ const Pagination = ({
   testId,
 }) => {
   const isControlled = selectedPageControlled !== undefined;
-  const [selectedPage, setSelectedPage] = useState(defaultSelectedPage);
-  const [paginationAttributes, setPaginationAttributes] = useState(
-    _getAttributes(totalPages, selectedPage)
-  );
+  const [selectedPageInternal, setSelectedPageInternal] =
+    useState(defaultSelectedPage);
 
-  useEffect(() => {
-    const isOutOfBounds = totalPages < selectedPageControlled;
-    if (isControlled) {
-      setSelectedPage(isOutOfBounds ? 1 : selectedPageControlled);
-      setPaginationAttributes(
-        _getAttributes(totalPages, selectedPageControlled)
-      );
-    } else {
-      setPaginationAttributes(_getAttributes(totalPages, selectedPage));
-    }
-  }, [totalPages, selectedPageControlled, selectedPage]);
+  const selectedPage = isControlled
+    ? selectedPageControlled
+    : selectedPageInternal;
 
   const {
     visiblePages,
     selectedIndex,
     showPrev,
     showNext,
-    firstPage,
-    lastPage,
-  } = paginationAttributes;
+    showFirstPage,
+    showLastPage,
+  } = usePagination({
+    totalPages,
+    selectedPageNumber: selectedPage,
+  });
 
   const handlePageClick = ({ target }) => {
-    const page = parseInt(target.dataset.page, 10);
+    const targetPage = parseInt(target.dataset.page, 10);
     if (!isControlled) {
-      setSelectedPage(page);
+      setSelectedPageInternal(targetPage);
     }
-    onPageChange(page);
+    onPageChange(targetPage);
   };
 
   const handlePrevClick = () => {
-    const newSelectedPage = selectedPage - 1;
+    const previousPage = selectedPage - 1;
     if (!isControlled) {
-      setSelectedPage(newSelectedPage);
+      setSelectedPageInternal(previousPage);
     }
-    onPageChange(newSelectedPage);
+    onPageChange(previousPage);
   };
 
   const handleNextClick = () => {
-    const newSelectedPage = selectedPage + 1;
+    const nextPage = selectedPage + 1;
     if (!isControlled) {
-      setSelectedPage(newSelectedPage);
+      setSelectedPageInternal(nextPage);
     }
-    onPageChange(newSelectedPage);
+    onPageChange(nextPage);
   };
 
   const pagination = (
@@ -153,7 +95,7 @@ const Pagination = ({
             </span>
           </Row.Item>
 
-          {firstPage && (
+          {showFirstPage && (
             <Row.Item as="li" shrink>
               <span
                 role="button"
@@ -165,14 +107,14 @@ const Pagination = ({
                     handlePageClick(e);
                   }
                 }}
-                data-page={firstPage}
+                data-page={1}
                 className="nds-pagination-page"
               >
-                {firstPage.toString()}
+                1
               </span>
             </Row.Item>
           )}
-          {firstPage && (
+          {showFirstPage && (
             <Row.Item as="li" shrink>
               <div className="nds-pagination-ellipsis">&hellip;</div>
             </Row.Item>
@@ -204,12 +146,12 @@ const Pagination = ({
             </Row.Item>
           ))}
 
-          {lastPage && (
+          {showLastPage && (
             <Row.Item as="li" shrink>
               <div className="nds-pagination-ellipsis">&hellip;</div>
             </Row.Item>
           )}
-          {lastPage && (
+          {showLastPage && (
             <Row.Item as="li" shrink>
               <span
                 role="button"
@@ -221,10 +163,10 @@ const Pagination = ({
                     handlePageClick(e);
                   }
                 }}
-                data-page={lastPage}
+                data-page={totalPages}
                 className="nds-pagination-page"
               >
-                {lastPage.toString()}
+                {totalPages.toString()}
               </span>
             </Row.Item>
           )}

--- a/src/Pagination/index.scss
+++ b/src/Pagination/index.scss
@@ -1,5 +1,4 @@
 .nds-pagination {
-  --page-min-size: 1.5em;
   color: var(--theme-primary);
   display: flex;
   justify-content: center;
@@ -33,9 +32,9 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  height: var(--page-min-size);
-  min-width: var(--page-min-size);
-  border-radius: var(--page-min-size);
+  height: rem(28px);
+  min-width: rem(28px);
+  border-radius: rem(28px);
   padding: 0 var(--space-xs);
 }
 

--- a/src/Pagination/index.scss
+++ b/src/Pagination/index.scss
@@ -18,7 +18,7 @@
     grid-auto-flow: column;
     justify-items: center;
     align-items: center;
-    gap: var(--space-xxs);
+    gap: rem(4px);
 
     // Every column should be the same width as the widest item to prevent
     // UX shifting when paging between single, double, tripple, (or more)

--- a/src/Pagination/index.scss
+++ b/src/Pagination/index.scss
@@ -1,17 +1,29 @@
 .nds-pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  --page-min-size: 1.5em;
   color: var(--theme-primary);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  ul {
-    list-style-type: none;
-  }
   ul,
   li {
     text-indent: 0;
     margin: 0;
     padding: 0;
+  }
+
+  ul {
+    list-style-type: none;
+    display: grid;
+    grid-auto-flow: column;
+    justify-items: center;
+    align-items: center;
+    gap: var(--space-xxs);
+
+    // Every column should be the same width as the widest item to prevent
+    // UX shifting when paging between single, double, tripple, (or more)
+    grid-auto-columns: 1fr;
+    width: max-content;
   }
 }
 
@@ -21,9 +33,9 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  height: rem(28px);
-  min-width: rem(28px);
-  border-radius: rem(28px);
+  height: var(--page-min-size);
+  min-width: var(--page-min-size);
+  border-radius: var(--page-min-size);
   padding: 0 var(--space-xs);
 }
 

--- a/src/Pagination/index.test.js
+++ b/src/Pagination/index.test.js
@@ -1,64 +1,10 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import Pagination, { _getAttributes } from "./";
+import Pagination from "./";
 
 const CLASS_SELECTED = "nds-pagination-page--selected";
 
 describe("Pagination", () => {
-  describe("getAttributes", () => {
-    it("shows pages 1-5 for 5 total pages", () => {
-      const { visiblePages } = _getAttributes(5);
-      expect(visiblePages).toEqual([1, 2, 3, 4, 5]);
-    });
-
-    it("shows pages 6-10 when 8 of 10 is selected", () => {
-      const { visiblePages } = _getAttributes(10, 8);
-      expect(visiblePages).toEqual([6, 7, 8, 9, 10]);
-    });
-
-    it("does NOT show previous arrow when rendering first 5 pages", () => {
-      const { showPrev } = _getAttributes(10);
-      expect(showPrev).toBeFalsy();
-    });
-
-    it("shows previous arrow when page 6 or above is selected", () => {
-      const { showPrev } = _getAttributes(10, 6);
-      expect(showPrev).toBeTruthy();
-    });
-
-    it("shows next arrow when total is higher than highest visible page", () => {
-      const { showNext } = _getAttributes(10, 1);
-      expect(showNext).toBeTruthy();
-    });
-
-    it("does NOT show next arrow when last page is visible", () => {
-      const { showNext } = _getAttributes(10, 9);
-      expect(showNext).toBeFalsy();
-    });
-
-    it("shows last page when 2 is selected of 20", () => {
-      const total = 20;
-      const { lastPage } = _getAttributes(total, 2);
-      expect(lastPage).toBe(total);
-    });
-
-    it("does NOT show last page when 18 is selected of 20", () => {
-      const total = 20;
-      const { lastPage } = _getAttributes(total, 18);
-      expect(lastPage).toBeFalsy();
-    });
-
-    it("shows first page when 8 is selected of 20", () => {
-      const { firstPage } = _getAttributes(20, 8);
-      expect(firstPage).toBe(1);
-    });
-
-    it("does NOT show first page when 4 is selected of 20", () => {
-      const { firstPage } = _getAttributes(20, 4);
-      expect(firstPage).toBeFalsy();
-    });
-  });
-
   describe("Component render and interaction", () => {
     it("does not render pagination when totalPages is 1", () => {
       render(<Pagination totalPages={1} />);
@@ -101,7 +47,7 @@ describe("Pagination", () => {
           totalPages={20}
           onPageChange={handlePageChange}
           defaultSelectedPage={10}
-        />
+        />,
       );
       const prev = screen.getByLabelText("Previous page");
       const page9 = screen.getByLabelText("Page 9");
@@ -122,7 +68,7 @@ describe("Pagination", () => {
           totalPages={20}
           onPageChange={handlePageChange}
           defaultSelectedPage={10}
-        />
+        />,
       );
       const first = screen.getByLabelText("First page");
 
@@ -145,7 +91,7 @@ describe("Pagination", () => {
           totalPages={total}
           onPageChange={handlePageChange}
           defaultSelectedPage={4}
-        />
+        />,
       );
       const last = screen.getByLabelText("Last page");
 

--- a/src/Pagination/usePagination.test.ts
+++ b/src/Pagination/usePagination.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react";
+import { usePagination } from "./usePagination";
+
+describe("usePagination", () => {
+  describe("visible pages", () => {
+    it("shows all pages when they fit in window", () => {
+      const { result } = renderHook(() => usePagination({ totalPages: 5 }));
+      expect(result.current.visiblePages).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("centers selected page when possible", () => {
+      const { result } = renderHook(() =>
+        usePagination({ totalPages: 10, selectedPageNumber: 6 }),
+      );
+      expect(result.current.visiblePages).toEqual([5, 6, 7]);
+      expect(result.current.selectedIndex).toBe(1);
+    });
+
+    it("respects custom window size", () => {
+      const { result } = renderHook(() =>
+        usePagination({
+          totalPages: 10,
+          selectedPageNumber: 5,
+          windowSize: 3,
+        }),
+      );
+      expect(result.current.visiblePages).toEqual([5]);
+      expect(result.current.selectedIndex).toBe(0);
+    });
+  });
+
+  describe("navigation controls", () => {
+    it("shows/hides prev/next arrows correctly", () => {
+      const { result: firstPage } = renderHook(() =>
+        usePagination({ totalPages: 10, selectedPageNumber: 1 }),
+      );
+      expect(firstPage.current.showPrev).toBe(false);
+      expect(firstPage.current.showNext).toBe(true);
+
+      const { result: lastPage } = renderHook(() =>
+        usePagination({ totalPages: 10, selectedPageNumber: 10 }),
+      );
+      expect(lastPage.current.showPrev).toBe(true);
+      expect(lastPage.current.showNext).toBe(false);
+    });
+
+    it("shows first/last page buttons when needed", () => {
+      const { result } = renderHook(() =>
+        usePagination({ totalPages: 20, selectedPageNumber: 10 }),
+      );
+      expect(result.current.showFirstPage).toBe(true);
+      expect(result.current.showLastPage).toBe(true);
+      expect(result.current.visiblePages.includes(1)).toBe(false);
+      expect(result.current.visiblePages.includes(20)).toBe(false);
+    });
+
+    it("hides first/last buttons when all pages visible", () => {
+      const { result } = renderHook(() =>
+        usePagination({ totalPages: 5, selectedPageNumber: 3 }),
+      );
+      expect(result.current.showFirstPage).toBe(false);
+      expect(result.current.showLastPage).toBe(false);
+    });
+  });
+
+  describe("ellipsis adjustment", () => {
+    it("reduces window size for ellipsis space", () => {
+      const { result } = renderHook(() =>
+        usePagination({
+          totalPages: 20,
+          selectedPageNumber: 10,
+          windowSize: 5,
+        }),
+      );
+      expect(result.current.visiblePages).toHaveLength(3);
+      expect(result.current.visiblePages).toEqual([9, 10, 11]);
+    });
+  });
+});

--- a/src/Pagination/usePagination.test.ts
+++ b/src/Pagination/usePagination.test.ts
@@ -8,6 +8,13 @@ describe("usePagination", () => {
       expect(result.current.visiblePages).toEqual([1, 2, 3, 4, 5]);
     });
 
+    it("shows all pages when there's only one extra page to avoid ellipsis", () => {
+      const { result } = renderHook(() => usePagination({ totalPages: 6 }));
+      expect(result.current.visiblePages).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(result.current.showFirstPage).toBe(false);
+      expect(result.current.showLastPage).toBe(false);
+    });
+
     it("centers selected page when possible", () => {
       const { result } = renderHook(() =>
         usePagination({ totalPages: 10, selectedPageNumber: 6 }),

--- a/src/Pagination/usePagination.test.ts
+++ b/src/Pagination/usePagination.test.ts
@@ -63,7 +63,7 @@ describe("usePagination", () => {
     });
   });
 
-  describe("ellipsis adjustment", () => {
+  describe("adjusts ellipsis", () => {
     it("reduces window size for ellipsis space", () => {
       const { result } = renderHook(() =>
         usePagination({
@@ -74,6 +74,30 @@ describe("usePagination", () => {
       );
       expect(result.current.visiblePages).toHaveLength(3);
       expect(result.current.visiblePages).toEqual([9, 10, 11]);
+    });
+
+    it("does NOT adjust window size when first page is in visible range", () => {
+      const { result } = renderHook(() =>
+        usePagination({
+          totalPages: 20,
+          selectedPageNumber: 1,
+          windowSize: 5,
+        }),
+      );
+      expect(result.current.visiblePages).toHaveLength(5);
+      expect(result.current.visiblePages).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("does NOT adjust window size when last page is in visible range", () => {
+      const { result } = renderHook(() =>
+        usePagination({
+          totalPages: 20,
+          selectedPageNumber: 20,
+          windowSize: 5,
+        }),
+      );
+      expect(result.current.visiblePages).toHaveLength(5);
+      expect(result.current.visiblePages).toEqual([16, 17, 18, 19, 20]);
     });
   });
 });

--- a/src/Pagination/usePagination.ts
+++ b/src/Pagination/usePagination.ts
@@ -1,0 +1,101 @@
+const MAX_VISIBLE_PAGES = 5;
+
+interface UsePaginationOptions {
+  /** The total number of pages */
+  totalPages: number;
+  /** The selected page by page number */
+  selectedPageNumber?: number;
+  /** The size of the visible window of pages */
+  windowSize?: number;
+}
+
+type UsePaginationResult = {
+  /** List of visible pages by page number */
+  visiblePages: number[];
+  /** The page number of the currently selected page */
+  selectedPage: number;
+  /** The index of the currently selected page */
+  selectedIndex: number;
+  /** Whether to show the first page button */
+  showFirstPage: boolean;
+  /** Whether to show the last page button */
+  showLastPage: boolean;
+  /** Whether to show previous arrow */
+  showPrev: boolean;
+  /** Whether to show next arrow */
+  showNext: boolean;
+};
+
+/**
+ * Create an array of consecutive numbers from start to end (inclusive)
+ */
+export const range = (start: number, end: number): number[] =>
+  [...Array(end - start + 1)].map((_, i) => start + i);
+
+/**
+ * Calculate the sliding window of visible pages
+ */
+export const calculateVisiblePages = (
+  totalPages: number,
+  selectedPage: number,
+  windowSize: number,
+): number[] => {
+  // If all pages fit in the window, show them all
+  if (totalPages <= windowSize) {
+    return range(1, totalPages);
+  }
+
+  // Reserve space for first/last page buttons when ellipsis are needed
+  const showFirst = selectedPage > Math.ceil(windowSize / 2);
+  const showLast = selectedPage <= totalPages - Math.floor(windowSize / 2);
+  const ellipsisCount = [showFirst, showLast].filter(Boolean).length;
+  const effectiveSize = Math.max(1, windowSize - ellipsisCount);
+  const halfWindow = Math.floor(effectiveSize / 2);
+
+  // Calculate the centered window
+  let start = selectedPage - halfWindow;
+  let end = start + effectiveSize - 1;
+
+  // Adjust bounds to stay within valid page range
+  if (start < 1) {
+    start = 1;
+    end = effectiveSize;
+  } else if (end > totalPages) {
+    end = totalPages;
+    start = totalPages - effectiveSize + 1;
+  }
+
+  return range(start, end);
+};
+
+/**
+ * Headless hook for pagination attributes.
+ * Creates a sliding window of visible pages with current selection centered.
+ */
+export const usePagination = ({
+  totalPages,
+  selectedPageNumber = 1,
+  windowSize = MAX_VISIBLE_PAGES,
+}: UsePaginationOptions): UsePaginationResult => {
+  const normalizedTotalPages = Math.max(1, totalPages);
+  const normalizedSelectedPage = Math.max(
+    1,
+    Math.min(selectedPageNumber, normalizedTotalPages),
+  );
+
+  const visiblePages = calculateVisiblePages(
+    normalizedTotalPages,
+    normalizedSelectedPage,
+    windowSize,
+  );
+
+  return {
+    visiblePages,
+    selectedPage: normalizedSelectedPage,
+    selectedIndex: visiblePages.indexOf(normalizedSelectedPage),
+    showFirstPage: visiblePages[0] > 1,
+    showLastPage: visiblePages[visiblePages.length - 1] < normalizedTotalPages,
+    showPrev: normalizedSelectedPage > 1,
+    showNext: normalizedSelectedPage < normalizedTotalPages,
+  };
+};

--- a/src/Pagination/usePagination.ts
+++ b/src/Pagination/usePagination.ts
@@ -40,8 +40,9 @@ export const calculateVisiblePages = (
   selectedPage: number,
   windowSize: number,
 ): number[] => {
-  // If all pages fit in the window, show them all
-  if (totalPages <= windowSize) {
+  // If all pages fit in the window, or there's only one extra page,
+  // show them all to avoid unnecessary ellipsis
+  if (totalPages <= windowSize + 1) {
     return range(1, totalPages);
   }
 

--- a/src/Pagination/usePagination.ts
+++ b/src/Pagination/usePagination.ts
@@ -49,7 +49,7 @@ export const calculateVisiblePages = (
   const showFirst = selectedPage > Math.ceil(windowSize / 2);
   const showLast = selectedPage <= totalPages - Math.floor(windowSize / 2);
   const ellipsisCount = [showFirst, showLast].filter(Boolean).length;
-  const effectiveSize = Math.max(1, windowSize - ellipsisCount);
+  const effectiveSize = ellipsisCount === 2 ? windowSize - 2 : windowSize;
   const halfWindow = Math.floor(effectiveSize / 2);
 
   // Calculate the centered window

--- a/src/Pagination/usePagination.ts
+++ b/src/Pagination/usePagination.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 const MAX_VISIBLE_PAGES = 5;
 
 interface UsePaginationOptions {
@@ -84,10 +86,14 @@ export const usePagination = ({
     Math.min(selectedPageNumber, normalizedTotalPages),
   );
 
-  const visiblePages = calculateVisiblePages(
-    normalizedTotalPages,
-    normalizedSelectedPage,
-    windowSize,
+  const visiblePages = useMemo(
+    () =>
+      calculateVisiblePages(
+        normalizedTotalPages,
+        normalizedSelectedPage,
+        windowSize,
+      ),
+    [normalizedTotalPages, normalizedSelectedPage, windowSize],
   );
 
   return {


### PR DESCRIPTION
Closes NDS-1768

Refactor core pagination logic into a react hook; uses a more standard UX behavior matching this example: <https://atlassian.design/components/pagination/examples>

- Remove `_getAttributes` helper function
- Add `usePagination` to calculate attributes needed for rendering
- Add tests for `usePagination`

### Why not use an existing hook?
There aren't many libraries that expose pagination logic in a convenient hook, and most of them manage the `onPageChange` responsibility. It was frankly easier to roll my own using material and atlassian as implementation references.

### Anatomy of `Pagination`
These are the parts that usePagination is managing...

**Red:** the "sliding window" aka `visiblePages`
**Blue:** the ellipsis that appear when the first or last page is outside the visible window respectively
**Lime:** first and last pages
**Purple:** next/prev buttons
<img width="682" height="92" alt="Screenshot 2025-08-25 at 6 56 39 PM" src="https://github.com/user-attachments/assets/9fac0a48-d088-4d01-9c15-842bdfaaf139" />

### Preview build (updated 9/3)
[View Storybook preview](https://60620d422ffdf100216415b2-vbhgdbdyih.chromatic.com/)
