### PR TITLE
Support `kind="rating"` in `Radio`

### DIFF
--- a/src/Radio/index.scss
+++ b/src/Radio/index.scss
@@ -141,3 +141,30 @@
     color: var(--theme-primary);
   }
 }
+
+// kind="rating"
+.nds-singleRadio--rating {
+  border: 1px solid var(--border-color-default);
+  color: var(--font-color-secondary);
+  border-radius: var(--border-radius-s);
+  width: rem(32px);
+  height: rem(32px);
+  display: flex;
+  align-items: center;
+  text-align: center;
+
+  &:hover,
+  &:focus-within {
+    background-color: rgba(var(--theme-rgb-primary), var(--alpha-10));
+  }
+
+  &:focus-within {
+    outline: 3px solid RGBA(var(--theme-rgb-primary), var(--alpha-10));
+  }
+
+  &:has(input:checked) {
+    background-color: rgba(var(--theme-rgb-primary), var(--alpha-10));
+    border-color: var(--theme-primary);
+    color: var(--theme-primary);
+  }
+}

--- a/src/Radio/index.stories.js
+++ b/src/Radio/index.stories.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React, { useState } from "react";
 import Radio from "./";
+import Row from "../Row";
 
 const Template = (args) => <Radio {...args} />;
 
@@ -166,6 +167,24 @@ AsCheckmark.parameters = {
         "Checkmark variant displays with a simple checkmark icon that appears on hover and selection. The layout is reversed with the checkmark on the right side.",
     },
   },
+};
+
+export const AsRating = () => {
+  return (
+    <Row gapSize="xs">
+      {[...Array(10)].map((_, index) => (
+        <Row.Item key={index} shrink>
+          <Radio
+            name="rating-demo"
+            value={(index + 1).toString()}
+            kind="rating"
+          >
+            {index + 1}
+          </Radio>
+        </Row.Item>
+      ))}
+    </Row>
+  );
 };
 
 export const ErrorStates = () => {

--- a/src/Radio/index.tsx
+++ b/src/Radio/index.tsx
@@ -5,7 +5,12 @@ import Error from "../Error";
 
 const noop = () => {};
 
-export type RadioKind = "normal" | "card" | "input-card" | "checkmark";
+export type RadioKind =
+  | "normal"
+  | "card"
+  | "input-card"
+  | "checkmark"
+  | "rating";
 
 interface RadioProps {
   /** The `name` attribute for radio input. Use this to group radio sets. */
@@ -51,6 +56,7 @@ const Radio = ({
   const isCardKind = kind === "card";
   const isInputCardKind = kind === "input-card";
   const isCheckmarkKind = kind === "checkmark";
+  const isRatingKind = kind === "rating";
   const inputId = `${name}-${value}`;
 
   const handleChange = ({ target }) => {
@@ -94,7 +100,7 @@ const Radio = ({
         ])}
         htmlFor={inputId}
       >
-        <Row gapSize="s">
+        <Row gapSize={isRatingKind ? "none" : "s"}>
           {isCardKind && <Row.Item>{children}</Row.Item>}
           <Row.Item shrink>
             {inputElement}


### PR DESCRIPTION


Closes NDS-1873

Adds a new variant to `Radio` to display each option as a rating button. Consumers are responsible for layout of the buttons, which may be composed with `Row`.

### Focus, hover, and selection states
<img width="425" height="60" alt="Screenshot 2025-10-01 at 6 58 04 PM" src="https://github.com/user-attachments/assets/61f35900-0463-4d59-a6dd-475da7b3e95c" />
<img width="420" height="80" alt="Screenshot 2025-10-01 at 6 58 01 PM" src="https://github.com/user-attachments/assets/d5007a13-024c-4b28-8511-c70ab7ea3491" />


### Preview
https://60620d422ffdf100216415b2-nzvcjkizgf.chromatic.com/iframe.html?globals=&args=&id=components-radio--as-rating&viewMode=story
