### PR TITLE
Fix `MenuButton` click event handling

### DIFF
--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -47,6 +47,7 @@ const MenuButton = ({
     setIsOpen,
     matchWidth: false,
     placement: side,
+    alignment: alignment,
   });
 
   const handleKeyUp = ({ key }) => {

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -52,7 +52,7 @@ const MenuButton = ({
     setIsOpen,
     matchWidth: false,
     placement: side,
-    isPortalled: true,
+    isPortalled: false,
   });
 
   const handleKeyUp = ({ key }) => {

--- a/src/MenuButton/index.js
+++ b/src/MenuButton/index.js
@@ -36,18 +36,23 @@ const MenuButton = ({
   const menuItems = React.Children.toArray(children);
   const allItems = footerItem ? menuItems.concat(footerItem) : menuItems;
   const canToggleCloseRef = useRef(isOpen);
+  const openedAtRef = useRef(0);
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);
     canToggleCloseRef.current = false;
   }, [canToggleCloseRef]);
 
+  useEffect(() => {
+    if (isOpen) openedAtRef.current = Date.now();
+  }, [isOpen]);
+
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
     setIsOpen,
     matchWidth: false,
     placement: side,
-    alignment: alignment,
+    isPortalled: true,
   });
 
   const handleKeyUp = ({ key }) => {
@@ -69,6 +74,14 @@ const MenuButton = ({
    * relevant `MenuButton.Item` and calls it.
    */
   const handleOnSelect = (itemId) => {
+    // `react-aria` uses mouse down to track open state of the menu.
+    // If the menu is positioned over the anchor in any way, the mouse up
+    // event will be captured by an item in the menu.
+    //
+    // In the long term, we should consider replacing `react-aria`
+    // with our own hooks for managing menu states.
+    if (Date.now() - openedAtRef.current < 150) return;
+
     const selectedItem = allItems.find(
       (item) => labelToItemId(item.props.label) === itemId,
     );


### PR DESCRIPTION
Closes NDS-2705

Use a timestamp guard for our menus. They're too fast for `react-aria` now, and we don't have the option to change their internal behavior of using `mousedown`, causing `mouseup` to get captured on an item.