### PR TITLE
fix(Tooltip): apply maxWidth to styles

### DIFF
--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -97,8 +97,8 @@ const Tooltip = ({
         data-placement={side}
         {...layerRest}
         style={{
-          maxWidth: maxWidth,
           ...layerRest.style,
+          maxWidth: maxWidth,
         }}
         data-testid={testId}
         onMouseEnter={openPopover}


### PR DESCRIPTION
Fixes how we apply the MaxWidth prop to the Tooltip component's styles