### PR TITLE
fix(AsElement): sanitize href to prevent click-triggered XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2916,9 +2916,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2938,43 +2938,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3375,13 +3342,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -3402,9 +3370,10 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
     "node_modules/@internationalized/date": {
@@ -11962,26 +11931,6 @@
         "typescript": ">=5"
       }
     },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -13302,16 +13251,17 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -13679,12 +13629,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -13771,21 +13715,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -13793,18 +13722,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/optionator": {
@@ -15026,6 +14943,21 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -16861,6 +16793,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/js2xmlparser": {
       "version": "4.0.2",

--- a/src/Avatar/index.test.tsx
+++ b/src/Avatar/index.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import Avatar from "./";
+
+describe("Avatar", () => {
+  it("renders an anchor with href when linkurl is safe", () => {
+    render(<Avatar label="User" linkurl="https://narmi.com" initials="NM" />);
+    const el = document.querySelector("a");
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute("href", "https://narmi.com");
+  });
+
+  it("does not render a dangerous href when linkurl is unsafe", () => {
+    render(
+      <Avatar label="User" linkurl="javascript:alert(1)" initials="NM" />,
+    );
+    const el = document.querySelector("a");
+    expect(el).toBeInTheDocument();
+    expect(el).not.toHaveAttribute("href");
+  });
+});

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -84,4 +84,16 @@ describe("Button", () => {
     expect(icon).toBeInTheDocument();
     expect(icon).toHaveClass(`narmi-icon-${iconName}`);
   });
+
+  it("strips unsafe href when rendered as anchor", () => {
+    render(<Button as="a" label={LABEL} href="javascript:alert(1)" />);
+    const button = getButton();
+    expect(button).not.toHaveAttribute("href");
+  });
+
+  it("preserves safe href when rendered as anchor", () => {
+    render(<Button as="a" label={LABEL} href="/safe-path" />);
+    const button = getButton();
+    expect(button).toHaveAttribute("href", "/safe-path");
+  });
 });

--- a/src/IconButton/index.test.js
+++ b/src/IconButton/index.test.js
@@ -43,4 +43,20 @@ describe("IconButton", () => {
     const iconButton = getIconButton();
     expect(iconButton).toHaveClass(`nds-icon-button--${kind}`);
   });
+
+  it("strips unsafe href when rendered as anchor", () => {
+    render(
+      <IconButton as="a" name="info" label="Help" href="javascript:alert(1)" />,
+    );
+    const iconButton = getIconButton();
+    expect(iconButton).not.toHaveAttribute("href");
+  });
+
+  it("preserves safe href when rendered as anchor", () => {
+    render(
+      <IconButton as="a" name="info" label="Help" href="/safe-path" />,
+    );
+    const iconButton = getIconButton();
+    expect(iconButton).toHaveAttribute("href", "/safe-path");
+  });
 });

