### PR TITLE
feat(Select,Combobox): add clearSelectionOnAction prop

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -145,6 +145,7 @@ const Combobox = ({
   filterItemsByInput = defaultFilterItemsByInput,
   children,
   disableFiltering = false,
+  clearSelectionOnAction = false,
   errorText,
   icon,
   testId,
@@ -236,8 +237,10 @@ const Combobox = ({
         newSelectedItem.props.onSelect();
         return {
           ...changes,
-          selectedItem: previousSelectedItem,
-          inputValue: itemToString(previousSelectedItem),
+          selectedItem: clearSelectionOnAction ? null : previousSelectedItem,
+          inputValue: clearSelectionOnAction
+            ? ""
+            : itemToString(previousSelectedItem),
           isOpen: false,
         };
       }
@@ -485,6 +488,10 @@ Combobox.propTypes = {
    * as the user types.
    */
   disableFiltering: PropTypes.bool,
+  /**
+   * When `true`, selecting an action will clear any existing selection.
+   */
+  clearSelectionOnAction: PropTypes.bool,
   /**
    * Optionally pass a function to customize filtering behavior
    *

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -287,6 +287,35 @@ export const WithActions = () => {
   );
 };
 
+export const ClearingSelctionWithAction = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  return (
+    <>
+      <Combobox
+        label="Select Account"
+        inputValue={inputValue}
+        onInputChange={(val) => setInputValue(val)}
+        clearSelectionOnAction={true}
+      >
+        <Combobox.Item value="Primary Checking - 4567" />
+        <Combobox.Item value="Cheese Fund - 5432" />
+        <Combobox.Item value="Primary Savings - 1234" />
+        <Combobox.Item value="Secondary Checking - 7892" />
+        <Combobox.Action
+          onSelect={() => {
+            setIsOpen(true);
+          }}
+          label="Do Action"
+        />
+      </Combobox>
+      <Drawer isOpen={isOpen} onUserDismiss={() => setIsOpen(false)}>
+        <div className="padding--y--s">🎬 Action!</div>
+      </Drawer>
+    </>
+  );
+};
+
 export default {
   title: "Components/Combobox",
   component: Combobox,
@@ -297,60 +326,59 @@ export default {
 };
 
 export const WithCategoriesInForm = () => {
-
   const [inputValue, setInputValue] = useState("");
-  const [selectedValue, setSelectedValue] = useState("")
+  const [selectedValue, setSelectedValue] = useState("");
 
   return (
     <>
-    <div>selected value {selectedValue}</div>
-    <Combobox
-      label="Select item"
-      inputValue={inputValue}
-      onChange={(selected) => {
-        setSelectedValue(selected)
-      }}
-      filterItemsByInput={(items, inputVal) => {
-        return items.filter((item) => {
-          if (!item) return false;
-          const query = (item.props.searchValue || item.props.value).toLowerCase();
-          return query.includes(inputVal);
-        })
-      }}
-      onInputChange={(selected) => {
-        setInputValue(selected);
-      }}
-    >
-      <Combobox.Category label="Checking">
-        <Combobox.Item searchValue="Business Checking" value="checking1">
-          Business Checking - 11234
-        </Combobox.Item>
-        <Combobox.Item searchValue="Main Checking" value="checking2">
-          Main Checking - 13989
-        </Combobox.Item>
-        <Combobox.Item searchValue="Joint Checking" value="checking3">
-          Joint Checking - 14857
-        </Combobox.Item>
-      </Combobox.Category>
-      <Combobox.Category label="Savings">
-        <Combobox.Item searchValue="Business Checking" value="savings1">
-          Business Savings - 13938
-        </Combobox.Item>
-        <Combobox.Item searchValue="Main Savings" value="savings2">
-          Main Savings - 48274
-        </Combobox.Item>
-        <Combobox.Item searchValue="Joint Savings" value="savings3">
-          Joint Savings - 48284
-        </Combobox.Item>
-      </Combobox.Category>
-      <Combobox.Category label="External Accounts">
-        <Combobox.Item value="Sasha">Sasha - 84839</Combobox.Item>
-        <Combobox.Item value="Joan">Joan - 36183</Combobox.Item>
-        <Combobox.Item value="Benoit">Benoit - 53261</Combobox.Item>
-      </Combobox.Category>
-
-    </Combobox>
+      <div>selected value {selectedValue}</div>
+      <Combobox
+        label="Select item"
+        inputValue={inputValue}
+        onChange={(selected) => {
+          setSelectedValue(selected);
+        }}
+        filterItemsByInput={(items, inputVal) => {
+          return items.filter((item) => {
+            if (!item) return false;
+            const query = (
+              item.props.searchValue || item.props.value
+            ).toLowerCase();
+            return query.includes(inputVal);
+          });
+        }}
+        onInputChange={(selected) => {
+          setInputValue(selected);
+        }}
+      >
+        <Combobox.Category label="Checking">
+          <Combobox.Item searchValue="Business Checking" value="checking1">
+            Business Checking - 11234
+          </Combobox.Item>
+          <Combobox.Item searchValue="Main Checking" value="checking2">
+            Main Checking - 13989
+          </Combobox.Item>
+          <Combobox.Item searchValue="Joint Checking" value="checking3">
+            Joint Checking - 14857
+          </Combobox.Item>
+        </Combobox.Category>
+        <Combobox.Category label="Savings">
+          <Combobox.Item searchValue="Business Checking" value="savings1">
+            Business Savings - 13938
+          </Combobox.Item>
+          <Combobox.Item searchValue="Main Savings" value="savings2">
+            Main Savings - 48274
+          </Combobox.Item>
+          <Combobox.Item searchValue="Joint Savings" value="savings3">
+            Joint Savings - 48284
+          </Combobox.Item>
+        </Combobox.Category>
+        <Combobox.Category label="External Accounts">
+          <Combobox.Item value="Sasha">Sasha - 84839</Combobox.Item>
+          <Combobox.Item value="Joan">Joan - 36183</Combobox.Item>
+          <Combobox.Item value="Benoit">Benoit - 53261</Combobox.Item>
+        </Combobox.Category>
+      </Combobox>
     </>
-  )
-
+  );
 };

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -126,6 +126,7 @@ const Select = ({
   defaultOpen = false,
   disabled = false,
   getTypeaheadString = defaultGetTypeAheadString,
+  clearSelectionOnAction = false,
   errorText,
   testId,
 }) => {
@@ -165,10 +166,8 @@ const Select = ({
     initialIsOpen: defaultOpen,
     itemToString: (item) => getTypeaheadString(userInput, item),
     onSelectedItemChange: ({ selectedItem }) => {
-      // for Select.Action items, we only fire the side effect
-      if (isAction(selectedItem)) {
-        selectedItem.props.onSelect();
-      } else {
+      // Actions are handled in the state reducer, so this only handles regular items
+      if (selectedItem && !isAction(selectedItem)) {
         onChange(selectedItem.props ? selectedItem.props.value : "");
       }
     },
@@ -178,6 +177,8 @@ const Select = ({
     // <https://www.downshift-js.com/use-select#state-reducer>
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;
+      const { selectedItem: previousSelectedItem } = state;
+      const { selectedItem: newSelectedItem } = changes;
       let isOpen = changes.isOpen;
 
       if (type === useSelect.stateChangeTypes.ToggleButtonKeyDownCharacter) {
@@ -186,6 +187,19 @@ const Select = ({
         isOpen = true;
       } else {
         setUserInput(""); // reset input after any other event
+      }
+
+      // When an action is selected, execute it and handle clearing if needed
+      if (isAction(newSelectedItem)) {
+        newSelectedItem.props.onSelect();
+        if (clearSelectionOnAction) {
+          onChange(""); // allows controlled 'value' to be cleared
+        }
+        return {
+          ...changes,
+          selectedItem: clearSelectionOnAction ? null : previousSelectedItem,
+          isOpen: false,
+        };
       }
 
       return {
@@ -396,6 +410,10 @@ Select.propTypes = {
    * See "Changing Typeahead Behavior" story for example.
    */
   getTypeaheadString: PropTypes.func,
+  /**
+   * When `true`, selecting an action will clear any existing selection.
+   */
+  clearSelectionOnAction: PropTypes.bool,
   /**
    * Use to set a default selection by passing the `value` prop
    * of one of the `<Select.Item>` children.

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -85,6 +85,33 @@ WithAction.parameters = {
   },
 };
 
+export const ClearingSelctionWithAction = Template.bind({});
+ClearingSelctionWithAction.args = {
+  label: "Account",
+  id: "account-field",
+  clearSelectionOnAction: true,
+  children: [
+    ...children,
+    <Select.Action
+      onSelect={() => {
+        alert("side effect triggered");
+      }}
+    >
+      <span className="fontColor--pine fontWeight--bold">
+        <span className="narmi-icon-plus padding--right--xs" /> Add new icon
+      </span>
+    </Select.Action>,
+  ],
+};
+WithAction.parameters = {
+  docs: {
+    description: {
+      story:
+        "Use `clearSelectionOnAction` to clear any existing selection when any action is selected.",
+    },
+  },
+};
+
 export const WithCategories = Template.bind({});
 WithCategories.args = {
   id: "withCategories",


### PR DESCRIPTION
Relates to: https://linear.app/narmi/issue/BDB-1271/recipientselector-should-clear-input-when-selecting-add-new-recipient

Adds `clearSelectionOnAction` prop to `Combobox` and `Select`.

When `true`, the current selection will be cleared when the user selects any Action item in the dropdown.