### PR TITLE
fix(Combobox,Select): write inline zindex

### DIFF
--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -83,7 +83,6 @@ $breakpoints: (
   border-radius: var(--border-radius-default);
   margin-top: var(--space-xxs) !important;
   margin-bottom: var(--space-xxs) !important;
-  z-index: 4;
 
   &:focus {
     outline: none;

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -89,8 +89,9 @@ const useDropdownLayer = ({
           }
         : polyFillLayerStyles),
 
-      // Always include visibility rule.
+      // Always include visibility and z-index rules.
       display: isOpen ? "block" : "none",
+      zIndex: 4,
     };
 
     return {


### PR DESCRIPTION
Closes NDS-1854

The `{...layerProps}`/"layer" element that `useDropdownLayer` is supposed to position must have a z-index.

I was relying on existing CSS to do this, but the element that _looks_ like a dropdown may not always be the same element that positions the dropdown. This change ensures the z-index responsibility is on the hook.