### PR TITLE
feat(Chip): add isLabelVisible prop

### DIFF
--- a/src/Chip/index.stories.js
+++ b/src/Chip/index.stories.js
@@ -56,6 +56,15 @@ export const CustomIcon = () => (
   </>
 );
 
+export const IconOnly = () => (
+  <>
+    <p>
+      Chip accepts both a <code>startIcon</code> and <code>endIcon</code> prop.
+    </p>
+    <Chip kind="info" isLabelVisible={false} onClick={() => {}} endIcon="zap" />
+  </>
+);
+
 const storyIcons = ["anchor", "wifi", "sun", "phone-off", "moon", "music"];
 export const Kinds = () => (
   <ul className="list--reset">

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -34,6 +34,8 @@ export interface ChipProps {
   count?: string | number;
   /** Adds a border to the badege when `true` */
   hasBorder?: boolean;
+  /** Defines if the label is visible */
+  isLabelVisible?: boolean;
 }
 
 /**
@@ -51,6 +53,7 @@ const Chip = ({
   startIcon,
   endIcon,
   hasBorder = false,
+  isLabelVisible = true,
 }: ChipProps) => {
   const isButton = typeof onClick === "function";
   const isDismissable = !isButton && typeof onDismiss === "function";
@@ -61,6 +64,7 @@ const Chip = ({
       elementType={isButton ? "button" : "div"}
       onClick={isButton ? onClick : undefined}
       type={isButton ? "button" : undefined}
+      aria-label={isLabelVisible ? undefined : label}
       className={cc([
         "nds-chip",
         "fontSize--s",
@@ -70,6 +74,7 @@ const Chip = ({
           "button--reset": isButton,
           "nds-chip--button": isButton,
           "nds-chip--hasBorder": hasBorder,
+          "padding--x--xxs": !isLabelVisible,
         },
       ])}
     >
@@ -81,9 +86,11 @@ const Chip = ({
             />
           </Row.Item>
         )}
-        <Row.Item shrink>
-          <div className="nds-chip-label whiteSpace--truncate">{label}</div>
-        </Row.Item>
+        {isLabelVisible && (
+          <Row.Item shrink>
+            <div className="nds-chip-label whiteSpace--truncate">{label}</div>
+          </Row.Item>
+        )}
         {count && (
           <Row.Item shrink>
             <Count kind={countKind} value={count} />


### PR DESCRIPTION
Adds an isLabelVisible prop to the Chip element so that we can create chips with only an Icon w/ no additional padding.

Also adds a story which displays the usage described above