### PR TITLE
docs(ContentCard): add figma connect

### DIFF
--- a/src/ContentCard/index.figma.tsx
+++ b/src/ContentCard/index.figma.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ContentCard from "./index";
+import figma from "@figma/code-connect";
+
+figma.connect(
+  ContentCard,
+  "https://www.figma.com/design/nCjdO761StnkwNZHFmcrUu/Narmi-Design-System-v2?node-id=951-4727&m=dev",
+  {
+    props: {
+      children: figma.children("*"),
+    },
+    example: ({ children }) => <ContentCard>{children}</ContentCard>,
+  },
+);


### PR DESCRIPTION
Relates to NDS-2019

Needs design help - the `Card` symbol in the figma file isn't being recognized as a component. In draft until we solve that.