### PR TITLE
fix(Button): use readable color for disabled plain button

### DIFF
--- a/src/Button/states.scss
+++ b/src/Button/states.scss
@@ -9,7 +9,7 @@
 %btn-state-disabled-plain {
   @extend %_btn-state-disabled-base;
   border-width: 0 !important;
-  color: var(--font-color-hint);
+  color: var(--font-color-tertiary);
 }
 
 %btn-state-disabled-primary {


### PR DESCRIPTION
Closes NDS-2573

Fixes plain button so the disabled state uses secondary text instead of `hint`.