### PR TITLE
fix(Alert): use alert icon for error kind instead of rotating

### DIFF
--- a/src/Alert/index.scss
+++ b/src/Alert/index.scss
@@ -9,12 +9,6 @@
 .nds-alert--error {
   background-color: var(--color-errorLight);
 
-  // Rotating the info icon until we have a "!" icon
-  .nds-alert-icon {
-    display: inline-block;
-    transform: rotate(180deg);
-  }
-
   .nds-alert-icon::before {
     color: var(--color-errorDark);
   }

--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -37,7 +37,7 @@ const Alert = ({
   paddingSize = "l",
   children,
 }: AlertProps) => {
-  const iconName = kind === "success" ? "check" : "info";
+  const iconName = getIconName(kind);
 
   return (
     <div aria-live="polite">
@@ -74,6 +74,17 @@ const Alert = ({
       )}
     </div>
   );
+};
+
+const getIconName = (kind: AlertProps["kind"]): IconName => {
+  switch (kind) {
+    case "success":
+      return "check";
+    case "error":
+      return "alert-circle";
+    default:
+      return "info";
+  }
 };
 
 export default Alert;


### PR DESCRIPTION
Hilariously, we used to just vertically rotate the `info` icon for error Alerts instead of using the `alert-circle` icon. (It truly blows my mind that the `!` is just an upside-down `i`.) The problem was that if you supplied a custom icon, we'd rotate that, too:



https://github.com/user-attachments/assets/eaa0efcc-e45f-4658-b520-04449879f1e1


The fix is to remove the rotation and just use the correct icon.


https://github.com/user-attachments/assets/790fb6b4-9c7c-496e-891a-7aa6785d1432

