### PR TITLE
fix(Checkbox): avoid sanitizing target attr in links

### DIFF
--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -148,6 +148,7 @@ const Checkbox = ({
                     marked.parse(markdownLabel, {
                       renderer: markdownRenderer,
                     }) as string,
+                    { ADD_ATTR: ["target"] },
                   ),
                 }}
               />


### PR DESCRIPTION
Closes NDS-2700

Allow `target` attribute in links when sanitizing html from markdown. This preserves the previous behavior of markdown links opening in a new window.