### PR TITLE
feat(Dialog): update visual display to match figma NDSv2

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -9,3 +9,17 @@ class MockResizeObserver {
 window.ResizeObserver = MockResizeObserver;
 
 window.HTMLElement.prototype.scroll = function () {};
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/src/Dialog/index.scss
+++ b/src/Dialog/index.scss
@@ -1,7 +1,3 @@
-.nds-dialog {
-  --overflow-gradient-height: 20px;
-}
-
 .nds-dialog-root {
   position: fixed;
   inset: 0;
@@ -71,15 +67,15 @@
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  border-top-right-radius: var(--border-radius-m);
-  border-top-left-radius: var(--border-radius-m);
+  border-top-right-radius: var(--border-radius-default);
+  border-top-left-radius: var(--border-radius-default);
 
   max-height: 96%; // relative to parent, .nds-dialog-focuslock
   min-width: 100dvw;
 
   // for tablet or larger, display the modal dialog as a floating box.
   @include atMediaUp("s", $includeHeight: true) {
-    border-radius: var(--border-radius-m);
+    border-radius: var(--border-radius-default);
     max-height: 80vh; // prevent modal from being taller than the shim content box
     min-width: 240px; // should be no narrower than this on larger viewports
     width: var(--dialog-preferred-width);
@@ -88,12 +84,10 @@
 
 .nds-dialog-header {
   background-color: var(--bgColor-cloudGrey);
-  border-radius: var(--border-radius-default) var(--border-radius-default) 0 0;
-  padding: var(--space-s);
+  padding-inline: var(--space-m);
+  padding-block: var(--space-s);
 
   h4 {
-    margin: 0;
-    padding: 0;
     font-family: var(--font-family-default);
     font-size: var(--font-size-default);
     color: var(--font-color-heading);
@@ -102,49 +96,55 @@
 
   @include atMediaUp("s", $includeHeight: true) {
     background-color: var(--color-white);
-    margin: 0 var(--space-xl);
-    padding-top: var(--space-xl);
-    padding-bottom: var(--space-xxs);
-    border-radius: 0;
-    padding-left: 0;
-    padding-right: 0;
+    padding-inline: unset;
+    padding-block: unset;
+    margin-inline: var(--space-l);
+    margin-top: var(--space-l);
+    border-bottom: 1px solid var(--border-color-default);
 
     h4 {
-      font-size: var(--font-size-xl);
-      font-weight: var(--font-weight-bold);
+      font-size: var(--font-size-l);
+      font-weight: var(--font-weight-semibold);
+      margin-bottom: var(--space-l);
     }
-  }
-}
-
-.nds-dialog-header--bordered {
-  @include atMediaUp("s", $includeHeight: true) {
-    border-bottom: var(--border-size-m) solid var(--theme-primary);
   }
 }
 
 .nds-dialog-header--banner {
   background-color: var(--theme-primary);
-  color: white;
-  margin: 0 0;
-  padding: 0 var(--space-s) 0 var(--space-s);
+
+  h4,
+  .nds-dialog-closeButton {
+    color: var(--color-white) !important;
+  }
+
+  h4 {
+    margin-bottom: unset;
+  }
+
   @include atMediaUp("s", $includeHeight: true) {
-    border-radius: var(--border-radius-m) var(--border-radius-m) 0 0;
+    margin: 0;
+    padding-inline: var(--space-l);
+    padding-block: var(--space-m);
+    border-top-left-radius: var(--border-radius-default);
+    border-top-right-radius: var(--border-radius-default);
   }
 }
 
 .nds-dialog-closeButton {
-  position: absolute;
   font-size: var(--font-size-xl) !important;
   color: var(--font-color-primary);
-  right: var(--space-m);
-  top: var(--space-xs);
-  @include atMediaUp("s", $includeHeight: true) {
-    top: var(--space-m);
-  }
-}
 
-.nds-dialog-closeButton--banner {
-  color: white !important;
+  // Scale effect on hover.
+  transition: scale 150ms ease;
+  &:focus,
+  &:hover {
+    scale: 1.1;
+  }
+
+  @include atMediaUp("s", $includeHeight: true) {
+    transform: translateY(-0.18em);
+  }
 }
 
 .nds-dialog-header,
@@ -156,37 +156,14 @@
 }
 
 .nds-dialog-content {
-  padding: 0 var(--space-xl);
+  padding-inline: var(--space-l);
+  padding-block: var(--space-s);
   overflow-y: auto;
   flex-grow: 1;
 }
 
 .nds-dialog-footer {
-  margin: 0 var(--space-xl) var(--space-xl);
-  padding-top: var(--space-default);
-}
-
-.nds-dialog-footer--overflowing {
-  position: relative;
-
-  // prevent edge case where last line of text is obscured by the overflow
-  // gradient above the dialog footer
-  .nds-dialog-content {
-    padding-bottom: var(--overflow-gradient-height);
-  }
-
-  &::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: -20px;
-    /* stack on top of footer border */
-    height: var(--overflow-gradient-height);
-    background-image: linear-gradient(
-      to top,
-      var(--color-white),
-      RGBA(var(--rgb-white), 0.33)
-    );
-  }
+  margin: 0 var(--space-l) var(--space-l);
+  border-top: 1px solid var(--border-color-default);
+  padding-top: var(--space-l);
 }

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -50,7 +50,6 @@ Overview.args = {
       <Button>Accept</Button>
     </div>
   ),
-  headerStyle: "bordered",
   onUserDismiss: () => {},
   width: "500px",
 };
@@ -270,4 +269,9 @@ WithNotification.args = {
 export default {
   title: "Components/Dialog",
   component: Dialog,
+  argTypes: {
+    headerStyle: {
+      options: ["plain", "banner"],
+    },
+  },
 };

--- a/src/Dialog/index.test.tsx
+++ b/src/Dialog/index.test.tsx
@@ -69,25 +69,26 @@ describe("Dialog", () => {
   });
 
   describe("Header styles", () => {
-    it("renders bordered header by default", () => {
+    it("renders plain header by default", () => {
       renderDialog();
-      expect(screen.getByText("Test Dialog").closest(".nds-dialog-header")).toHaveClass(
-        "nds-dialog-header--bordered"
-      );
+      expect(
+        screen.getByText("Test Dialog").closest(".nds-dialog-header"),
+      ).toHaveClass("nds-dialog-header--plain");
     });
 
     it("renders plain header", () => {
       renderDialog({ headerStyle: "plain" });
-      expect(screen.getByText("Test Dialog").closest(".nds-dialog-header")).toHaveClass(
-        "nds-dialog-header--plain"
-      );
+      expect(
+        screen.getByText("Test Dialog").closest(".nds-dialog-header"),
+      ).toHaveClass("nds-dialog-header--plain");
     });
 
     it("renders banner header with centered title", () => {
       renderDialog({ headerStyle: "banner" });
-      const header = screen.getByText("Test Dialog").closest(".nds-dialog-header");
+      const header = screen
+        .getByText("Test Dialog")
+        .closest(".nds-dialog-header");
       expect(header).toHaveClass("nds-dialog-header--banner");
-      expect(screen.getByText("Test Dialog")).toHaveStyle("text-align: center");
     });
   });
 
@@ -100,48 +101,50 @@ describe("Dialog", () => {
     it("calls onUserDismiss when close button is clicked", async () => {
       const onUserDismiss = vi.fn();
       renderDialog({ onUserDismiss });
-      
+
       const closeButton = screen.getByRole("button", { name: "close" });
       await userEvent.click(closeButton);
-      
+
       expect(onUserDismiss).toHaveBeenCalledTimes(1);
     });
 
     it("calls onUserDismiss when Escape key is pressed", () => {
       const onUserDismiss = vi.fn();
       renderDialog({ onUserDismiss });
-      
+
       fireEvent.keyDown(window, { key: "Escape" });
-      
+
       expect(onUserDismiss).toHaveBeenCalledTimes(1);
     });
 
     it("calls onUserDismiss when clicking on backdrop", async () => {
       const onUserDismiss = vi.fn();
       renderDialog({ onUserDismiss });
-      
+
       const backdrop = document.querySelector(".nds-shim--dark");
       await userEvent.click(backdrop);
-      
+
       expect(onUserDismiss).toHaveBeenCalledTimes(1);
     });
 
     it("does not call onUserDismiss when clicking on dialog content", async () => {
       const onUserDismiss = vi.fn();
       renderDialog({ onUserDismiss });
-      
+
       const dialog = screen.getByRole("dialog");
       await userEvent.click(dialog);
-      
+
       expect(onUserDismiss).not.toHaveBeenCalled();
     });
   });
 
   describe("Content sections", () => {
     it("renders notification section when provided", () => {
-      const notification = <div data-testid="notification">Important notice</div>;
+      const notification = (
+        <div data-testid="notification">Important notice</div>
+      );
       renderDialog({ notification });
-      
+
       expect(screen.getByTestId("notification")).toBeInTheDocument();
       expect(screen.getByText("Important notice")).toBeInTheDocument();
     });
@@ -154,25 +157,27 @@ describe("Dialog", () => {
         </div>
       );
       renderDialog({ footer });
-      
+
       expect(screen.getByTestId("footer")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Cancel" }),
+      ).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     });
 
     it("applies correct content padding when footer is present", () => {
       const footer = <div>Footer content</div>;
       renderDialog({ footer });
-      
+
       const content = document.querySelector(".nds-dialog-content");
-      expect(content).not.toHaveClass("padding--bottom--xl");
+      expect(content).not.toHaveClass("padding--bottom--l");
     });
 
     it("applies correct content padding when no footer", () => {
       renderDialog();
-      
+
       const content = document.querySelector(".nds-dialog-content");
-      expect(content).toHaveClass("padding--bottom--xl");
+      expect(content).toHaveClass("padding--bottom--l");
     });
   });
 
@@ -180,7 +185,7 @@ describe("Dialog", () => {
     it("has correct ARIA attributes", () => {
       renderDialog();
       const dialog = screen.getByRole("dialog");
-      
+
       expect(dialog).toHaveAttribute("aria-labelledby", "aria-dialog-label");
       expect(dialog).toHaveAttribute("aria-modal", "true");
     });
@@ -188,89 +193,19 @@ describe("Dialog", () => {
     it("has title linked to dialog via aria-labelledby", () => {
       renderDialog();
       const titleElement = document.getElementById("aria-dialog-label");
-      
+
       expect(titleElement).toBeInTheDocument();
       expect(titleElement).toHaveTextContent("Test Dialog");
     });
 
     it("focuses the dialog when opened", async () => {
       renderDialog();
-      
-      await waitFor(() => {
-        expect(document.querySelector(".nds-dialog-focuslock")).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe("Overflow detection", () => {
-    it("applies correct classes when content is not overflowing", async () => {
-      const footer = <div data-testid="footer">Footer content</div>;
-      
-      // Mock scrollHeight and clientHeight to simulate no overflow
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-        configurable: true,
-        value: 300,
-      });
-      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
-        configurable: true,
-        value: 400,
-      });
-      
-      renderDialog({ footer });
 
       await waitFor(() => {
-        const content = document.querySelector(".nds-dialog-content");
-        const footer = document.querySelector(".nds-dialog-footer");
-
-        // When not overflowing, content should not have bottom padding
-        expect(content).not.toHaveClass("padding--bottom--xl");
-        // Footer should not have overflowing class
-        expect(footer).not.toHaveClass("nds-dialog-footer--overflowing");
+        expect(
+          document.querySelector(".nds-dialog-focuslock"),
+        ).toBeInTheDocument();
       });
-    });
-
-    it("applies correct classes when content is overflowing", async () => {
-      const footer = <div data-testid="footer">Footer content</div>;
-
-      // Mock scrollHeight and clientHeight to simulate overflow
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-        configurable: true,
-        value: 600,
-      });
-      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
-        configurable: true,
-        value: 400,
-      });
-
-      renderDialog({ footer });
-
-      await waitFor(() => {
-        const content = document.querySelector(".nds-dialog-content");
-        const footer = document.querySelector(".nds-dialog-footer");
-
-        // When overflowing, content should have bottom padding
-        expect(content).toHaveClass("padding--bottom--xl");
-        // Footer should have overflowing class
-        expect(footer).toHaveClass("nds-dialog-footer--overflowing");
-      });
-    });
-
-    it("applies bottom padding when no footer is present", () => {
-      // Mock no overflow scenario
-      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-        configurable: true,
-        value: 300,
-      });
-      Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
-        configurable: true,
-        value: 400,
-      });
-      
-      renderDialog(); // No footer
-
-      const content = document.querySelector(".nds-dialog-content");
-      // When no footer, content should always have bottom padding
-      expect(content).toHaveClass("padding--bottom--xl");
     });
   });
 
