### PR TITLE
fix(TableAutocomplete): allow input to grow to parent width

### DIFF
--- a/src/TableAutocomplete/index.scss
+++ b/src/TableAutocomplete/index.scss
@@ -1,7 +1,6 @@
 .nds-tableAutocomplete {
   position: relative;
-  display: inline-block;
-  width: 100%;
+  display: block;
 }
 
 .nds-tableAutocomplete-dropdown {

--- a/src/TableAutocomplete/index.tsx
+++ b/src/TableAutocomplete/index.tsx
@@ -150,7 +150,7 @@ const TableAutocomplete = ({
 
   return (
     <div className="nds-tableAutocomplete">
-      <div {...triggerProps} style={{ display: "inline-block" }}>
+      <div {...triggerProps}>
         <TableInput
           label={label}
           placeholder={!isDisabled ? placeholder : undefined}

--- a/src/TableInput/index.scss
+++ b/src/TableInput/index.scss
@@ -1,9 +1,16 @@
 /** TableInput */
 .nds-tableField-input {
   border-width: 0;
-  display: inline-flex;
   border-radius: rem(4px);
   padding: var(--space-xs);
+
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-columns: 1fr min-content; // [input       ] [counter]
+  gap: var(--space-xxs);
+
+  // Input box should take full width of the parent.
+  width: 100%;
 
   // The 1px of border should always be present, so the
   // input doesn't "bounce" the layout 2px on focus
@@ -22,20 +29,31 @@
     font-size: inherit;
     font-weight: inherit;
     text-rendering: geometricprecision;
+    background: transparent;
+    min-width: 0; // Allow input to shrink below its content width
     &::placeholder {
       font-style: italic;
       color: var(--font-color-secondary);
     }
   }
 
+  // Regardless of what rennders in the DOM, only show the
+  // counter when the input is focused
+  .nds-tableInput-counter {
+    visibility: hidden;
+  }
+  input:focus + .nds-tableInput-counter {
+    visibility: visible;
+  }
+
+  &:has(input:hover) {
+    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
+  }
+
   &:has(input:focus) {
     outline: none;
     border: 1px solid var(--theme-primary);
-    background: var(--color-white);
-  }
-  
-  &:has(input:hover) {
-    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
+    background: var(--color-white) !important;
   }
 
   &--hasError {

--- a/src/TableInput/index.tsx
+++ b/src/TableInput/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import cc from "classcat";
-import Row from "../Row";
 
 export interface TableInputProps {
   /** Current value of the input */
@@ -51,36 +50,30 @@ const TableInput = React.forwardRef<HTMLInputElement, TableInputProps>(
           },
         ])}
       >
-        <Row gapSize="xs" alignItems="center">
-          <Row.Item>
-            <input
-              ref={ref}
-              type="text"
-              aria-label={label}
-              value={value}
-              onChange={onChange}
-              placeholder={placeholder}
-              disabled={isDisabled}
-              aria-invalid={hasError}
-              {...other}
-            />
-          </Row.Item>
+        <input
+          ref={ref}
+          type="text"
+          aria-label={label}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          aria-invalid={hasError}
+          {...other}
+        />
+        <div
+          className={cc([
+            "nds-tableInput-counter",
+            "fontSize--s",
+            { "fontColor--error": hasError || hasCountError },
+          ])}
+        >
           {showCharacterCounter && (
-            <Row.Item shrink>
-              <div
-                className={cc([
-                  "nds-tableInput-counter",
-                  "fontSize--s",
-                  {
-                    "fontColor--error": hasError || hasCountError,
-                  },
-                ])}
-              >
-                {characterCount}/{maxLength}
-              </div>
-            </Row.Item>
+            <span>
+              {characterCount}/{maxLength}
+            </span>
           )}
-        </Row>
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
Closes NDS-1813

- Change `TableInput` layout to grid; allow whole field to fill parent width
- Hide counter when input isn't focused
- Fix bad `style` property in `TableAutocomplete` that was preventing 100% width