### PR TITLE
Nds 2532/all layers use usedropdownlayer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "raf-schd": "^4.0.3",
         "react-aria-components": "^1.0.0",
         "react-focus-lock": "^2.9.4",
-        "react-laag": "^2.0.3",
         "react-transition-group": "^4.4.5",
         "usehooks-ts": "^3.1.1"
       },
@@ -22720,18 +22719,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/react-laag": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-laag/-/react-laag-2.0.5.tgz",
-      "integrity": "sha512-RCvublJhdcgGRHU1wMYJ8kRtnYsKUgYusLvVhMuftg65POnnOB4+fwXvnETm6adc0cMnc1spujlrK6bGIz6aug==",
-      "dependencies": {
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -25729,11 +25716,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
     "raf-schd": "^4.0.3",
     "react-aria-components": "^1.0.0",
     "react-focus-lock": "^2.9.4",
-    "react-laag": "^2.0.3",
     "react-transition-group": "^4.4.5",
     "usehooks-ts": "^3.1.1"
   },

--- a/src/AnchoredDialog/index.scss
+++ b/src/AnchoredDialog/index.scss
@@ -28,4 +28,5 @@
   padding: var(--space-xs) var(--space-xl) var(--space-xs) var(--space-default);
   overflow-y: auto;
   min-height: 0;
+  max-height: 33vh;
 }

--- a/src/ContextMenu/index.stories.tsx
+++ b/src/ContextMenu/index.stories.tsx
@@ -43,6 +43,14 @@ Overview.args = {
     />,
   ],
 };
+Overview.parameters = {
+  docs: {
+    description: {
+      story:
+        "Right-click on the element to open the context menu. Best viewed in Canvas view or as a standalone page.",
+    },
+  },
+};
 
 export default {
   title: "Components/ContextMenu",

--- a/src/ContextMenu/index.test.tsx
+++ b/src/ContextMenu/index.test.tsx
@@ -386,6 +386,26 @@ describe("ContextMenu", () => {
       });
     });
 
