### PR TITLE
fix(TextInput,Field): set input value color to primary

### DIFF
--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -67,10 +67,6 @@
     pointer-events: none;
     user-select: none;
     background-color: var(--bgColor-smokeGrey) !important;
-
-    input {
-      color: var(--color-mediumGrey);
-    }
   }
 
   &.error {
@@ -108,15 +104,11 @@
   input,
   textarea {
     background: transparent;
-  }
-
-  input {
-    color: var(--color-grey);
+    color: var(--font-color-primary);
   }
 
   textarea {
     @extend %shared-multiline-styles;
-    color: var(--color-grey);
     width: 100%;
     resize: none;
   }
@@ -164,7 +156,7 @@
 
 input::placeholder,
 textarea::placeholder {
-  color: var(--color-mediumGrey);
+  color: var(--font-color-secondary);
   font-weight: var(--font-weight-default);
   text-rendering: geometricPrecision;
 }
@@ -172,7 +164,7 @@ textarea::placeholder {
 input::autofill,
 textarea::autofill {
   background: transparent;
-  color: var(--color-mediumGrey);
+  color: var(--font-color-secondary);
 }
 
 .nds-input-multiline-grid {


### PR DESCRIPTION
Closes NDS-2535

Maps `input` and `textarea` color to standard NDSv2 vars for placeholders and values. The value now looks darker than the placeholder again, as intended:

<img width="244" height="131" alt="Screenshot 2026-04-08 at 5 44 25 PM" src="https://github.com/user-attachments/assets/aef4b255-b85d-4bbd-998b-a111408c7b8d" />
<img width="298" height="112" alt="Screenshot 2026-04-08 at 5 44 30 PM" src="https://github.com/user-attachments/assets/0b836dce-5145-496a-94ae-99f969a4fe20" />
