### PR TITLE
fix(AnchoredDialog): remove fixed min height

### DIFF
--- a/src/AnchoredDialog/index.scss
+++ b/src/AnchoredDialog/index.scss
@@ -10,7 +10,6 @@
   width: clamp(200px, max-content, 50vw);
 
   background: var(--color-white);
-  height: 60vh;
 }
 
 .nds-anchoredDialog-inner {


### PR DESCRIPTION
Closes NDS-2584

Now that `useDropdownLayer` sets height for dropdowns, we can remove the fixed `60vh` on AnchoredDialog. In some cases, the content area looked way too big compared to the content. This change will allow the height of the content area to set the height of the modal, so it's only ever as tall as it needs to be with scroll overflow for longer lists.