--- a/src/util/AsElement.js
+++ b/src/util/AsElement.js
@@ -1,6 +1,23 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+const SAFE_HREF_PROTOCOLS = ["http:", "https:", "mailto:", "tel:"];
+
+/**
+ * Returns the href if it uses a safe protocol, or undefined if it
+ * uses a potentially dangerous scheme (javascript:, data:, etc).
+ */
+export const getSafeHref = (href) => {
+  if (href == null) return href;
+  if (typeof href !== "string") return undefined;
+  // eslint-disable-next-line no-control-regex
+  const normalized = href.trim().replace(/[\u0000-\u001F\u007F\s]+/g, "");
+  const m = normalized.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
+  if (!m) return href;
+  const protocol = `${m[1].toLowerCase()}:`;
+  return SAFE_HREF_PROTOCOLS.includes(protocol) ? href : undefined;
+};
+
 /**
  * This is not a complete list of HTML elements;
  * only the elements we want to support in `as` props.
@@ -34,12 +51,16 @@ export const VALID_ELEMENTS = [
  * @usage <AsElement elementName="ul" otherProp="this gets passed through">
  */
 const AsElement = ({ elementType = "div", children, ...rest }) => {
+  const safeRest = Object.prototype.hasOwnProperty.call(rest, "href")
+    ? { ...rest, href: getSafeHref(rest.href) }
+    : rest;
+
   if (
     typeof elementType === "function" ||
     typeof elementType.type === "function"
   ) {
     // this is a react component so render it directly
-    return React.createElement(elementType, rest, children);
+    return React.createElement(elementType, safeRest, children);
   }
 
   let Element = "div"; // always fall back to div if something is wrong
@@ -50,7 +71,7 @@ const AsElement = ({ elementType = "div", children, ...rest }) => {
     Element = elementType;
   }
 
-  return <Element {...rest}>{children}</Element>;
+  return <Element {...safeRest}>{children}</Element>;
 };
 
 AsElement.propTypes = {

--- a/src/util/asElement.test.js
+++ b/src/util/asElement.test.js
@@ -1,6 +1,51 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import AsElement from "./AsElement";
+import { getSafeHref } from "./AsElement";
+
+describe("getSafeHref", () => {
+  it.each([
+    ["/", "/"],
+    ["/dashboard", "/dashboard"],
+    ["./settings", "./settings"],
+    ["../settings", "../settings"],
+    ["#section", "#section"],
+    ["?tab=profile", "?tab=profile"],
+    ["//example.com/path", "//example.com/path"],
+    ["https://narmi.com", "https://narmi.com"],
+    ["http://narmi.com", "http://narmi.com"],
+    ["mailto:test@example.com", "mailto:test@example.com"],
+    ["tel:+15555555555", "tel:+15555555555"],
+  ])("preserves safe href %s", (input, expected) => {
+    expect(getSafeHref(input)).toBe(expected);
+  });
+
+  it("returns null for null input", () => {
+    expect(getSafeHref(null)).toBeNull();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(getSafeHref(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for non-string input", () => {
+    expect(getSafeHref(123)).toBeUndefined();
+    expect(getSafeHref({})).toBeUndefined();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "java\nscript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "blob:https://x/y",
+    "about:blank",
+  ])("blocks unsafe href %s", (input) => {
+    expect(getSafeHref(input)).toBeUndefined();
+  });
+});
 
 describe("AsElement", () => {
   it("renders the given element", () => {
@@ -18,5 +63,38 @@ describe("AsElement", () => {
     const TestComponent = () => <p>Test</p>;
     render(<AsElement elementType={TestComponent} />);
     expect(document.querySelector("p")).toBeInTheDocument();
+  });
+
+  it("strips unsafe href from native element", () => {
+    render(
+      <AsElement elementType="a" href="javascript:alert(1)">
+        link
+      </AsElement>,
+    );
+    const el = document.querySelector("a");
+    expect(el).toBeInTheDocument();
+    expect(el).not.toHaveAttribute("href");
+  });
+
+  it("preserves safe href on native element", () => {
+    render(
+      <AsElement elementType="a" href="https://narmi.com">
+        link
+      </AsElement>,
+    );
+    const el = document.querySelector("a");
+    expect(el).toHaveAttribute("href", "https://narmi.com");
+  });
+
+  it("sanitizes href passed to custom React component", () => {
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    const CustomLink = (props) => <a {...props} />;
+    render(
+      <AsElement elementType={CustomLink} href="javascript:alert(1)">
+        link
+      </AsElement>,
+    );
+    const el = document.querySelector("a");
+    expect(el).not.toHaveAttribute("href");
   });
 });


### PR DESCRIPTION
## Summary

Centralizes href sanitization in `AsElement` to prevent click-triggered XSS via `javascript:`, `data:`, `vbscript:`, and other dangerous URL schemes passed to link-capable components.

### Components that inherit this fix
- `Button` (when `as="a"`)
- `IconButton` (when `as="a"`)
- `Avatar` (via `linkurl` prop)
- Any component using `AsElement` with an `href` prop

### Allowed URL schemes
- `http:`, `https:`, `mailto:`, `tel:`
- Relative paths (`/path`, `./path`, `../path`)
- Hash fragments (`#section`), query strings (`?key=val`), protocol-relative (`//example.com`)

### Blocked URL schemes
- `javascript:`, `data:`, `vbscript:`, `file:`, `blob:`, `about:`, and any other non-allowlisted scheme
- Obfuscation via mixed case (`JaVaScRiPt:`) and embedded whitespace/control characters (`java\nscript:`) is also blocked

### Custom component passthrough
When `elementType` is a React component (function), the sanitized href is passed through identically, ensuring custom link wrappers also receive safe values.

### Test additions
- `src/util/asElement.test.js`: Unit tests for `getSafeHref` (safe values preserved, unsafe values blocked, null/undefined/non-string handling) and `AsElement` integration tests for both native elements and custom components
- `src/Button/index.test.js`: Regression tests for unsafe and safe href on `Button as="a"`
- `src/IconButton/index.test.js`: Regression tests for unsafe and safe href on `IconButton as="a"`
- `src/Avatar/index.test.tsx`: Tests for `linkurl` with safe and unsafe URLs