### PR TITLE
feat(Tooltip): use CSS native positioning

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
-import { useLayer } from "react-laag";
 import { Button as AriaButton, Menu, MenuTrigger } from "react-aria-components";
 import iconSelection from "src/icons/selection.json";
 import MenuButtonItem from "./MenuButtonItem";
 import MenuItem from "./AriaMenuItem";
 import Row from "../Row";
-import { createUseLayerContainer } from "src/util/dom";
+import useDropdownLayer from "../hooks/useDropdownLayer";
 
 export const VALID_ICON_NAMES = iconSelection.icons.map(
   (icon) => icon.properties.name,
@@ -43,13 +42,11 @@ const MenuButton = ({
     canToggleCloseRef.current = false;
   }, [canToggleCloseRef]);
 
-  const { renderLayer, triggerProps, layerProps } = useLayer({
+  const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
-    auto: true,
-    onOutsideClick: closeMenu,
-    placement: `${side}-${alignment}`,
-    container: createUseLayerContainer,
-    triggerOffset: offset,
+    setIsOpen,
+    matchWidth: false,
+    placement: side,
   });
 
   const handleKeyUp = ({ key }) => {
@@ -86,6 +83,12 @@ const MenuButton = ({
     }
   }, [closeMenu]);
 
+  const {
+    ref: anchorRef,
+    style: anchorStyle,
+    ...restAnchorProps
+  } = anchorProps;
+
   return (
     <MenuTrigger
       isOpen={isOpen}
@@ -98,9 +101,10 @@ const MenuButton = ({
       className="nds-menubutton"
     >
       <AriaButton
+        ref={anchorRef}
         aria-label={label}
         className="button--reset nds-menubutton-ariaButton"
-        {...triggerProps}
+        style={anchorStyle}
         onClick={pressButton}
       >
         {typeof renderTrigger === "function" ? (
@@ -136,50 +140,49 @@ const MenuButton = ({
           </div>
         )}
       </AriaButton>
-      {isOpen &&
-        renderLayer(
-          <div className="nds-menubutton-popover" {...layerProps}>
-            <Menu
-              onAction={handleOnSelect}
-              className="nds-menubutton-menu rounded--all elevation--high"
-              // autoFocus is required to enter the menu focus trap when
-              // the menu popover opens
-              // eslint-disable-next-line jsx-a11y/no-autofocus
-              autoFocus={true}
-            >
-              {menuItems.map((child, childIndex) => {
-                const itemId = labelToItemId(child.props.label);
-                return (
-                  <MenuItem
-                    key={itemId}
-                    id={itemId}
-                    value={itemId}
-                    label={child.props.label}
-                    startIcon={child.props.startIcon}
-                    endIcon={child.props.endIcon}
-                    roundedTop={childIndex === 0}
-                    roundedBottom={
-                      childIndex === menuItems.length - 1 && !footerItem
-                    }
-                  />
-                );
-              })}
-              {footerItem && (
+      <div className="nds-menubutton-popover" {...layerProps}>
+        {isOpen && (
+          <Menu
+            onAction={handleOnSelect}
+            className="nds-menubutton-menu rounded--all elevation--high"
+            // autoFocus is required to enter the menu focus trap when
+            // the menu popover opens
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus={true}
+          >
+            {menuItems.map((child, childIndex) => {
+              const itemId = labelToItemId(child.props.label);
+              return (
                 <MenuItem
-                  className="padding--y--s padding--x--s border--top"
-                  id={labelToItemId(footerItem.props.label)}
-                  value={labelToItemId(footerItem.props.label)}
-                  label={footerItem.props.label}
-                  startIcon={footerItem.props.startIcon}
-                  endIcon={footerItem.props.endIcon}
-                  roundedBottom
-                >
-                  {footerItem}
-                </MenuItem>
-              )}
-            </Menu>
-          </div>,
+                  key={itemId}
+                  id={itemId}
+                  value={itemId}
+                  label={child.props.label}
+                  startIcon={child.props.startIcon}
+                  endIcon={child.props.endIcon}
+                  roundedTop={childIndex === 0}
+                  roundedBottom={
+                    childIndex === menuItems.length - 1 && !footerItem
+                  }
+                />
+              );
+            })}
+            {footerItem && (
+              <MenuItem
+                className="padding--y--s padding--x--s border--top"
+                id={labelToItemId(footerItem.props.label)}
+                value={labelToItemId(footerItem.props.label)}
+                label={footerItem.props.label}
+                startIcon={footerItem.props.startIcon}
+                endIcon={footerItem.props.endIcon}
+                roundedBottom
+              >
+                {footerItem}
+              </MenuItem>
+            )}
+          </Menu>
         )}
+      </div>
     </MenuTrigger>
   );
 };

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -27,8 +27,8 @@ const MenuButton = ({
   triggerIcon = "more-vertical",
   showDropdownIndicator = false,
   side = "bottom",
-  alignment = "start",
-  offset = 2,
+  alignment = "start", // eslint-disable-line no-unused-vars
+  offset = 2, // eslint-disable-line no-unused-vars
   children,
   footerItem,
 }) => {
@@ -83,11 +83,7 @@ const MenuButton = ({
     }
   }, [closeMenu]);
 
-  const {
-    ref: anchorRef,
-    style: anchorStyle,
-    ...restAnchorProps
-  } = anchorProps;
+  const { ref: anchorRef, style: anchorStyle } = anchorProps;
 
   return (
     <MenuTrigger

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -23,6 +23,7 @@
  * the tooltip and the anchor exactly.
  */
 @supports (position-anchor: --a) {
+  // Shared base styles for the arrow pseudo-element
   .nds-tooltip::before {
     content: "";
     position: fixed;
@@ -30,17 +31,63 @@
     width: calc(var(--nds-layer-gap) * 2);
     height: var(--nds-layer-gap);
     background: var(--color-black);
+  }
 
-    // Default: tooltip above anchor → arrow below tooltip, pointing down
+  // -------------------------------------------------------
+  // Default arrow directions based on initial placement
+  // -------------------------------------------------------
+
+  // placement="top": tooltip above anchor → arrow pointing down
+  .nds-tooltip[data-placement="top"]::before {
     left: anchor(var(--nds-anchor-name) center);
     transform: translateX(-50%);
     top: calc(anchor(var(--nds-anchor-name) top) - var(--nds-layer-gap));
     clip-path: polygon(50% 100%, 0 0, 100% 0);
   }
 
-  // Tooltip flipped to below anchor → arrow above tooltip, pointing up
+  // placement="bottom": tooltip below anchor → arrow pointing up
+  .nds-tooltip[data-placement="bottom"]::before {
+    top: auto;
+    bottom: calc(anchor(var(--nds-anchor-name) bottom) - var(--nds-layer-gap));
+    left: anchor(var(--nds-anchor-name) center);
+    right: auto;
+    transform: translateX(-50%);
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  }
+
+  // placement="right": tooltip right of anchor → arrow pointing left
+  .nds-tooltip[data-placement="right"]::before {
+    width: var(--nds-layer-gap);
+    height: calc(var(--nds-layer-gap) * 2);
+    left: auto;
+    right: calc(anchor(var(--nds-anchor-name) right) - var(--nds-layer-gap));
+    top: anchor(var(--nds-anchor-name) center);
+    bottom: auto;
+    transform: translateY(-50%);
+    clip-path: polygon(0 50%, 100% 0, 100% 100%);
+  }
+
+  // placement="left": tooltip left of anchor → arrow pointing right
+  .nds-tooltip[data-placement="left"]::before {
+    width: var(--nds-layer-gap);
+    height: calc(var(--nds-layer-gap) * 2);
+    right: auto;
+    left: calc(anchor(var(--nds-anchor-name) left) - var(--nds-layer-gap));
+    top: anchor(var(--nds-anchor-name) center);
+    bottom: auto;
+    transform: translateY(-50%);
+    clip-path: polygon(0 0, 100% 50%, 0 100%);
+  }
+
+  // -------------------------------------------------------
+  // Fallback overrides when the browser flips placement
+  // -------------------------------------------------------
+
+  // Flipped to below anchor → arrow pointing up
   @container anchored(fallback: --nds-try-below) {
     .nds-tooltip::before {
+      width: calc(var(--nds-layer-gap) * 2);
+      height: var(--nds-layer-gap);
       top: auto;
       bottom: calc(
         anchor(var(--nds-anchor-name) bottom) - var(--nds-layer-gap)
@@ -52,13 +99,27 @@
     }
   }
 
-  // Tooltip flipped to right of anchor → arrow left of tooltip, pointing left
+  // Flipped to above anchor → arrow pointing down
+  @container anchored(fallback: --nds-dropdown-above) {
+    .nds-tooltip::before {
+      width: calc(var(--nds-layer-gap) * 2);
+      height: var(--nds-layer-gap);
+      left: anchor(var(--nds-anchor-name) center);
+      right: auto;
+      top: calc(anchor(var(--nds-anchor-name) top) - var(--nds-layer-gap));
+      bottom: auto;
+      transform: translateX(-50%);
+      clip-path: polygon(50% 100%, 0 0, 100% 0);
+    }
+  }
+
+  // Flipped to right of anchor → arrow pointing left
   @container anchored(fallback: --nds-try-right) {
     .nds-tooltip::before {
+      width: var(--nds-layer-gap);
+      height: calc(var(--nds-layer-gap) * 2);
       left: auto;
-      right: calc(
-        anchor(var(--nds-anchor-name) right) - calc(var(--nds-layer-gap) * 2)
-      );
+      right: calc(anchor(var(--nds-anchor-name) right) - var(--nds-layer-gap));
       top: anchor(var(--nds-anchor-name) center);
       bottom: auto;
       transform: translateY(-50%);
@@ -66,13 +127,13 @@
     }
   }
 
-  // Tooltip flipped to left of anchor → arrow right of tooltip, pointing right
+  // Flipped to left of anchor → arrow pointing right
   @container anchored(fallback: --nds-try-left) {
     .nds-tooltip::before {
+      width: var(--nds-layer-gap);
+      height: calc(var(--nds-layer-gap) * 2);
       right: auto;
-      left: calc(
-        anchor(var(--nds-anchor-name) left) - calc(var(--nds-layer-gap) * 2)
-      );
+      left: calc(anchor(var(--nds-anchor-name) left) - var(--nds-layer-gap));
       top: anchor(var(--nds-anchor-name) center);
       bottom: auto;
       transform: translateY(-50%);

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -9,58 +9,74 @@
   position: relative;
   container-type: anchored;
 
-  // Override the hook's default gap to accommodate the arrow (7px) + 2px breathing room
+  // Gap between tooltip and anchor; also used as the arrow height
   --nds-layer-gap: 9px;
 }
 
 /**
- * SVG triangle arrow inside the tooltip.
- * Only rendered when anchored container queries are supported.
- * Default position: tooltip is above the anchor, arrow at bottom pointing down.
- * Flips via @container anchored() rules when position-try fallbacks activate.
+ * CSS-only triangle arrow using a fixed-positioned ::before pseudo-element.
+ * Uses anchor() to track the anchor element's center directly,
+ * independent of where the browser places the tooltip.
+ * Only rendered when CSS anchor positioning is supported.
+ *
+ * The arrow height equals --nds-layer-gap, filling the space between
+ * the tooltip and the anchor exactly.
  */
-.nds-tooltip-arrow {
-  position: absolute;
-  fill: var(--color-black);
-  display: block;
-  width: 14px;
-  height: 7px;
+@supports (position-anchor: --a) {
+  .nds-tooltip::before {
+    content: "";
+    position: fixed;
+    position-anchor: var(--nds-anchor-name);
+    width: calc(var(--nds-layer-gap) * 2);
+    height: var(--nds-layer-gap);
+    background: var(--color-black);
 
-  // Default: tooltip above anchor → arrow at bottom, pointing down
-  bottom: -7px;
-  left: 50%;
-  transform: translateX(-50%) rotate(180deg);
-}
-
-// Tooltip flipped to below anchor → arrow at top, pointing up
-@container anchored(fallback: --nds-tooltip-below) {
-  .nds-tooltip-arrow {
-    top: -7px;
-    bottom: auto;
-    left: 50%;
-    right: auto;
-    transform: translateX(-50%) rotate(0deg);
+    // Default: tooltip above anchor → arrow below tooltip, pointing down
+    left: anchor(var(--nds-anchor-name) center);
+    transform: translateX(-50%);
+    top: calc(anchor(var(--nds-anchor-name) top) - var(--nds-layer-gap));
+    clip-path: polygon(50% 100%, 0 0, 100% 0);
   }
-}
 
-// Tooltip flipped to right of anchor → arrow at left, pointing left
-@container anchored(fallback: --nds-tooltip-right) {
-  .nds-tooltip-arrow {
-    left: -7px;
-    right: auto;
-    top: 50%;
-    bottom: auto;
-    transform: translateY(-50%) rotate(90deg);
+  // Tooltip flipped to below anchor → arrow above tooltip, pointing up
+  @container anchored(fallback: --nds-tooltip-below) {
+    .nds-tooltip::before {
+      top: auto;
+      bottom: calc(
+        anchor(var(--nds-anchor-name) bottom) - var(--nds-layer-gap)
+      );
+      left: anchor(var(--nds-anchor-name) center);
+      right: auto;
+      transform: translateX(-50%);
+      clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    }
   }
-}
 
-// Tooltip flipped to left of anchor → arrow at right, pointing right
-@container anchored(fallback: --nds-tooltip-left) {
-  .nds-tooltip-arrow {
-    right: -7px;
-    left: auto;
-    top: 50%;
-    bottom: auto;
-    transform: translateY(-50%) rotate(270deg);
+  // Tooltip flipped to right of anchor → arrow left of tooltip, pointing left
+  @container anchored(fallback: --nds-tooltip-right) {
+    .nds-tooltip::before {
+      left: auto;
+      right: calc(
+        anchor(var(--nds-anchor-name) right) - calc(var(--nds-layer-gap) * 2)
+      );
+      top: anchor(var(--nds-anchor-name) center);
+      bottom: auto;
+      transform: translateY(-50%);
+      clip-path: polygon(0 50%, 100% 0, 100% 100%);
+    }
+  }
+
+  // Tooltip flipped to left of anchor → arrow right of tooltip, pointing right
+  @container anchored(fallback: --nds-tooltip-left) {
+    .nds-tooltip::before {
+      right: auto;
+      left: calc(
+        anchor(var(--nds-anchor-name) left) - calc(var(--nds-layer-gap) * 2)
+      );
+      top: anchor(var(--nds-anchor-name) center);
+      bottom: auto;
+      transform: translateY(-50%);
+      clip-path: polygon(0 0, 100% 50%, 0 100%);
+    }
   }
 }

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -6,9 +6,61 @@
   color: var(--color-white);
   text-align: center;
   z-index: 999;
+  position: relative;
+  container-type: anchored;
 
-  // The arrow SVG path
-  path {
-    fill: var(--color-black);
+  // Override the hook's default gap to accommodate the arrow (7px) + 2px breathing room
+  --nds-layer-gap: 9px;
+}
+
+/**
+ * SVG triangle arrow inside the tooltip.
+ * Only rendered when anchored container queries are supported.
+ * Default position: tooltip is above the anchor, arrow at bottom pointing down.
+ * Flips via @container anchored() rules when position-try fallbacks activate.
+ */
+.nds-tooltip-arrow {
+  position: absolute;
+  fill: var(--color-black);
+  display: block;
+  width: 14px;
+  height: 7px;
+
+  // Default: tooltip above anchor → arrow at bottom, pointing down
+  bottom: -7px;
+  left: 50%;
+  transform: translateX(-50%) rotate(180deg);
+}
+
+// Tooltip flipped to below anchor → arrow at top, pointing up
+@container anchored(fallback: --nds-tooltip-below) {
+  .nds-tooltip-arrow {
+    top: -7px;
+    bottom: auto;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%) rotate(0deg);
+  }
+}
+
+// Tooltip flipped to right of anchor → arrow at left, pointing left
+@container anchored(fallback: --nds-tooltip-right) {
+  .nds-tooltip-arrow {
+    left: -7px;
+    right: auto;
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%) rotate(90deg);
+  }
+}
+
+// Tooltip flipped to left of anchor → arrow at right, pointing right
+@container anchored(fallback: --nds-tooltip-left) {
+  .nds-tooltip-arrow {
+    right: -7px;
+    left: auto;
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%) rotate(270deg);
   }
 }

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -39,7 +39,7 @@
   }
 
   // Tooltip flipped to below anchor → arrow above tooltip, pointing up
-  @container anchored(fallback: --nds-tooltip-below) {
+  @container anchored(fallback: --nds-try-below) {
     .nds-tooltip::before {
       top: auto;
       bottom: calc(
@@ -53,7 +53,7 @@
   }
 
   // Tooltip flipped to right of anchor → arrow left of tooltip, pointing left
-  @container anchored(fallback: --nds-tooltip-right) {
+  @container anchored(fallback: --nds-try-right) {
     .nds-tooltip::before {
       left: auto;
       right: calc(
@@ -67,7 +67,7 @@
   }
 
   // Tooltip flipped to left of anchor → arrow right of tooltip, pointing right
-  @container anchored(fallback: --nds-tooltip-left) {
+  @container anchored(fallback: --nds-try-left) {
     .nds-tooltip::before {
       right: auto;
       left: calc(

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -135,6 +135,39 @@ ScrollingBehavior.parameters = {
   },
 };
 
+export const ArrowTracking = () => (
+  <div
+    style={{
+      resize: "horizontal",
+      overflow: "hidden",
+      display: "flex",
+      justifyContent: "flex-end",
+      alignItems: "center",
+      outline: "1px dashed hotpink",
+      padding: "var(--space-l)",
+      width: "100%",
+      minWidth: "200px",
+      height: "200px",
+    }}
+  >
+    <Tooltip
+      isOpen={true}
+      text="This tooltip has enough text to cause a collision with the right edge of the viewport"
+    >
+      <Button>Trigger</Button>
+    </Tooltip>
+  </div>
+);
+
+ArrowTracking.parameters = {
+  docs: {
+    description: {
+      story:
+        "Demonstrates arrow tracking behavior near viewport edges. Drag the bottom-right resize handle to move the trigger away from the right edge and observe how the arrow does (or does not) stay aligned with the anchor.",
+    },
+  },
+};
+
 export default {
   title: "Components/Tooltip",
   component: Tooltip,

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -130,7 +130,7 @@ ScrollingBehavior.parameters = {
   docs: {
     description: {
       story:
-        "Scroll the page so the trigger is near the top of the viewport. The tooltip will flip from top to bottom when there isn't enough space above.",
+        "(Must be viewed as a standalone page) Scroll the page so the trigger is near the top of the viewport. The tooltip will flip from top to bottom when there isn't enough space above.",
     },
   },
 };

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -107,6 +107,34 @@ ControlledTooltip.parameters = {
   },
 };
 
+export const ScrollingBehavior = () => (
+  <div
+    style={{
+      height: "300vh",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      paddingTop: "120vh",
+    }}
+  >
+    <Tooltip
+      isOpen={true}
+      text="This tooltip flips when scrolled to the top of the viewport"
+    >
+      <Button>Scroll down to see me flip</Button>
+    </Tooltip>
+  </div>
+);
+
+ScrollingBehavior.parameters = {
+  docs: {
+    description: {
+      story:
+        "Scroll the page so the trigger is near the top of the viewport. The tooltip will flip from top to bottom when there isn't enough space above.",
+    },
+  },
+};
+
 export default {
   title: "Components/Tooltip",
   component: Tooltip,

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useId } from "react";
 import useDropdownLayer from "../hooks/useDropdownLayer";
 
 export interface TooltipProps {
@@ -35,6 +35,7 @@ const Tooltip = ({
 }: TooltipProps) => {
   const isControlled = isOpen === true || isOpen === false;
   const [open, setOpen] = useState(false);
+  const tooltipId = useId();
   const delays = {
     open: 500,
     close: 100,
@@ -74,7 +75,7 @@ const Tooltip = ({
     <>
       <div
         ref={anchorRef as React.Ref<HTMLDivElement>}
-        aria-describedby="nds-tooltip"
+        aria-describedby={shouldRenderTooltip ? tooltipId : undefined}
         aria-expanded={anchorExpanded}
         style={{ ...anchorStyle, display: wrapperDisplay }}
         onFocus={openPopover}
@@ -90,7 +91,7 @@ const Tooltip = ({
       </div>
       <div
         ref={layerRef as React.Ref<HTMLDivElement>}
-        id="nds-tooltip"
+        id={tooltipId}
         role="tooltip"
         className="nds-typography nds-tooltip elevation--middle"
         {...layerRest}

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { useLayer, Arrow } from "react-laag";
-import { createUseLayerContainer } from "../util/dom";
+import React, { useState, useCallback } from "react";
+import useDropdownLayer from "../hooks/useDropdownLayer";
+import useSupportsAnchoredContainerQueries from "../hooks/useSupportsAnchoredContainerQueries";
 
 export interface TooltipProps {
   /** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
@@ -20,6 +20,23 @@ export interface TooltipProps {
 }
 
 /**
+ * Small SVG triangle used as the tooltip arrow.
+ * Rendered only when CSS anchored container queries are supported;
+ * positioned and flipped purely via CSS (see Tooltip/index.scss).
+ */
+const TooltipArrow = () => (
+  <svg
+    className="nds-tooltip-arrow"
+    width="14"
+    height="7"
+    viewBox="0 0 14 7"
+    aria-hidden="true"
+  >
+    <path d="M1,7 L6,1 Q7,0 8,1 L13,7 Z" />
+  </svg>
+);
+
+/**
  * Renders a text-only tooltip on hover or focus of a trigger.
  *
  * The tooltip will position itself based on the `side` prop, but will
@@ -36,11 +53,13 @@ const Tooltip = ({
 }: TooltipProps) => {
   const isControlled = isOpen === true || isOpen === false;
   const [open, setOpen] = useState(false);
+  const supportsAnchoredContainerQueries =
+    useSupportsAnchoredContainerQueries();
   const delays = {
     open: 500,
     close: 100,
   };
-  let activeTimer;
+  let activeTimer: ReturnType<typeof setTimeout>;
 
   const shouldRenderTooltip = isControlled ? isOpen : open;
 
@@ -49,31 +68,36 @@ const Tooltip = ({
     activeTimer = setTimeout(setOpen, delays.open, true);
   };
 
-  const closePopover = () => {
+  const closePopover = useCallback(() => {
     clearTimeout(activeTimer);
     activeTimer = setTimeout(setOpen, delays.close, false);
-  };
+  }, []);
 
-  const { renderLayer, triggerProps, layerProps, arrowProps } = useLayer({
-    isOpen: shouldRenderTooltip,
-    onOutsideClick: closePopover,
-    onDisappear: closePopover,
-    auto: true,
-    placement: `${side}-center`,
-    preferX: "left",
-    preferY: "top",
-    triggerOffset: 12,
-    arrowOffset: 12,
-    container: createUseLayerContainer,
+  const { anchorProps, layerProps } = useDropdownLayer({
+    isOpen: !!shouldRenderTooltip,
+    setIsOpen: (v) => {
+      if (!v) closePopover();
+    },
+    matchWidth: false,
+    ariaPopupType: "false",
+    placement: side,
   });
+
+  const {
+    ref: anchorRef,
+    style: anchorStyle,
+    "aria-expanded": anchorExpanded,
+  } = anchorProps;
+  const { ref: layerRef, ...layerRest } = layerProps;
 
   return (
     <>
       <div
-        {...triggerProps}
+        ref={anchorRef as React.Ref<HTMLDivElement>}
         aria-describedby="nds-tooltip"
         aria-label={text}
-        style={{ display: wrapperDisplay }}
+        aria-expanded={anchorExpanded}
+        style={{ ...anchorStyle, display: wrapperDisplay }}
         onFocus={openPopover}
         onBlur={closePopover}
         onMouseEnter={openPopover}
@@ -82,29 +106,26 @@ const Tooltip = ({
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
         data-testid="nds-tooltip-trigger"
-        aria-expanded={open}
       >
         {children}
       </div>
-      {renderLayer(
-        <>
-          {shouldRenderTooltip && (
-            <div
-              id="nds-tooltip"
-              role="tooltip"
-              className="nds-typography nds-tooltip elevation--middle"
-              {...layerProps}
-              style={{ maxWidth: maxWidth, ...layerProps.style }}
-              data-testid={testId}
-              onMouseEnter={openPopover}
-              onMouseLeave={closePopover}
-            >
-              {text}
-              <Arrow {...arrowProps} />
-            </div>
-          )}
-        </>,
-      )}
+      <div
+        ref={layerRef as React.Ref<HTMLDivElement>}
+        id="nds-tooltip"
+        role="tooltip"
+        className="nds-typography nds-tooltip elevation--middle"
+        {...layerRest}
+        style={{
+          maxWidth: maxWidth,
+          ...layerRest.style,
+        }}
+        data-testid={testId}
+        onMouseEnter={openPopover}
+        onMouseLeave={closePopover}
+      >
+        {shouldRenderTooltip ? text : null}
+        {supportsAnchoredContainerQueries && <TooltipArrow />}
+      </div>
     </>
   );
 };

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -19,11 +19,6 @@ export interface TooltipProps {
   testId?: string;
 }
 
-/**
- * Small SVG triangle used as the tooltip arrow.
- * Rendered only when CSS anchored container queries are supported;
- * positioned and flipped purely via CSS (see Tooltip/index.scss).
- */
 const TooltipArrow = () => (
   <svg
     className="nds-tooltip-arrow"

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback } from "react";
 import useDropdownLayer from "../hooks/useDropdownLayer";
-import useSupportsAnchoredContainerQueries from "../hooks/useSupportsAnchoredContainerQueries";
 
 export interface TooltipProps {
   /** The root node of JSX passed into Tooltip as children will act as the tooltip trigger */
@@ -19,18 +18,6 @@ export interface TooltipProps {
   testId?: string;
 }
 
-const TooltipArrow = () => (
-  <svg
-    className="nds-tooltip-arrow"
-    width="14"
-    height="7"
-    viewBox="0 0 14 7"
-    aria-hidden="true"
-  >
-    <path d="M1,7 L6,1 Q7,0 8,1 L13,7 Z" />
-  </svg>
-);
-
 /**
  * Renders a text-only tooltip on hover or focus of a trigger.
  *
@@ -48,8 +35,6 @@ const Tooltip = ({
 }: TooltipProps) => {
   const isControlled = isOpen === true || isOpen === false;
   const [open, setOpen] = useState(false);
-  const supportsAnchoredContainerQueries =
-    useSupportsAnchoredContainerQueries();
   const delays = {
     open: 500,
     close: 100,
@@ -118,7 +103,6 @@ const Tooltip = ({
         onMouseLeave={closePopover}
       >
         {shouldRenderTooltip ? text : null}
-        {supportsAnchoredContainerQueries && <TooltipArrow />}
       </div>
     </>
   );

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -94,6 +94,7 @@ const Tooltip = ({
         id={tooltipId}
         role="tooltip"
         className="nds-typography nds-tooltip elevation--middle"
+        data-placement={side}
         {...layerRest}
         style={{
           maxWidth: maxWidth,

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -90,7 +90,6 @@ const Tooltip = ({
       <div
         ref={anchorRef as React.Ref<HTMLDivElement>}
         aria-describedby="nds-tooltip"
-        aria-label={text}
         aria-expanded={anchorExpanded}
         style={{ ...anchorStyle, display: wrapperDisplay }}
         onFocus={openPopover}

--- a/src/base-styles/custom-properties.scss
+++ b/src/base-styles/custom-properties.scss
@@ -27,7 +27,6 @@
 * Position-try fallbacks for tooltip placements.
 * These allow the browser to flip the tooltip to the opposite side
 * when there isn't enough space in the preferred direction.
-* The margin includes --tooltip-arrow-gap (arrow height + 2px breathing room).
 */
 @position-try --nds-tooltip-below {
   position-area: bottom;

--- a/src/base-styles/custom-properties.scss
+++ b/src/base-styles/custom-properties.scss
@@ -24,23 +24,23 @@
 }
 
 /**
-* Position-try fallbacks for tooltip placements.
-* These allow the browser to flip the tooltip to the opposite side
+* Position-try fallbacks for anchor-positioned layers.
+* These allow the browser to flip the layer to the opposite side
 * when there isn't enough space in the preferred direction.
 */
-@position-try --nds-tooltip-below {
+@position-try --nds-try-below {
   position-area: bottom;
   margin-top: var(--nds-layer-gap, var(--space-xxs));
   margin-bottom: 0;
 }
 
-@position-try --nds-tooltip-right {
+@position-try --nds-try-right {
   position-area: right;
   margin-left: var(--nds-layer-gap, var(--space-xxs));
   margin-right: 0;
 }
 
-@position-try --nds-tooltip-left {
+@position-try --nds-try-left {
   position-area: left;
   margin-right: var(--nds-layer-gap, var(--space-xxs));
   margin-left: 0;

--- a/src/base-styles/custom-properties.scss
+++ b/src/base-styles/custom-properties.scss
@@ -20,5 +20,29 @@
 @position-try --nds-dropdown-above {
   position-area: top;
   margin-top: 0;
-  margin-bottom: var(--space-xxs);
+  margin-bottom: var(--nds-layer-gap, var(--space-xxs));
+}
+
+/**
+* Position-try fallbacks for tooltip placements.
+* These allow the browser to flip the tooltip to the opposite side
+* when there isn't enough space in the preferred direction.
+* The margin includes --tooltip-arrow-gap (arrow height + 2px breathing room).
+*/
+@position-try --nds-tooltip-below {
+  position-area: bottom;
+  margin-top: var(--nds-layer-gap, var(--space-xxs));
+  margin-bottom: 0;
+}
+
+@position-try --nds-tooltip-right {
+  position-area: right;
+  margin-left: var(--nds-layer-gap, var(--space-xxs));
+  margin-right: 0;
+}
+
+@position-try --nds-tooltip-left {
+  position-area: left;
+  margin-right: var(--nds-layer-gap, var(--space-xxs));
+  margin-left: 0;
 }

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -135,6 +135,8 @@ const useDropdownLayer = ({
       width: matchWidth ? "anchor-size(width)" : "min(80vw, max-content)",
       maxWidth: matchWidth ? "anchor-size(width)" : "80vw",
       minWidth: matchWidth ? "anchor-size(width)" : "auto",
+      // Expose anchor name to CSS descendants (e.g. tooltip arrow)
+      "--nds-anchor-name": anchorName,
     };
 
     const layerStyle = {

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -10,7 +10,7 @@ export type UseDropdownLayerResult = {
       anchorName?: string;
     };
     "aria-haspopup": string;
-    "aria-expanded": boolean;
+    "aria-expanded"?: boolean;
   };
   /** Props to spread onto the dropdown menu element */
   layerProps: {

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -118,7 +118,6 @@ const useDropdownLayer = ({
         anchorName: isAnchorPositionSupported ? anchorName : undefined,
       },
       "aria-haspopup": ariaPopupType,
-      "aria-expanded": isOpen,
     }),
     [anchorRef, isAnchorPositionSupported, anchorName, isOpen, ariaPopupType],
   );

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -63,17 +63,17 @@ const PLACEMENT_CONFIG: Record<
   },
   top: {
     positionArea: "top",
-    positionTryFallbacks: "--nds-tooltip-below, flip-inline",
+    positionTryFallbacks: "--nds-try-below, flip-inline",
     margin: "marginBottom",
   },
   left: {
     positionArea: "left",
-    positionTryFallbacks: "--nds-tooltip-right, flip-block",
+    positionTryFallbacks: "--nds-try-right, flip-block",
     margin: "marginRight",
   },
   right: {
     positionArea: "right",
-    positionTryFallbacks: "--nds-tooltip-left, flip-block",
+    positionTryFallbacks: "--nds-try-left, flip-block",
     margin: "marginLeft",
   },
 };

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -10,7 +10,7 @@ export type UseDropdownLayerResult = {
       anchorName?: string;
     };
     "aria-haspopup": string;
-    "aria-expanded": string;
+    "aria-expanded": boolean;
   };
   /** Props to spread onto the dropdown menu element */
   layerProps: {
@@ -23,7 +23,11 @@ export type UseDropdownLayerResult = {
         }
       | React.CSSProperties;
   };
+  /** Whether the browser supports native CSS anchor positioning */
+  isAnchorPositionSupported: boolean;
 };
+
+export type Placement = "bottom" | "top" | "left" | "right";
 
 export interface UseDropdownLayerOptions {
   /** Whether the dropdown is currently open (required) */
@@ -41,7 +45,38 @@ export interface UseDropdownLayerOptions {
    * @default "menu"
    */
   ariaPopupType?: string;
+  /** Preferred placement of the layer relative to the anchor.
+   * @default "bottom"
+   */
+  placement?: Placement;
 }
+
+/** Maps placement to CSS anchor positioning values */
+const PLACEMENT_CONFIG: Record<
+  Placement,
+  { positionArea: string; positionTryFallbacks: string; margin: string }
+> = {
+  bottom: {
+    positionArea: "bottom",
+    positionTryFallbacks: "--nds-dropdown-above, flip-inline",
+    margin: "marginTop",
+  },
+  top: {
+    positionArea: "top",
+    positionTryFallbacks: "--nds-tooltip-below, flip-inline",
+    margin: "marginBottom",
+  },
+  left: {
+    positionArea: "left",
+    positionTryFallbacks: "--nds-tooltip-right, flip-block",
+    margin: "marginRight",
+  },
+  right: {
+    positionArea: "right",
+    positionTryFallbacks: "--nds-tooltip-left, flip-block",
+    margin: "marginLeft",
+  },
+};
 
 /**
  * Progressive enhancement driven layout helper for dropdowns/menus.
@@ -54,6 +89,7 @@ const useDropdownLayer = ({
   matchWidth = true,
   isPortalled = false,
   ariaPopupType = "menu",
+  placement = "bottom",
 }: UseDropdownLayerOptions): UseDropdownLayerResult => {
   const anchorRef = useRef<HTMLElement>(null);
   const layerRef = useRef<HTMLElement>(null);
@@ -70,6 +106,7 @@ const useDropdownLayer = ({
     matchWidth,
     isOpen,
     setIsOpen,
+    placement,
   });
 
   useDropdownMaxHeight({ anchorRef, layerRef, isOpen });
@@ -82,20 +119,21 @@ const useDropdownLayer = ({
         anchorName: isAnchorPositionSupported ? anchorName : undefined,
       },
       "aria-haspopup": ariaPopupType,
-      "aria-expanded": isOpen.toString(),
+      "aria-expanded": isOpen,
     }),
     [anchorRef, isAnchorPositionSupported, anchorName, isOpen, ariaPopupType],
   );
 
   // Memoized props to spread onto the positioned layer element
   const layerProps = useMemo(() => {
+    const config = PLACEMENT_CONFIG[placement];
     // The anchor uses position fixed regardless of code path.
     const anchorPositionStyles = {
       position: "fixed" as const,
       positionAnchor: anchorName,
-      positionArea: "bottom",
-      positionTryFallbacks: "--nds-dropdown-above, flip-inline",
-      marginTop: "var(--space-xxs)",
+      positionArea: config.positionArea,
+      positionTryFallbacks: config.positionTryFallbacks,
+      [config.margin]: "var(--nds-layer-gap, var(--space-xxs))",
       width: matchWidth ? "anchor-size(width)" : "min(80vw, max-content)",
       maxWidth: matchWidth ? "anchor-size(width)" : "80vw",
       minWidth: matchWidth ? "anchor-size(width)" : "auto",
@@ -121,6 +159,7 @@ const useDropdownLayer = ({
     isPortalled,
     anchorName,
     matchWidth,
+    placement,
     polyFillLayerStyles,
     layerRef,
   ]);
@@ -128,6 +167,7 @@ const useDropdownLayer = ({
   return {
     anchorProps,
     layerProps,
+    isAnchorPositionSupported,
   };
 };
 

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -106,7 +106,6 @@ const useDropdownLayer = ({
     matchWidth,
     isOpen,
     setIsOpen,
-    placement,
   });
 
   useDropdownMaxHeight({ anchorRef, layerRef, isOpen });

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
@@ -1,7 +1,6 @@
 import { useLayoutEffect } from "react";
 import useSupportsAnchorPositioning from "../useSupportsAnchorPositioning";
 import { resolveSpaceToken } from "./useDropdownMaxHeight";
-import type { Placement } from "./index";
 
 interface UseAnchorPolyfillParams {
   /** Reference to the element that the dropdown should be anchored to */
@@ -14,10 +13,6 @@ interface UseAnchorPolyfillParams {
   isOpen: boolean;
   /** Function to close the dropdown */
   setIsOpen: (isOpen: boolean) => void;
-  /** Preferred placement of the layer relative to the anchor
-   * @default "bottom"
-   */
-  placement?: Placement;
 }
 
 /**
@@ -28,7 +23,6 @@ export const calculatePosition = (
   anchorEl: HTMLElement,
   layerEl: HTMLElement,
   matchWidth: boolean,
-  placement: Placement = "bottom",
 ): void => {
   if (typeof window === "undefined") return;
   const anchorRect = anchorEl.getBoundingClientRect();
@@ -39,7 +33,6 @@ export const calculatePosition = (
   const edgeClearance = resolveSpaceToken("--space-l", 20);
 
   const vvHeight = window.visualViewport?.height ?? window.innerHeight;
-  const vvWidth = window.visualViewport?.width ?? window.innerWidth;
 
   // Reset to a known baseline before measuring layer position.
   layerEl.style.setProperty("--js-dropdown-top", "0px");
@@ -47,66 +40,28 @@ export const calculatePosition = (
   layerEl.style.setProperty("--js-dropdown-left", "0px");
 
   const layerRect = layerEl.getBoundingClientRect();
+  const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
+  const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
+  const shouldFlip = spaceAbove > spaceBelow;
 
-  if (placement === "left" || placement === "right") {
-    const spaceRight = vvWidth - anchorRect.right - anchorGap - edgeClearance;
-    const spaceLeft = anchorRect.left - anchorGap - edgeClearance;
-    const shouldFlip =
-      placement === "right" ? spaceLeft > spaceRight : spaceRight > spaceLeft;
-    const useRight =
-      (placement === "right" && !shouldFlip) ||
-      (placement === "left" && shouldFlip);
-
-    if (useRight) {
-      layerEl.style.setProperty(
-        "--js-dropdown-left",
-        `${anchorRect.right - layerRect.left + anchorGap}px`,
-      );
-    } else {
-      layerEl.style.setProperty(
-        "--js-dropdown-left",
-        `${anchorRect.left - layerRect.left - layerRect.width - anchorGap}px`,
-      );
-    }
-
-    // Vertically center relative to anchor
-    const anchorMid = anchorRect.top + anchorRect.height / 2;
+  if (shouldFlip) {
+    layerEl.style.setProperty(
+      "--js-dropdown-bottom",
+      `${vvHeight - anchorRect.top + anchorGap}px`,
+    );
+    layerEl.style.removeProperty("--js-dropdown-top");
+  } else {
     layerEl.style.setProperty(
       "--js-dropdown-top",
-      `${anchorMid - layerRect.top - layerRect.height / 2}px`,
+      `${anchorRect.bottom - layerRect.top + anchorGap}px`,
     );
     layerEl.style.removeProperty("--js-dropdown-bottom");
-  } else {
-    // top/bottom placement
-    const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
-    const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
-    const shouldFlip =
-      placement === "bottom"
-        ? spaceAbove > spaceBelow
-        : spaceBelow > spaceAbove;
-    const useAbove =
-      (placement === "top" && !shouldFlip) ||
-      (placement === "bottom" && shouldFlip);
-
-    if (useAbove) {
-      layerEl.style.setProperty(
-        "--js-dropdown-bottom",
-        `${vvHeight - anchorRect.top + anchorGap}px`,
-      );
-      layerEl.style.removeProperty("--js-dropdown-top");
-    } else {
-      layerEl.style.setProperty(
-        "--js-dropdown-top",
-        `${anchorRect.bottom - layerRect.top + anchorGap}px`,
-      );
-      layerEl.style.removeProperty("--js-dropdown-bottom");
-    }
-
-    layerEl.style.setProperty(
-      "--js-dropdown-left",
-      `${anchorRect.left - layerRect.left}px`,
-    );
   }
+
+  layerEl.style.setProperty(
+    "--js-dropdown-left",
+    `${anchorRect.left - layerRect.left}px`,
+  );
 
   if (matchWidth) {
     layerEl.style.setProperty("--js-dropdown-width", `${anchorRect.width}px`);
@@ -145,7 +100,6 @@ const useAnchorPolyfill = ({
   matchWidth = false,
   isOpen,
   setIsOpen,
-  placement = "bottom",
 }: UseAnchorPolyfillParams) => {
   const isAnchorPositionSupported = useSupportsAnchorPositioning();
 
@@ -158,7 +112,7 @@ const useAnchorPolyfill = ({
     const layerEl = layerRef.current;
     if (!anchorEl || !layerEl) return;
 
-    const calculateArgs = [anchorEl, layerEl, matchWidth, placement] as const;
+    const calculateArgs = [anchorEl, layerEl, matchWidth] as const;
 
     const armObserver = () => {
       if (disposed) return;
@@ -232,7 +186,6 @@ const useAnchorPolyfill = ({
     matchWidth,
     isOpen,
     setIsOpen,
-    placement,
   ]);
 
   return {

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from "react";
 import useSupportsAnchorPositioning from "../useSupportsAnchorPositioning";
 import { resolveSpaceToken } from "./useDropdownMaxHeight";
+import type { Placement } from "./index";
 
 interface UseAnchorPolyfillParams {
   /** Reference to the element that the dropdown should be anchored to */
@@ -13,6 +14,10 @@ interface UseAnchorPolyfillParams {
   isOpen: boolean;
   /** Function to close the dropdown */
   setIsOpen: (isOpen: boolean) => void;
+  /** Preferred placement of the layer relative to the anchor
+   * @default "bottom"
+   */
+  placement?: Placement;
 }
 
 /**
@@ -23,6 +28,7 @@ export const calculatePosition = (
   anchorEl: HTMLElement,
   layerEl: HTMLElement,
   matchWidth: boolean,
+  placement: Placement = "bottom",
 ): void => {
   if (typeof window === "undefined") return;
   const anchorRect = anchorEl.getBoundingClientRect();
@@ -33,6 +39,7 @@ export const calculatePosition = (
   const edgeClearance = resolveSpaceToken("--space-l", 20);
 
   const vvHeight = window.visualViewport?.height ?? window.innerHeight;
+  const vvWidth = window.visualViewport?.width ?? window.innerWidth;
 
   // Reset to a known baseline before measuring layer position.
   layerEl.style.setProperty("--js-dropdown-top", "0px");
@@ -40,28 +47,66 @@ export const calculatePosition = (
   layerEl.style.setProperty("--js-dropdown-left", "0px");
 
   const layerRect = layerEl.getBoundingClientRect();
-  const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
-  const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
-  const shouldFlip = spaceAbove > spaceBelow;
 
-  if (shouldFlip) {
-    layerEl.style.setProperty(
-      "--js-dropdown-bottom",
-      `${vvHeight - anchorRect.top + anchorGap}px`,
-    );
-    layerEl.style.removeProperty("--js-dropdown-top");
-  } else {
+  if (placement === "left" || placement === "right") {
+    const spaceRight = vvWidth - anchorRect.right - anchorGap - edgeClearance;
+    const spaceLeft = anchorRect.left - anchorGap - edgeClearance;
+    const shouldFlip =
+      placement === "right" ? spaceLeft > spaceRight : spaceRight > spaceLeft;
+    const useRight =
+      (placement === "right" && !shouldFlip) ||
+      (placement === "left" && shouldFlip);
+
+    if (useRight) {
+      layerEl.style.setProperty(
+        "--js-dropdown-left",
+        `${anchorRect.right - layerRect.left + anchorGap}px`,
+      );
+    } else {
+      layerEl.style.setProperty(
+        "--js-dropdown-left",
+        `${anchorRect.left - layerRect.left - layerRect.width - anchorGap}px`,
+      );
+    }
+
+    // Vertically center relative to anchor
+    const anchorMid = anchorRect.top + anchorRect.height / 2;
     layerEl.style.setProperty(
       "--js-dropdown-top",
-      `${anchorRect.bottom - layerRect.top + anchorGap}px`,
+      `${anchorMid - layerRect.top - layerRect.height / 2}px`,
     );
     layerEl.style.removeProperty("--js-dropdown-bottom");
-  }
+  } else {
+    // top/bottom placement
+    const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
+    const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
+    const shouldFlip =
+      placement === "bottom"
+        ? spaceAbove > spaceBelow
+        : spaceBelow > spaceAbove;
+    const useAbove =
+      (placement === "top" && !shouldFlip) ||
+      (placement === "bottom" && shouldFlip);
 
-  layerEl.style.setProperty(
-    "--js-dropdown-left",
-    `${anchorRect.left - layerRect.left}px`,
-  );
+    if (useAbove) {
+      layerEl.style.setProperty(
+        "--js-dropdown-bottom",
+        `${vvHeight - anchorRect.top + anchorGap}px`,
+      );
+      layerEl.style.removeProperty("--js-dropdown-top");
+    } else {
+      layerEl.style.setProperty(
+        "--js-dropdown-top",
+        `${anchorRect.bottom - layerRect.top + anchorGap}px`,
+      );
+      layerEl.style.removeProperty("--js-dropdown-bottom");
+    }
+
+    layerEl.style.setProperty(
+      "--js-dropdown-left",
+      `${anchorRect.left - layerRect.left}px`,
+    );
+  }
 
   if (matchWidth) {
     layerEl.style.setProperty("--js-dropdown-width", `${anchorRect.width}px`);
@@ -100,6 +145,7 @@ const useAnchorPolyfill = ({
   matchWidth = false,
   isOpen,
   setIsOpen,
+  placement = "bottom",
 }: UseAnchorPolyfillParams) => {
   const isAnchorPositionSupported = useSupportsAnchorPositioning();
 
@@ -112,7 +158,7 @@ const useAnchorPolyfill = ({
     const layerEl = layerRef.current;
     if (!anchorEl || !layerEl) return;
 
-    const calculateArgs = [anchorEl, layerEl, matchWidth] as const;
+    const calculateArgs = [anchorEl, layerEl, matchWidth, placement] as const;
 
     const armObserver = () => {
       if (disposed) return;
@@ -186,6 +232,7 @@ const useAnchorPolyfill = ({
     matchWidth,
     isOpen,
     setIsOpen,
+    placement,
   ]);
 
   return {

--- a/src/hooks/useSupportsAnchoredContainerQueries/index.ts
+++ b/src/hooks/useSupportsAnchoredContainerQueries/index.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+
+/**
+ * Hook to detect if the browser supports CSS anchored container queries.
+ * This is a newer feature that allows styling descendants of an
+ * anchor-positioned element based on which position-try fallback is active.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Anchor_positioning/Anchored_container_queries
+ */
+const useSupportsAnchoredContainerQueries = (): boolean => {
+  const isSupported = useMemo<boolean>(() => {
+    if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+      return false;
+    }
+    return CSS.supports("container-type", "anchored");
+  }, []);
+
+  return isSupported;
+};
+
+export default useSupportsAnchoredContainerQueries;


### PR DESCRIPTION
Relates to NDS-2532

Replace `react-laag` with our CSS-native positioning engine for Tooltip.

- Add `placement` option to useDropdownLayer for preferred placement (tooltip goes on top)
- improve accessibility properties
- add a browser support hook for **anchored container style queries** used to position the arrow
- use style queries in Tooltip CSS to dynamically position the arrow
- update `MenuButton` to use the same positioning hook, for compatibility of using `Tooltip` as a trigger element for other popup menus

### What is a style query?

With the addition of CSS-only positioning with "try fallbacks", the need arose to be able to conditionally style something based on the style of something else. To do this, you must first make the element you want to read a container type of `anchor`:

```css
.myContainer {
  container-type: anchored;
}
```

Now consider this query. Let's say some JS toggles visibility, but we want CSS to be responsible for adding an outline:

```css
@container anchored(visibility: hidden) { /* true/false conditional for rules inside */
   .myContainer {
      outline: 1px solid red; /* outline it when visually hidden */
   }
}
```
In this example, the `.myContainer` selector inside the directive will use the first `anchored` ancestor it finds, starting with itself. Aside from proximity, you can also give containers unique names to query with `container-name`.

For `Tooltip`, we want to measure the `fallback` property. If the tooltip has fallen back to bottom positioning, we can use that information to change the position of the arrow. **No js needed :)**

### What about older browsers?
They'll get a tooltip without an arrow. `placement` only supports top/bottom try fallbacks in the JS polyfill.
This is all fine, and how progressive enhancement is meant to be