### PR TITLE
feat(Tabs): modernize scroll listeners for performance

### DIFF
--- a/src/Tabs/Arrow.tsx
+++ b/src/Tabs/Arrow.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useRef } from "react";
-import { CSSTransition } from "react-transition-group";
+import cc from "classcat";
+import React, { useContext } from "react";
 import IconButton from "../IconButton";
 import TabsContext from "./context";
 
@@ -11,26 +11,22 @@ interface ArrowProps {
 
 const Arrow = ({ direction, onClick, show }: ArrowProps) => {
   const { isResponsive } = useContext(TabsContext);
-  const arrowRef = useRef();
 
   return (
     isResponsive && (
       <div className="arrow-reponsive">
-        <CSSTransition
-          nodeRef={arrowRef}
-          in={show}
-          timeout={300}
-          unmountOnExit
-          classNames="nds-tabs-arrow"
+        <div
+          className={cc([
+            "nds-tabs-arrow",
+            { "nds-tabs-arrow--visible": show },
+          ])}
         >
-          <div ref={arrowRef} className="nds-tabs-arrow">
-            <IconButton
-              onClick={onClick}
-              name={direction === "left" ? "arrow-left" : "arrow-right"}
-              kind="action"
-            />
-          </div>
-        </CSSTransition>
+          <IconButton
+            onClick={onClick}
+            name={direction === "left" ? "arrow-left" : "arrow-right"}
+            kind="action"
+          />
+        </div>
       </div>
     )
   );

--- a/src/Tabs/TabsList.tsx
+++ b/src/Tabs/TabsList.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import rafSchd from "raf-schd";
 import React, { LegacyRef, useContext, useEffect, useState } from "react";
 import Arrow from "./Arrow";
 import TabsContext from "./context";
@@ -33,6 +32,7 @@ const TabsList = ({ children, xPadding = "none" }: TabsListProps) => {
   const childArray = React.Children.toArray(children);
 
   const updateScrollButtonState = () => {
+    if (!tabsListRef.current) return;
     const { scrollWidth, clientWidth, scrollLeft } = tabsListRef.current;
     const nextShowLeftArrow = scrollLeft > 1;
     const nextShowRightArrow = scrollLeft < scrollWidth - clientWidth - 1;
@@ -42,34 +42,26 @@ const TabsList = ({ children, xPadding = "none" }: TabsListProps) => {
     setIsResponsive(nextShowLeftArrow || nextShowRightArrow);
   };
 
-  const scheduleScrollButtonUpdate = () => {
-    if (tabsListRef.current) {
-      rafSchd(updateScrollButtonState());
-    }
-  };
-
+  // ResizeObserver to detect when container size changes
   useEffect(() => {
-    scheduleScrollButtonUpdate();
+    if (!tabsListRef.current) return;
+    const observer = new ResizeObserver(updateScrollButtonState);
+    observer.observe(tabsListRef.current);
+    return () => observer.disconnect();
   }, []);
 
+  // Scroll listener for touch/programmatic scroll updates
   useEffect(() => {
-    window.addEventListener("resize", scheduleScrollButtonUpdate);
-
-    return () => {
-      window.removeEventListener("resize", scheduleScrollButtonUpdate);
-    };
+    const el = tabsListRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", updateScrollButtonState);
+    return () => el.removeEventListener("scroll", updateScrollButtonState);
   }, []);
 
+  // Initial check
   useEffect(() => {
-    tabsListRef.current.addEventListener("scroll", scheduleScrollButtonUpdate);
-
-    return () => {
-      tabsListRef?.current?.removeEventListener(
-        "scroll",
-        scheduleScrollButtonUpdate,
-      );
-    };
-  }, [tabsListRef.current]);
+    updateScrollButtonState();
+  }, []);
 
   // populate tabIds state variable in root component
   // with tabId props from `Tabs.Tab` children passed into `Tabs.List`
@@ -97,38 +89,16 @@ const TabsList = ({ children, xPadding = "none" }: TabsListProps) => {
     }
   };
 
-  // Heavily inspired from https://github.com/mui/material-ui/blob/master/packages/mui-material-next/src/Tabs/Tabs.js#L395
-  const getScrollSize = () => {
-    const containerSize = tabsListRef.current.clientWidth;
-    let totalSize = 0;
-    const children = Array.from(tabsListRef.current.children);
-
-    for (let i = 0; i < children.length; i += 1) {
-      const tab = children[i];
-      if (totalSize + tab.clientWidth > containerSize) {
-        // If the first item is longer than the container size, then only scroll
-        // by the container size.
-        if (i === 0) {
-          totalSize = containerSize;
-        }
-        break;
-      }
-      totalSize += tab.clientWidth;
-    }
-
-    return totalSize;
-  };
-
   const onLeftClick = () => {
     tabsListRef.current.scroll({
-      left: tabsListRef.current.scrollLeft - getScrollSize(),
+      left: tabsListRef.current.scrollLeft - tabsListRef.current.clientWidth,
       behavior: "smooth",
     });
   };
 
   const onRightClick = () => {
     tabsListRef.current.scroll({
-      left: tabsListRef.current.scrollLeft + getScrollSize(),
+      left: tabsListRef.current.scrollLeft + tabsListRef.current.clientWidth,
       behavior: "smooth",
     });
   };

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -2,11 +2,11 @@
   display: flex;
   justify-content: flex-start;
   align-items: flex-end;
-  overflow-x: hidden;
-  scrollbar-width: "none"; // Firefox
+  overflow-x: auto;
+  scrollbar-width: none; // Firefox
 
-  &:webkit-scrollbar {
-    display: "none"; // Safari + Chrome
+  &::-webkit-scrollbar {
+    display: none; // Safari + Chrome
   }
 
   .nds-tabs--bordered & {
@@ -43,28 +43,17 @@
 
 .nds-tabs-arrow {
   padding-top: 6px;
-}
-
-.nds-tabs-arrow-enter {
-  max-width: 0px;
-  opacity: 0;
-}
-
-.nds-tabs-arrow-enter-active {
-  max-width: 32px;
-  opacity: 1;
-  transition: max-width 300ms, opacity 300ms;
-}
-
-.nds-tabs-arrow-exit {
-  max-width: 32px;
-  opacity: 1;
-}
-
-.nds-tabs-arrow-exit-active {
   max-width: 0;
   opacity: 0;
-  transition: max-width 300ms, opacity 300ms;
+  overflow: hidden;
+  transition:
+    max-width 300ms,
+    opacity 300ms;
+
+  &--visible {
+    max-width: 32px;
+    opacity: 1;
+  }
 }
 
 .arrow-reponsive {


### PR DESCRIPTION
Relates to NDS-2437

Modernizes `Tabs` responsive behavior.

- Move all transition logic into plain CSS
- Allow touch scrolling in addition to scroll buttons
- Use modern observer APIs for measuring things and responding to events

Existing behavior has been preserved:
<img width="304" height="116" alt="May-19-2026 14-04-53" src="https://github.com/user-attachments/assets/46beda01-8950-43c9-8e7d-1a2c0e484e45" />
