### PR TITLE
UI refresh/patch 1

### DIFF
--- a/src/DisabledShim/index.scss
+++ b/src/DisabledShim/index.scss
@@ -8,10 +8,8 @@
   user-select: none;
   pointer-events: none;
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  inset: 0;
   background-color: var(--bgColor-scrimLight);
+  border-radius: var(--border-radius-default);
   z-index: 2;
 }

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -168,6 +168,58 @@ ArrowTracking.parameters = {
   },
 };
 
+export const MultipleTooltips = () => (
+  <div
+    style={{
+      height: "400px",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+      gap: "var(--space-xl)",
+    }}
+  >
+    <div style={{ display: "flex", gap: "var(--space-l)" }}>
+      <Tooltip text="Tooltip on top" side="top">
+        <Button>Top</Button>
+      </Tooltip>
+      <Tooltip text="Tooltip on the right" side="right">
+        <Button>Right</Button>
+      </Tooltip>
+      <Tooltip text="Tooltip on the bottom" side="bottom">
+        <Button>Bottom</Button>
+      </Tooltip>
+      <Tooltip text="Tooltip on the left" side="left">
+        <Button>Left</Button>
+      </Tooltip>
+    </div>
+    <div
+      style={{ display: "flex", gap: "var(--space-l)", alignItems: "center" }}
+    >
+      <Tooltip text="Icon button tooltip">
+        <IconButton kind="action" name="info" />
+      </Tooltip>
+      <Tooltip text="This tooltip has a longer message to demonstrate text wrapping behavior within the tooltip container">
+        <Button kind="secondary">Long text</Button>
+      </Tooltip>
+      <Tooltip text="Inline tooltip">
+        <span style={{ textDecoration: "underline dotted", cursor: "help" }}>
+          hover this text
+        </span>
+      </Tooltip>
+    </div>
+  </div>
+);
+
+MultipleTooltips.parameters = {
+  docs: {
+    description: {
+      story:
+        "Multiple tooltips can coexist on the same page. Each tooltip operates independently, showing on hover/focus of its own trigger element.",
+    },
+  },
+};
+
 export default {
   title: "Components/Tooltip",
   component: Tooltip,

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useId } from "react";
+import React, { useState, useCallback, useId, useRef } from "react";
 import useDropdownLayer from "../hooks/useDropdownLayer";
 
 export interface TooltipProps {
@@ -40,18 +40,18 @@ const Tooltip = ({
     open: 500,
     close: 100,
   };
-  let activeTimer: ReturnType<typeof setTimeout>;
+  const activeTimer = useRef<ReturnType<typeof setTimeout>>();
 
   const shouldRenderTooltip = isControlled ? isOpen : open;
 
   const openPopover = () => {
-    clearTimeout(activeTimer);
-    activeTimer = setTimeout(setOpen, delays.open, true);
+    clearTimeout(activeTimer.current);
+    activeTimer.current = setTimeout(setOpen, delays.open, true);
   };
 
   const closePopover = useCallback(() => {
-    clearTimeout(activeTimer);
-    activeTimer = setTimeout(setOpen, delays.close, false);
+    clearTimeout(activeTimer.current);
+    activeTimer.current = setTimeout(setOpen, delays.close, false);
   }, []);
 
   const { anchorProps, layerProps } = useDropdownLayer({

--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -82,6 +82,21 @@ $breakpoints: (
   border: 1px solid var(--theme-primary);
   border-radius: var(--border-radius-default);
 
+  // Override leaking styles for overly broad selectors like
+  // `.balance-options * { display: flex; }` which can select
+  // children in a dropdown when unportalled.
+  //
+  // Long term fix is to require a cascade layer in the consumer:
+  // <https://linear.app/narmi/issue/NDS-2718/breaking-require-consumers-to-use-a-cascade-layer>
+  display: block;
+  font-size: var(--font-size-default);
+  color: var(--font-color-default);
+  text-align: start;
+  text-transform: none;
+  letter-spacing: normal;
+  line-height: var(--line-height-default);
+  padding: 0;
+
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
Fixes NDS-2708
Fixes NDS-2704
Fixes NDS-2701

Will be backported to v6.11.1 as `6.11.1-patch.1`.

- Rounds our `DisabledShim` to prevent noticeable overlap over rounded corners
- Fix timers for `Tooltip`
- Prevent anchor positioned containers from inheriting breaking properties until we introduce cascade layers everywhere