### PR TITLE
fix(MenuButton): limit height of popover to 60vh

### DIFF
--- a/src/MenuButton/index.scss
+++ b/src/MenuButton/index.scss
@@ -31,6 +31,8 @@
   background-color: var(--color-white);
   box-shadow: var(--elevation-high);
   outline: none;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .nds-menubutton-item {


### PR DESCRIPTION
Closes NDS-1794

Prevent very long lists of items from overflowing the viewport. This is an edge case, as when we show a lot of items, a `AutocompleteModal` is a more appropriate UX.