@@ -278,12 +213,14 @@ describe("Dialog", () => {
     it("removes event listeners when unmounted", () => {
       const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
       const { unmount } = renderDialog();
-      
+
       unmount();
-      
-      expect(removeEventListenerSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
-      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-      
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "keydown",
+        expect.any(Function),
+      );
+
       removeEventListenerSpy.mockRestore();
     });
   });
@@ -291,7 +228,7 @@ describe("Dialog", () => {
   describe("Edge cases", () => {
     it("handles missing onUserDismiss gracefully", () => {
       renderDialog({ onUserDismiss: undefined });
-      
+
       const closeButton = screen.getByRole("button", { name: "close" });
       expect(() => fireEvent.click(closeButton)).not.toThrow();
     });
@@ -315,12 +252,14 @@ describe("Dialog", () => {
           </ul>
         </div>
       );
-      
+
       renderDialog({ children: complexChildren });
 
       expect(screen.getByText("Complex Content")).toBeInTheDocument();
       expect(screen.getByText("Paragraph content")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Action Button" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Action Button" }),
+      ).toBeInTheDocument();
       expect(screen.getByText("List item 1")).toBeInTheDocument();
     });
   });

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/no-autofocus */
-import React, { useRef, useEffect, useState } from "react";
+import React, { useRef, useEffect } from "react";
 import ReactDOM from "react-dom";
