### PR TITLE
UI Refresh patch fix 2 to main

### DIFF
--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -89,6 +89,7 @@
 
   .nds-dropdownTrigger-button {
     @extend %tableField;
+    color: var(--font-color-primary);
     min-height: unset;
     grid-template-columns: 1fr min-content; // [value] [chevron]
 
@@ -104,6 +105,7 @@
     .nds-dropdownTrigger-chevron {
       display: none !important;
     }
+
     &:hover .nds-dropdownTrigger-chevron,
     &:focus .nds-dropdownTrigger-chevron {
       display: block !important;

--- a/src/MenuButton/index.scss
+++ b/src/MenuButton/index.scss
@@ -27,12 +27,10 @@
 }
 
 .nds-menubutton-menu {
+  @extend %nds-dropdown-layer;
   white-space: nowrap;
   background-color: var(--color-white);
   box-shadow: var(--elevation-high);
-  outline: none;
-  max-height: 60vh;
-  overflow-y: auto;
 }
 
 .nds-menubutton-item {

--- a/src/MenuButton/index.stories.js
+++ b/src/MenuButton/index.stories.js
@@ -201,6 +201,47 @@ export const WithFooterContent = () => {
   );
 };
 
+export const StyleIsolation = () => (
+  <div className="style-isolation-parent">
+    <style>{`
+      .style-isolation-parent * {
+        display: flex;
+        font-size: 24px;
+        font-weight: 900;
+        color: purple;
+      }
+    `}</style>
+    <MenuButton label="Should render normally">
+      <MenuButton.Item
+        key="edit"
+        startIcon="edit-2"
+        label="Edit"
+        onSelect={() => alert("edit")}
+      />
+      <MenuButton.Item
+        key="screenshot"
+        startIcon="camera"
+        label="Screenshot"
+        onSelect={() => alert("screenshot")}
+      />
+      <MenuButton.Item
+        key="deposit"
+        startIcon="bank"
+        label="Deposit"
+        onSelect={() => alert("deposit")}
+      />
+    </MenuButton>
+  </div>
+);
+StyleIsolation.parameters = {
+  docs: {
+    description: {
+      story:
+        "Demonstrates that the dropdown menu is visually isolated from broad parent selectors (e.g. `.parent * { ... }`). Menu items should render with standard design system styles.",
+    },
+  },
+};
+
 export default {
   title: "Components/MenuButton",
   component: MenuButton,

--- a/src/TableAutocomplete/index.scss
+++ b/src/TableAutocomplete/index.scss
@@ -5,10 +5,9 @@
 
 .nds-tableAutocomplete-dropdown {
   @extend %tableField-offset;
+  @extend %nds-dropdown-layer;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  border: 1px solid var(--theme-primary);
   background-color: var(--color-white);
   box-shadow: var(--elevation-middle);
   max-height: rem(312px);

--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -82,20 +82,31 @@ $breakpoints: (
   border: 1px solid var(--theme-primary);
   border-radius: var(--border-radius-default);
 
-  // Override leaking styles for overly broad selectors like
-  // `.balance-options * { display: flex; }` which can select
-  // children in a dropdown when unportalled.
+  // Defend against broad consumer selectors like `.parent * { display: flex; }`
+  // !important wins regardless of specificity or source order.
   //
-  // Long term fix is to require a cascade layer in the consumer:
-  // <https://linear.app/narmi/issue/NDS-2718/breaking-require-consumers-to-use-a-cascade-layer>
-  display: block;
-  font-size: var(--font-size-default);
-  color: var(--font-color-default);
-  text-align: start;
-  text-transform: none;
-  letter-spacing: normal;
-  line-height: var(--line-height-default);
-  padding: 0;
+  // In an upcoming major release, we will require consumers to wrap their styles
+  // in their own @app-{app name} CSS layer and these overrides may be removed.
+  // See: https://linear.app/narmi/issue/NDS-2718
+  font-size: var(--font-size-default) !important;
+  color: var(--font-color-primary) !important;
+  text-align: start !important;
+  text-transform: none !important;
+  letter-spacing: normal !important;
+  line-height: var(--line-height-default) !important;
+  font-weight: normal !important;
+  padding: 0 !important;
+
+  // Force all descendants to inherit from this protected container
+  & * {
+    font-size: unset !important;
+    color: unset !important;
+    text-align: unset !important;
+    text-transform: unset !important;
+    letter-spacing: unset !important;
+    line-height: unset !important;
+    font-weight: unset !important;
+  }
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Merging these fixes to main release channel before backporting commits for a `v6.11.1-patch.2` release.

Closes NDS-2699
Closes NDS-2741
Closes NDS-2715

- Fix styles leaking through popover. This addresses all components that `useDropdownLayer`, including Tooltip.
- For the `kind="table"` variant of the DropdownTrigger, we always want the button text to be `primary` color.
- Allow `TableAutocomplete` styles to inherit the new and improved placeholder that manages height _and_ scroll behavior.
