### PR TITLE
chore(ci): harden workflows per zizmor audit

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -2,7 +2,6 @@
 name: 'Chromatic PR Checks'
 permissions:
   contents: read
-  pull-requests: write
 on:
   pull_request:
     branches:
@@ -19,6 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for relevant changes
         id: changes
@@ -47,6 +47,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
@@ -88,10 +89,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check_changes, run_chromatic]
     if: needs.check_changes.outputs.has_relevant_changes == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Log run_chromatic job outputs
-        run: echo "${{ toJson(needs.run_chromatic.outputs) }}"
-
       - name: Comment Storybook URL and diff status in PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # 3.0.1
         with:
@@ -118,7 +119,7 @@ jobs:
     steps:
       - name: Set status based on changes
         run: |
-          if [ "${{ needs.check_changes.outputs.has_relevant_changes }}" = "true" ]; then
+          if [ "${NEEDS_CHECK_CHANGES_OUTPUTS_HAS_RELEVANT_CHANGES}" = "true" ]; then
             if [ "${{ needs.run_chromatic.result }}" = "success" ]; then
               echo "Chromatic checks passed"
               exit 0
@@ -130,3 +131,5 @@ jobs:
             echo "No relevant changes detected, skipping Chromatic checks"
             exit 0
           fi
+        env:
+          NEEDS_CHECK_CHANGES_OUTPUTS_HAS_RELEVANT_CHANGES: ${{ needs.check_changes.outputs.has_relevant_changes }}

--- a/.github/workflows/figma-variables.yaml
+++ b/.github/workflows/figma-variables.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v4


### PR DESCRIPTION
Addresses findings from a zizmor audit of our GitHub Actions workflows.

## Changes

### `chromatic-pr.yaml`
- **Least privilege for `pull-requests: write`**: Moved this permission from the workflow level to only the `post_chromatic_comment` job, which is the sole job that needs it (zizmor `excessive-permissions`, High confidence).
- **Removed template-injection vector**: Deleted the debug step `echo \"\${{ toJson(needs.run_chromatic.outputs) }}\"` which interpolated action outputs directly into a shell `run` block (zizmor `template-injection`).
- **Safer env-var passing**: `chromatic_status` job now reads `needs.check_changes.outputs.has_relevant_changes` via env var rather than inline `\${{ ... }}` in the shell script.

### All workflows
- **`persist-credentials: false` on every `actions/checkout`** to prevent the auto-provisioned `GITHUB_TOKEN` from being written to `.git/config` and reused by later steps.

## Verification
No functional behavior change — these are purely hardening adjustments. The removed debug echo was log-only.