-import rafSchd from "raf-schd";
 import cc from "classcat";
 import useLockBodyScroll from "../hooks/useLockBodyScroll";
 import { CSSTransition } from "react-transition-group";

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -6,24 +6,10 @@ import cc from "classcat";
 import useLockBodyScroll from "../hooks/useLockBodyScroll";
 import { CSSTransition } from "react-transition-group";
 import FocusLock from "react-focus-lock";
+import Row from "../Row";
+import useBreakpoints from "../hooks/useBreakpoints";
 
 const noop = () => {};
-
-/**
- * Checks if content in content area is overflowing
- * @param {Object} contentRef ref of the element to check
- * @returns {Boolean}
- */
-const getIsContentTooLong = (contentRef) => {
-  const threshold = 1; // Scrollheight in firefox is reported as 1px taller
-  let result = false;
-  if (contentRef.current) {
-    result =
-      contentRef.current.scrollHeight >
-      contentRef.current.clientHeight + threshold;
-  }
-  return result;
-};
 
 export interface DialogProps {
   /** Scrollable contents of the Dialog */
@@ -35,14 +21,14 @@ export interface DialogProps {
   /** Contents of Dialog footer, typically reserved for action buttons */
   footer?: React.ReactNode;
   /** Visual style for Dialog header */
-  headerStyle?: "bordered" | "plain" | "banner";
+  headerStyle?: "bordered" | "plain" | "banner"; // @deprecated "bordered". Maps to "plain".
   /** Controls open/close state of the modal. Use the `onUserDismiss` callback to update. */
   isOpen?: boolean;
   /**
    * Callback to handle user taking an action to dismiss the modal
    * (click outside, Escape key, click close button)
    */
-  onUserDismiss?: (event?: React.MouseEvent<HTMLButtonElement>) => void
+  onUserDismiss?: (event?: React.MouseEvent<HTMLButtonElement>) => void;
   /**
    * Sets a custom modal width.
    * Use the full CSS value with the unit (e.g. "400px")
@@ -63,25 +49,19 @@ const Dialog = ({
   isOpen = false,
   onUserDismiss = noop,
   title = "",
-  headerStyle = "bordered",
+  headerStyle = "plain",
   children,
   notification,
   footer,
   width = "500px",
   testId,
 }: DialogProps) => {
-  const [isContentOverflowing, setIsContentOverflowing] = useState(false);
+  const { s: minScreenSize } = useBreakpoints();
   const contentRef = useRef(null);
   const shimRef = useRef(null);
   const dialogRef = useRef(null);
   const isBanner = headerStyle === "banner";
   useLockBodyScroll(isOpen);
-
-  // `rafSchd` uses `requestAnimationFrame` to schedule the state update
-  // for the next frame the browser draws - good for performance
-  const checkContentOverflow = () => {
-    rafSchd(setIsContentOverflowing(getIsContentTooLong(contentRef)));
-  };
 
   const handleKeyDown = ({ key }) => {
     if (key === "Escape") {
@@ -90,14 +70,11 @@ const Dialog = ({
   };
 
   useEffect(() => {
-    if (isOpen) checkContentOverflow(); // run when the dialog initially opens
     window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("resize", checkContentOverflow);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
-      window.removeEventListener("resize", checkContentOverflow);
     };
-  }, [handleKeyDown, checkContentOverflow, isOpen]);
+  }, [handleKeyDown, isOpen]);
 
   const handleShimClick = ({ target }) => {
     if (shimRef.current && target === shimRef.current) {
@@ -122,7 +99,13 @@ const Dialog = ({
   // the shim has events for mouse users only; does not require a role
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const dialogJSX = (
-    <CSSTransition timeout={1} classNames="nds-dialog-transition" appear in nodeRef={dialogRef}>
+    <CSSTransition
+      timeout={1}
+      classNames="nds-dialog-transition"
+      appear
+      in
+      nodeRef={dialogRef}
+    >
       <div className="nds-dialog-root" ref={dialogRef}>
         <div className="nds-shim--dark" ref={shimRef} onClick={handleShimClick}>
           <FocusLock autoFocus={false} className="nds-dialog-focuslock">
@@ -138,23 +121,12 @@ const Dialog = ({
               <div
                 className={`nds-dialog-header nds-dialog-header--${headerStyle}`}
               >
-                {isBanner ? (
-                  <div className="margin--y--s">
-                    <div
-                      className="padding--y--xxs"
-                      id="aria-dialog-label"
-                      style={{ textAlign: "center" }}
-                    >
-                      {title}
-                    </div>
-                    {closeButtonJSX}
-                  </div>
-                ) : (
-                  <>
+                <Row alignItems={minScreenSize ? "start" : "center"}>
+                  <Row.Item>
                     <h4 id="aria-dialog-label">{title}</h4>
-                    {closeButtonJSX}
-                  </>
-                )}
+                  </Row.Item>
+                  <Row.Item shrink>{closeButtonJSX}</Row.Item>
+                </Row>
               </div>
               {notification && (
                 <div className="nds-dialog-notification padding--y padding--x--xl">
@@ -166,21 +138,12 @@ const Dialog = ({
                 ref={contentRef}
                 className={cc([
                   "nds-dialog-content nds-typography padding--top--xs",
-                  { "padding--bottom--xl": !footer || isContentOverflowing },
+                  { "padding--bottom--l": !footer },
                 ])}
               >
                 {children}
               </div>
-              {footer && (
-                <div
-                  className={cc([
-                    "nds-dialog-footer",
-                    { "nds-dialog-footer--overflowing": isContentOverflowing },
-                  ])}
-                >
-                  {footer}
-                </div>
-              )}
+              {footer && <div className="nds-dialog-footer">{footer}</div>}
             </div>
           </FocusLock>
         </div>


### PR DESCRIPTION
Closes NDS-2427

Update `Dialog` styles to match NDSv2 Figma library styling.


### Spacing responsibility changes

The elements (header, content, footer) of the Dialog now manage their spacing via `margin`, so their border is inset within the outer Dialog gutter. The header element is highlighted here in red to demonstrate:
<img width="537" height="681" alt="Screenshot 2026-04-06 at 5 14 12 PM" src="https://github.com/user-attachments/assets/8beb089f-e422-4dd3-ac18-64746724d3b6" />

### `kind` deprecation
The `bordered` variant of `headerStyle` now maps to `plain`, as we always include a border now.
The `banner` variant is still supported, but has been updated to match Figma.

### Smaller viewports
Previous behavior is maintained. By default Dialog renders as a full width drawer from the bottom of the screen.
<img width="501" height="434" alt="Screenshot 2026-04-06 at 6 21 41 PM" src="https://github.com/user-attachments/assets/b08834ae-29c5-417f-9419-e87fab79a57e" />
<img width="426" height="752" alt="Screenshot 2026-04-06 at 6 28 27 PM" src="https://github.com/user-attachments/assets/033282e8-efd5-4b47-b69e-01ca8df44325" />

### Larger viewports
Previous behavior is maintained. Once the aspect ratio media query is satisfied, the Dialog renders as a window.
<img width="596" height="689" alt="Screenshot 2026-04-06 at 6 27 22 PM" src="https://github.com/user-attachments/assets/780e64c9-acd9-4cc0-942f-785bcbf4e5f3" />
<img width="890" height="515" alt="Screenshot 2026-04-06 at 6 27 59 PM" src="https://github.com/user-attachments/assets/f4ec04f3-6b93-4d5a-8603-5689ad4e020d" />
