### PR TITLE
chore(gitignore): ignore .vscode file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 .DS_Store
 storybook-static
 build-storybook.log
+.vscode/
 
 # IntelliJ IDEA
 .idea


### PR DESCRIPTION
.vscode is a configuration file generated by vscode (obviously),  so we're fine to ignore it in version control.