+    it("closes menu when a native contextmenu event fires on the document", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+
+      // Open menu
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+
+      // Simulate native contextmenu event (e.g. Shift+F10 or right-click elsewhere)
+      fireEvent.contextMenu(document.body);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+      });
+    });
+
     it("handles mouse events correctly", () => {
       renderContextMenu();
 

--- a/src/ContextMenu/index.test.tsx
+++ b/src/ContextMenu/index.test.tsx
@@ -84,25 +84,6 @@ vi.mock("react-aria-components", () => {
   };
 });
 
-// Mock react-laag
-vi.mock("react-laag", () => ({
-  useLayer: vi.fn(() => ({
-    renderLayer: (content) => content,
-    triggerProps: {},
-    layerProps: {},
-  })),
-  useMousePositionAsTrigger: () => ({
-    handleMouseEvent: vi.fn(),
-    trigger: { current: null },
-    parentRef: { current: null },
-  }),
-}));
-
-// Mock DOM utility
-vi.mock("../util/dom", () => ({
-  createUseLayerContainer: vi.fn(),
-}));
-
 const defaultProps: ContextMenuProps = {
   children: <div>Right-click me</div>,
   menuItems: [

--- a/src/ContextMenu/index.test.tsx
+++ b/src/ContextMenu/index.test.tsx
@@ -366,6 +366,26 @@ describe("ContextMenu", () => {
       });
     });
 
+    it("closes menu when clicking outside the menu layer", async () => {
+      const user = userEvent.setup();
+      renderContextMenu();
+
+      // Open menu
+      const triggerElement = screen.getByText("Right-click me");
+      await user.pointer({ keys: "[MouseRight]", target: triggerElement });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("menu")).toBeInTheDocument();
+      });
+
+      // Simulate mousedown outside the layer element
+      fireEvent.mouseDown(document.body);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("menu")).not.toBeInTheDocument();
+      });
+    });
+
     it("handles mouse events correctly", () => {
       renderContextMenu();
 

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef, useCallback } from "react";
 import { MenuTrigger, Menu, MenuItem } from "react-aria-components";
-import { useLayer, useMousePositionAsTrigger } from "react-laag";
 import cc from "classcat";
 import ContextMenuItem from "./ContextMenuItem";
 import Row from "../Row";
-import { createUseLayerContainer } from "../util/dom";
+import useDropdownLayer from "../hooks/useDropdownLayer";
 
 export interface ContextMenuProps {
   /** Optional value for `data-testid` attribute */
@@ -22,32 +21,30 @@ export interface ContextMenuProps {
  */
 function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [isMouseOverEventEnabled, setIsMouseOverEventEnabled] =
-    React.useState(true);
-  const { handleMouseEvent, trigger, parentRef } = useMousePositionAsTrigger({
-    enabled: isMouseOverEventEnabled,
+  const parentRef = useRef<HTMLDivElement>(null);
+  const virtualAnchorRef = useRef<HTMLDivElement>(null);
+
+  const { anchorProps, layerProps } = useDropdownLayer({
+    isOpen,
+    setIsOpen,
+    matchWidth: false,
+    placement: "bottom",
   });
 
-  const { renderLayer, triggerProps, layerProps } = useLayer({
-    isOpen,
-    auto: true,
-    onOutsideClick: () => {
-      setIsOpen(false);
-      setIsMouseOverEventEnabled(true);
-    },
-    preferX: "right",
-    preferY: "bottom",
-    placement: "bottom-start",
-    trigger,
-    container: createUseLayerContainer,
-  });
+  // Override the anchor ref to point to our virtual anchor element
+  const { ref: _anchorRef, ...anchorRest } = anchorProps;
+  const { ref: layerRef, ...layerRest } = layerProps;
 
   function handleContextMenuClick(
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) {
     event.preventDefault();
+    // Position the virtual anchor at the mouse cursor
+    if (virtualAnchorRef.current) {
+      virtualAnchorRef.current.style.top = `${event.clientY}px`;
+      virtualAnchorRef.current.style.left = `${event.clientX}px`;
+    }
     setIsOpen(true);
-    setIsMouseOverEventEnabled(false);
   }
 
   function handleContextMenuKeyDown(
@@ -55,12 +52,17 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   ) {
     event.preventDefault();
     if (event.key === "F12" && event.ctrlKey) {
+      // Position virtual anchor near the target element center
+      if (virtualAnchorRef.current && parentRef.current) {
+        const rect = parentRef.current.getBoundingClientRect();
+        virtualAnchorRef.current.style.top = `${rect.top + rect.height / 2}px`;
+        virtualAnchorRef.current.style.left = `${rect.left + rect.width / 2}px`;
+      }
       setIsOpen(true);
-      setIsMouseOverEventEnabled(false);
     }
   }
 
-  const handleOnSelect = (itemId) => {
+  const handleOnSelect = (itemId: React.Key) => {
     const selectedItem = menuItems.find((item) => item.props.id === itemId);
 
     if (selectedItem?.props.onSelect) {
@@ -70,43 +72,69 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
       );
     }
     setIsOpen(false);
-    setIsMouseOverEventEnabled(true);
   };
 
-  const handleKeyUp = ({ key }) => {
-    if (key === "Escape" && isOpen) {
-      setIsOpen(false);
-      setIsMouseOverEventEnabled(true);
-    }
-  };
+  const handleKeyUp = useCallback(
+    ({ key }: KeyboardEvent) => {
+      if (key === "Escape" && isOpen) {
+        setIsOpen(false);
+      }
+    },
+    [isOpen],
+  );
 
-  const handleNativeContextMenu = (event: MouseEvent) => {
+  const handleNativeContextMenu = useCallback((event: MouseEvent) => {
     if (!parentRef.current?.contains(event.target as Node)) {
       setIsOpen(false);
-      setIsMouseOverEventEnabled(true);
     }
-  };
+  }, []);
 
   useEffect(() => {
     window.addEventListener("keyup", handleKeyUp);
-    // Right click event listener
     window.addEventListener("contextmenu", handleNativeContextMenu);
 
     return () => {
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("contextmenu", handleNativeContextMenu);
     };
-  }, [handleKeyUp]);
+  }, [handleKeyUp, handleNativeContextMenu]);
+
   return (
     <MenuTrigger
       isOpen={true}
-      onOpenChange={(isOpen) => {
-        if (isOpen) {
-          setIsOpen(isOpen);
+      onOpenChange={(open) => {
+        if (open) {
+          setIsOpen(open);
         }
       }}
       data-testid={testId}
     >
+      {/* Hidden zero-size element positioned at mouse cursor, used as CSS anchor */}
+      <div
+        ref={(el) => {
+          (
+            virtualAnchorRef as React.MutableRefObject<HTMLDivElement | null>
+          ).current = el;
+          // Also assign to the anchorProps ref so useDropdownLayer tracks this element
+          if (typeof anchorProps.ref === "function") {
+            anchorProps.ref(el);
+          } else if (anchorProps.ref) {
+            (
+              anchorProps.ref as React.MutableRefObject<HTMLElement | null>
+            ).current = el;
+          }
+        }}
+        {...(anchorRest as React.HTMLAttributes<HTMLDivElement>)}
+        style={{
+          ...anchorRest.style,
+          position: "fixed",
+          width: 0,
+          height: 0,
+          pointerEvents: "none" as const,
+          overflow: "hidden",
+        }}
+        aria-hidden="true"
+      />
       <div
         ref={parentRef}
         role="button"
@@ -114,55 +142,56 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
         aria-label="Press Control + F12 to open the context menu"
         onContextMenu={handleContextMenuClick}
         onKeyDown={handleContextMenuKeyDown}
-        onMouseMove={handleMouseEvent}
-        {...triggerProps}
       >
         {children}
       </div>
-      {isOpen &&
-        renderLayer(
-          <div className="nds-context-menu-popover" {...layerProps}>
-            <Menu
-              onAction={handleOnSelect}
-              className="nds-context-menu rounded--all elevation--high"
-            >
-              {menuItems.map((menuItem, menuItemIndex) => {
-                return (
-                  <MenuItem
-                    key={menuItem.props.id}
-                    id={menuItem.props.id}
-                    value={menuItem.props.id}
-                    className={({ isSelected, isFocused, isDisabled }) =>
-                      cc([
-                        "nds-context-menu-item",
-                        "padding--x--s padding--y--xs",
-                        {
-                          "nds-context-menu-item--highlighted":
-                            isSelected || isFocused,
-                          "nds-context-menu-item--disabled": isDisabled,
-                          "rounded--top": menuItemIndex === 0,
-                          "rounded--bottom":
-                            menuItemIndex === menuItems.length - 1,
-                        },
-                      ])
-                    }
-                  >
-                    <Row gapSize="s">
-                      {menuItem.props.startIcon && (
-                        <Row.Item shrink>
-                          <span
-                            className={`narmi-icon-${menuItem.props.startIcon}`}
-                          />
-                        </Row.Item>
-                      )}
-                      <Row.Item>{menuItem.props.label}</Row.Item>
-                    </Row>
-                  </MenuItem>
-                );
-              })}
-            </Menu>
-          </div>,
+      <div
+        ref={layerRef as React.Ref<HTMLDivElement>}
+        className="nds-context-menu-popover"
+        {...(layerRest as React.HTMLAttributes<HTMLDivElement>)}
+      >
+        {isOpen && (
+          <Menu
+            onAction={handleOnSelect}
+            className="nds-context-menu rounded--all elevation--high"
+          >
+            {menuItems.map((menuItem, menuItemIndex) => {
+              return (
+                <MenuItem
+                  key={menuItem.props.id}
+                  id={menuItem.props.id}
+                  value={menuItem.props.id}
+                  className={({ isSelected, isFocused, isDisabled }) =>
+                    cc([
+                      "nds-context-menu-item",
+                      "padding--x--s padding--y--xs",
+                      {
+                        "nds-context-menu-item--highlighted":
+                          isSelected || isFocused,
+                        "nds-context-menu-item--disabled": isDisabled,
+                        "rounded--top": menuItemIndex === 0,
+                        "rounded--bottom":
+                          menuItemIndex === menuItems.length - 1,
+                      },
+                    ])
+                  }
+                >
+                  <Row gapSize="s">
+                    {menuItem.props.startIcon && (
+                      <Row.Item shrink>
+                        <span
+                          className={`narmi-icon-${menuItem.props.startIcon}`}
+                        />
+                      </Row.Item>
+                    )}
+                    <Row.Item>{menuItem.props.label}</Row.Item>
+                  </Row>
+                </MenuItem>
+              );
+            })}
+          </Menu>
         )}
+      </div>
     </MenuTrigger>
   );
 }

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -30,7 +30,7 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     isOpen,
     setIsOpen,
     matchWidth: false,
-    placement: "bottom-start",
+    placement: "bottom",
   });
 
   const { ref: layerRef, ...layerRest } = layerProps;

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -86,11 +86,15 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
       if (key === "Escape") setIsOpen(false);
     };
 
+    const handleNativeContextMenu = () => setIsOpen(false);
+
     document.addEventListener("mousedown", handleDismiss);
     window.addEventListener("keyup", handleEscape);
+    document.addEventListener("contextmenu", handleNativeContextMenu);
     return () => {
       document.removeEventListener("mousedown", handleDismiss);
       window.removeEventListener("keyup", handleEscape);
+      document.removeEventListener("contextmenu", handleNativeContextMenu);
     };
   }, [isOpen]);
 

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -33,7 +33,6 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     placement: "bottom",
   });
 
