### PR TITLE
fix(Table.Row): Add border radius to `only-of-type` rows

### DIFF
--- a/src/Table/index.scss
+++ b/src/Table/index.scss
@@ -43,6 +43,9 @@
   &:last-of-type {
     border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
   }
+  &:only-of-type {
+    border-radius: var(--border-radius-default);
+  }
 
   // Clickable rows
   &--interactive:hover,


### PR DESCRIPTION
- [NDS-1839: Add radius to corners of table row](https://linear.app/narmi/issue/NDS-1839/add-radius-to-corners-of-table-row)

https://github.com/user-attachments/assets/95ab1608-2808-4c7e-bd96-4aa59e67906e

