### PR TITLE
chore(dependabot): Add cooldown to GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7 day cooldown to the GitHub Action Dependabot workflow to reduce the risk of a supply chain attack