-  const { ref: _anchorRef, ...anchorRest } = anchorProps;
   const { ref: layerRef, ...layerRest } = layerProps;
 
   function handleContextMenuClick(
@@ -107,18 +106,9 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     >
       {/* 1x1px invisible element positioned at mouse cursor, used as CSS anchor */}
       <div
-        ref={(el) => {
-          if (typeof anchorProps.ref === "function") {
-            anchorProps.ref(el);
-          } else if (anchorProps.ref) {
-            (
-              anchorProps.ref as React.MutableRefObject<HTMLElement | null>
-            ).current = el;
-          }
-        }}
-        {...(anchorRest as React.HTMLAttributes<HTMLDivElement>)}
+        ref={anchorProps.ref as React.Ref<HTMLDivElement>}
         style={{
-          ...anchorRest.style,
+          ...anchorProps.style,
           position: "fixed",
           top: anchorPosition.top,
           left: anchorPosition.left,

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -46,8 +46,8 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   function handleContextMenuKeyDown(
     event: React.KeyboardEvent<HTMLDivElement>,
   ) {
-    event.preventDefault();
     if (event.key === "F12" && event.ctrlKey) {
+      event.preventDefault();
       const rect = event.currentTarget.getBoundingClientRect();
       setAnchorPosition({
         top: rect.top + rect.height / 2,

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from "react";
+import React, { useEffect } from "react";
 import { MenuTrigger, Menu, MenuItem } from "react-aria-components";
 import cc from "classcat";
 import ContextMenuItem from "./ContextMenuItem";
@@ -21,8 +21,10 @@ export interface ContextMenuProps {
  */
 function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   const [isOpen, setIsOpen] = React.useState(false);
-  const parentRef = useRef<HTMLDivElement>(null);
-  const virtualAnchorRef = useRef<HTMLDivElement>(null);
+  const [anchorPosition, setAnchorPosition] = React.useState({
+    top: 0,
+    left: 0,
+  });
 
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
@@ -31,7 +33,6 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     placement: "bottom",
   });
 
-  // Override the anchor ref to point to our virtual anchor element
   const { ref: _anchorRef, ...anchorRest } = anchorProps;
   const { ref: layerRef, ...layerRest } = layerProps;
 
@@ -39,11 +40,7 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) {
     event.preventDefault();
-    // Position the virtual anchor at the mouse cursor
-    if (virtualAnchorRef.current) {
-      virtualAnchorRef.current.style.top = `${event.clientY}px`;
-      virtualAnchorRef.current.style.left = `${event.clientX}px`;
-    }
+    setAnchorPosition({ top: event.clientY, left: event.clientX });
     setIsOpen(true);
   }
 
@@ -52,12 +49,11 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
   ) {
     event.preventDefault();
     if (event.key === "F12" && event.ctrlKey) {
-      // Position virtual anchor near the target element center
-      if (virtualAnchorRef.current && parentRef.current) {
-        const rect = parentRef.current.getBoundingClientRect();
-        virtualAnchorRef.current.style.top = `${rect.top + rect.height / 2}px`;
-        virtualAnchorRef.current.style.left = `${rect.left + rect.width / 2}px`;
-      }
+      const rect = event.currentTarget.getBoundingClientRect();
+      setAnchorPosition({
+        top: rect.top + rect.height / 2,
+        left: rect.left + rect.width / 2,
+      });
       setIsOpen(true);
     }
   }
@@ -74,48 +70,44 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     setIsOpen(false);
   };
 
-  const handleKeyUp = useCallback(
-    ({ key }: KeyboardEvent) => {
-      if (key === "Escape" && isOpen) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleDismiss = (event: MouseEvent) => {
+      const layer =
+        typeof layerRef === "object"
+          ? (layerRef as React.RefObject<HTMLElement>)?.current
+          : null;
+      if (layer && !layer.contains(event.target as Node)) {
         setIsOpen(false);
       }
-    },
-    [isOpen],
-  );
-
-  const handleNativeContextMenu = useCallback((event: MouseEvent) => {
-    if (!parentRef.current?.contains(event.target as Node)) {
-      setIsOpen(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("keyup", handleKeyUp);
-    window.addEventListener("contextmenu", handleNativeContextMenu);
-
-    return () => {
-      window.removeEventListener("keyup", handleKeyUp);
-      window.removeEventListener("contextmenu", handleNativeContextMenu);
     };
-  }, [handleKeyUp, handleNativeContextMenu]);
+
+    const handleEscape = ({ key }: KeyboardEvent) => {
+      if (key === "Escape") setIsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleDismiss);
+    window.addEventListener("keyup", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleDismiss);
+      window.removeEventListener("keyup", handleEscape);
+    };
+  }, [isOpen]);
 
   return (
     <MenuTrigger
       isOpen={true}
-      onOpenChange={(open) => {
-        if (open) {
-          setIsOpen(open);
+      onOpenChange={(isOpen) => {
+        if (isOpen) {
+          setIsOpen(isOpen);
         }
       }}
       data-testid={testId}
     >
-      {/* Hidden zero-size element positioned at mouse cursor, used as CSS anchor */}
+      {/* 1x1px invisible element positioned at mouse cursor, used as CSS anchor */}
       <div
         ref={(el) => {
-          (
-            virtualAnchorRef as React.MutableRefObject<HTMLDivElement | null>
-          ).current = el;
-          // Also assign to the anchorProps ref so useDropdownLayer tracks this element
           if (typeof anchorProps.ref === "function") {
             anchorProps.ref(el);
           } else if (anchorProps.ref) {
@@ -128,15 +120,16 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
         style={{
           ...anchorRest.style,
           position: "fixed",
-          width: 0,
-          height: 0,
+          top: anchorPosition.top,
+          left: anchorPosition.left,
+          width: 1,
+          height: 1,
           pointerEvents: "none" as const,
-          overflow: "hidden",
+          opacity: 0,
         }}
         aria-hidden="true"
       />
       <div
-        ref={parentRef}
         role="button"
         tabIndex={0}
         aria-label="Press Control + F12 to open the context menu"

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -123,6 +123,8 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
         role="button"
         tabIndex={0}
         aria-label="Press Control + F12 to open the context menu"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
         onContextMenu={handleContextMenuClick}
         onKeyDown={handleContextMenuKeyDown}
       >

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -30,7 +30,7 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
     isOpen,
     setIsOpen,
     matchWidth: false,
-    placement: "bottom",
+    placement: "bottom-start",
   });
 
   const { ref: layerRef, ...layerRest } = layerProps;

--- a/src/ContextMenu/index.tsx
+++ b/src/ContextMenu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { MenuTrigger, Menu, MenuItem } from "react-aria-components";
 import cc from "classcat";
 import ContextMenuItem from "./ContextMenuItem";
@@ -20,6 +20,7 @@ export interface ContextMenuProps {
  * The menu can be trigger by right-clicking on the element or by pressing Control + F12.
  */
 function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
+  const triggerRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [anchorPosition, setAnchorPosition] = React.useState({
     top: 0,
@@ -86,7 +87,15 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
       if (key === "Escape") setIsOpen(false);
     };
 
-    const handleNativeContextMenu = () => setIsOpen(false);
+    const handleNativeContextMenu = (event: MouseEvent) => {
+      if (
+        triggerRef.current &&
+        triggerRef.current.contains(event.target as Node)
+      ) {
+        return;
+      }
+      setIsOpen(false);
+    };
 
     document.addEventListener("mousedown", handleDismiss);
     window.addEventListener("keyup", handleEscape);
@@ -124,6 +133,7 @@ function ContextMenu({ menuItems, testId, children }: ContextMenuProps) {
         aria-hidden="true"
       />
       <div
+        ref={triggerRef}
         role="button"
         tabIndex={0}
         aria-label="Press Control + F12 to open the context menu"

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -20,13 +20,10 @@ const noop = () => {};
  */
 const Popover = ({
   side = "bottom",
-  alignment = "center",
   content,
   children,
   renderTrigger = () => <></>,
   wrapperDisplay = "inline-flex",
-  offset = 2,
-  disableAutoPlacement = false,
   matchTriggerWidth = false,
   testId,
   closeOnContentClick = false,
@@ -169,11 +166,7 @@ Popover.propTypes = {
   renderTrigger: PropTypes.func,
   /** Sets preferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
-  /**
-   * ⚠️ DEPRECATED - this prop is no longer used.
-   * Sets preferred alignment of the tooltip relative to the trigger
-   */
-  alignment: PropTypes.oneOf(["start", "center", "end"]),
+
   /** CSS `display` value for the element that wraps the Tooltip children */
   wrapperDisplay: PropTypes.oneOf([
     "inline-flex",
@@ -182,17 +175,10 @@ Popover.propTypes = {
     "block",
     "flex",
   ]),
-  /** Distance of Popover from trigger element in number of pixels */
-  offset: PropTypes.number,
+
   /** When `true`, the Popover container will match the width of its triggering element */
   matchTriggerWidth: PropTypes.bool,
-  /**
-   * ⚠️ DEPRECATED - this prop is no longer used.
-   * By default, the Popover will automatically reposition itself to avoid viewport edges.
-   * Setting this prop to `true` will disable this behavior so that the Popover will
-   * always be placed on the given `side` prop.
-   */
-  disableAutoPlacement: PropTypes.bool,
+
   /** Optional value for `data-testid` attribute */
   testId: PropTypes.string,
   /** Close the popover if the User clicks on the content */

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -2,9 +2,8 @@
 import React, { useState, useEffect } from "react";
 import cc from "classcat";
 import PropTypes from "prop-types";
-import { useLayer } from "react-laag";
 import FocusLock from "react-focus-lock";
-import { createUseLayerContainer } from "src/util/dom";
+import useDropdownLayer from "../hooks/useDropdownLayer";
 
 const noop = () => {};
 
@@ -81,17 +80,35 @@ const Popover = ({
     }
   };
 
-  const { renderLayer, triggerProps, triggerBounds, layerProps } = useLayer({
+  const { anchorProps, layerProps } = useDropdownLayer({
     isOpen: shouldRenderPopover,
-    onOutsideClick: closePopover,
-    onDisappear: closePopover,
-    auto: !disableAutoPlacement,
-    placement: `${side}-${alignment}`,
-    preferX: "left",
-    preferY: "bottom",
-    container: createUseLayerContainer,
-    triggerOffset: offset,
+    setIsOpen: (v) => {
+      if (!v) closePopover();
+    },
+    matchWidth: matchTriggerWidth,
+    placement: side,
   });
+
+  const { ref: anchorRef, style: anchorStyle, ...anchorRest } = anchorProps;
+  const { ref: layerRef, ...layerRest } = layerProps;
+
+  useEffect(() => {
+    if (!shouldRenderPopover) return;
+    const handleOutsideClick = (event) => {
+      const anchor = typeof anchorRef === "object" ? anchorRef?.current : null;
+      const layer = typeof layerRef === "object" ? layerRef?.current : null;
+      if (
+        anchor &&
+        !anchor.contains(event.target) &&
+        layer &&
+        !layer.contains(event.target)
+      ) {
+        closePopover();
+      }
+    };
+    document.addEventListener("click", handleOutsideClick);
+    return () => document.removeEventListener("click", handleOutsideClick);
+  }, [shouldRenderPopover]);
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyUp);
@@ -100,19 +117,12 @@ const Popover = ({
     };
   }, [handleKeyUp]);
 
-  let layerStyle = layerProps.style;
-  if (triggerBounds && matchTriggerWidth) {
-    layerStyle = {
-      width: triggerBounds.width,
-      ...layerProps.style,
-    };
-  }
-
   return (
     <>
       <div
-        {...triggerProps}
-        style={{ display: wrapperDisplay }}
+        ref={anchorRef}
+        {...anchorRest}
+        style={{ ...anchorStyle, display: wrapperDisplay }}
         onClick={togglePopover}
         onKeyDown={handleKeyDown}
         role="button"
@@ -125,28 +135,25 @@ const Popover = ({
         {/* Support both legacy (children) and standard (render prop) triggers */}
         {hasChildren ? children : renderTrigger(isOpen)}
       </div>
-      {renderLayer(
-        <>
-          {shouldRenderPopover && (
-            <div
-              {...layerProps}
-              className={cc([
-                "nds-typography nds-popover",
-                "rounded--all bgColor--white",
-                {
-                  "nds-popover--elevated": hasShadow,
-                },
-              ])}
-              style={layerStyle}
-              data-testid={testId}
-            >
-              <div tabIndex={-1}>
-                <FocusLock autoFocus={autoFocus}>{popoverContent}</FocusLock>
-              </div>
-            </div>
-          )}
-        </>,
-      )}
+      <div
+        ref={layerRef}
+        {...layerRest}
+        className={cc([
+          "nds-typography nds-popover",
+          "rounded--all bgColor--white",
+          {
+            "nds-popover--elevated": hasShadow,
+          },
+        ])}
+        style={layerRest.style}
+        data-testid={testId}
+      >
+        {shouldRenderPopover && (
+          <div tabIndex={-1}>
+            <FocusLock autoFocus={autoFocus}>{popoverContent}</FocusLock>
+          </div>
+        )}
+      </div>
     </>
   );
 };
@@ -166,7 +173,10 @@ Popover.propTypes = {
   renderTrigger: PropTypes.func,
   /** Sets preferred side of the trigger the tooltip should appear */
   side: PropTypes.oneOf(["top", "right", "bottom", "left"]),
-  /** Sets preferred alignment of the tooltip relative to the trigger */
+  /**
+   * ⚠️ DEPRECATED - this prop is no longer used.
+   * Sets preferred alignment of the tooltip relative to the trigger
+   */
   alignment: PropTypes.oneOf(["start", "center", "end"]),
   /** CSS `display` value for the element that wraps the Tooltip children */
   wrapperDisplay: PropTypes.oneOf([
@@ -181,6 +191,7 @@ Popover.propTypes = {
   /** When `true`, the Popover container will match the width of its triggering element */
   matchTriggerWidth: PropTypes.bool,
   /**
+   * ⚠️ DEPRECATED - this prop is no longer used.
    * By default, the Popover will automatically reposition itself to avoid viewport edges.
    * Setting this prop to `true` will disable this behavior so that the Popover will
    * always be placed on the given `side` prop.

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-autofocus */
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import cc from "classcat";
 import PropTypes from "prop-types";
 import FocusLock from "react-focus-lock";
@@ -49,10 +49,10 @@ const Popover = ({
       })
     : content;
 
-  const closePopover = () => {
+  const closePopover = useCallback(() => {
     setOpen(false);
     onUserDismiss();
-  };
+  }, [onUserDismiss]);
 
   const togglePopover = (event) => {
     event.stopPropagation();
@@ -108,7 +108,7 @@ const Popover = ({
       document.removeEventListener("mousedown", handleOutsideClick);
       window.removeEventListener("keydown", handleEscape);
     };
-  }, [shouldRenderPopover]);
+  }, [shouldRenderPopover, closePopover, anchorRef, layerRef]);
 
   return (
     <>

--- a/src/Popover/index.js
+++ b/src/Popover/index.js
@@ -73,13 +73,6 @@ const Popover = ({
     }
   };
 
-  const handleKeyUp = ({ key }) => {
-    if (key === "Escape" && shouldRenderPopover) {
-      setOpen(false);
-      onUserDismiss();
-    }
-  };
-
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen: shouldRenderPopover,
     setIsOpen: (v) => {
@@ -94,6 +87,7 @@ const Popover = ({
 
   useEffect(() => {
     if (!shouldRenderPopover) return;
+
     const handleOutsideClick = (event) => {
       const anchor = typeof anchorRef === "object" ? anchorRef?.current : null;
       const layer = typeof layerRef === "object" ? layerRef?.current : null;
@@ -106,16 +100,18 @@ const Popover = ({
         closePopover();
       }
     };
-    document.addEventListener("click", handleOutsideClick);
-    return () => document.removeEventListener("click", handleOutsideClick);
-  }, [shouldRenderPopover]);
 
-  useEffect(() => {
-    window.addEventListener("keydown", handleKeyUp);
-    return () => {
-      window.removeEventListener("keydown", handleKeyUp);
+    const handleEscape = ({ key }) => {
+      if (key === "Escape") closePopover();
     };
-  }, [handleKeyUp]);
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    window.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [shouldRenderPopover]);
 
   return (
     <>

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -55,17 +55,15 @@ export const Positioning = Template.bind({});
 Positioning.args = {
   content: (
     <div className="padding--all--m">
-      Use <code>side</code> and <code>alignment</code> to set your preferred
-      positioning
+      Use <code>side</code> to set your preferred positioning
     </div>
   ),
   renderTrigger: () => (
     <Button type="button" kind="secondary">
-      Top / Start positioned Popover
+      Top positioned Popover
     </Button>
   ),
   side: "top",
-  alignment: "start",
 };
 Positioning.argTypes = {
   content: { control: false },
@@ -128,4 +126,8 @@ Controlled.parameters = {
 export default {
   title: "Components/Popover",
   component: Popover,
+  argTypes: {
+    alignment: { table: { disable: true } },
+    disableAutoPlacement: { table: { disable: true } },
+  },
 };

--- a/src/Popover/index.test.js
+++ b/src/Popover/index.test.js
@@ -45,7 +45,7 @@ describe("Popover", () => {
     expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
     fireEvent.click(trigger);
     expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
-    fireEvent.click(document.body);
+    fireEvent.mouseDown(document.body);
     expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
   });
 
@@ -98,7 +98,7 @@ describe("Popover", () => {
     expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
     act(() => fireEvent.click(trigger));
     expect(screen.queryByText(CONTENT_TEXT)).toBeInTheDocument();
-    act(() => fireEvent.click(document.body));
+    act(() => fireEvent.mouseDown(document.body));
     expect(screen.queryByText(CONTENT_TEXT)).not.toBeInTheDocument();
 
     expect(onUserDismiss).toHaveBeenCalledTimes(1);

--- a/src/TableAutocomplete/index.tsx
+++ b/src/TableAutocomplete/index.tsx
@@ -106,6 +106,7 @@ const TableAutocomplete = ({
     getInputProps,
     getItemProps,
     isOpen,
+    closeMenu,
   } = useCombobox({
     items: itemsToDisplay,
     selectedItem,
@@ -136,7 +137,9 @@ const TableAutocomplete = ({
 
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
-    setIsOpen: () => {},
+    setIsOpen: (open: boolean) => {
+      if (!open) closeMenu();
+    },
     matchWidth: true,
     placement: "bottom",
   });

--- a/src/TableAutocomplete/index.tsx
+++ b/src/TableAutocomplete/index.tsx
@@ -2,12 +2,11 @@
 import React, { useMemo } from "react";
 import cc from "classcat";
 import { useCombobox } from "downshift";
-import { useLayer } from "react-laag";
+import useDropdownLayer from "../hooks/useDropdownLayer";
 import Row from "../Row";
 import TableInput from "../TableInput";
 import Item from "./Item";
 export type { TableAutocompleteItemProps } from "./Item";
-import { createUseLayerContainer } from "../util/dom";
 
 export type TableAutocompleteItem = React.ReactElement;
 
@@ -135,22 +134,22 @@ const TableAutocomplete = ({
     },
   });
 
-  /** @see https://github.com/everweij/react-laag#api-docs */
-  const { renderLayer, triggerProps, layerProps, triggerBounds } = useLayer({
+  const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
-    overflowContainer: true,
-    auto: true,
-    snap: true,
-    placement: "bottom-start",
-    possiblePlacements: ["top-start", "bottom-start"],
-    preferY: "bottom",
-    triggerOffset: 2,
-    container: createUseLayerContainer,
+    setIsOpen: () => {},
+    matchWidth: true,
+    placement: "bottom",
   });
+
+  const { ref: anchorRef, ...anchorRest } = anchorProps;
+  const { ref: layerRef, ...layerRest } = layerProps;
 
   return (
     <div className="nds-tableAutocomplete">
-      <div {...triggerProps}>
+      <div
+        ref={anchorRef as React.Ref<HTMLDivElement>}
+        {...(anchorRest as React.HTMLAttributes<HTMLDivElement>)}
+      >
         <TableInput
           label={label}
           placeholder={!isDisabled ? placeholder : undefined}
@@ -161,16 +160,13 @@ const TableAutocomplete = ({
           })}
         />
       </div>
-      {isOpen &&
-        renderLayer(
-          <div
-            className={cc(["nds-tableAutocomplete-dropdown", "rounded--all"])}
-            {...layerProps}
-            style={{
-              ...layerProps.style,
-              width: triggerBounds?.width || "max-content",
-            }}
-          >
+      <div
+        className={cc(["nds-tableAutocomplete-dropdown", "rounded--all"])}
+        ref={layerRef as React.Ref<HTMLDivElement>}
+        {...(layerRest as React.HTMLAttributes<HTMLDivElement>)}
+      >
+        {isOpen && (
+          <>
             <ul
               className="nds-tableAutocomplete-menu list--reset rounded--all"
               {...getMenuProps()}
@@ -214,8 +210,9 @@ const TableAutocomplete = ({
                 {footerContent}
               </div>
             )}
-          </div>,
+          </>
         )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Closes NDS-2532

- Remove `react-laag` dependency entirely
- Replace all usage with the NDS `useDropdownLayer` hook

### Deprecation: `alignment`
The react-laag library supported `alignment` in addition to `side`. In the new useDropdownLayer hook, alignment is handled automatically. These props are marked deprecated now and are ignored by the components. They will be removed in the next major release.

### Special cases

#### Base `Popover`
We have some new listeners to handle the legacy `onOutsideClick` option from react-laag that we expose in the public component API.

#### `ContextMenu`
The popover appears on right click, but CSS anchor positioning needs an actual anchor element. The component now writes a 1x1 transparent element under the mouse cursor on right click within a context menu area.