### PR TITLE
feat(Button,SplitButton): add isFullWidth option

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -24,6 +24,19 @@
   pointer-events: none;
 }
 
+/* Boolean Flags */
+.nds-button--fullWidth {
+  width: 100%;
+  justify-content: space-between;
+  padding-inline: var(--space-m);
+
+  .nds-button-content {
+    text-align: start;
+    margin: 0 !important;
+    min-width: 100% !important;
+  }
+}
+
 /* Size variants */
 .nds-button--xs {
   @extend %btn-size-xs;

--- a/src/Button/index.stories.tsx
+++ b/src/Button/index.stories.tsx
@@ -121,6 +121,30 @@ export const ButtonSizes = () => (
   </>
 );
 
+export const FullWidthButton = () => (
+  <div style={{ maxWidth: "400px" }}>
+    <div className="margin--bottom--m">
+      <Button endIcon="arrow-right" label="Continue" isFullWidth />
+    </div>
+    <div className="margin--bottom--m">
+      <Button
+        kind="tonal"
+        startIcon="camera"
+        label="Take a picture"
+        isFullWidth
+      />
+    </div>
+  </div>
+);
+FullWidthButton.parameters = {
+  docs: {
+    description: {
+      story:
+        "When `isFullWidth` is `true`, the button expands to fill the width of its container. Useful for stacked actions in narrow layouts such as mobile views or sidebars.",
+    },
+  },
+};
+
 export default {
   title: "Components/Button",
   component: Button,

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -51,6 +51,11 @@ export interface ButtonProps {
    * in a future release. Use the `label` prop instead.
    */
   children?: React.ReactNode | string | undefined;
+  /**
+   * Will take up full width of its parent container when `true`.
+   * The label will align start with flex grow.
+   */
+  isFullWidth?: boolean;
   [x: string]: unknown; // spread props
 }
 
@@ -77,6 +82,7 @@ const Button = ({
   onClick = () => {},
   as = "button",
   ariaLabel = null,
+  isFullWidth = false,
   ...otherProps
 }: ButtonProps) => {
   const isButtonElement = as === "button";
@@ -116,6 +122,7 @@ const Button = ({
           resetButton: as === "button",
           "nds-button--disabled": disabled,
           "nds-button--loading": isLoading,
+          "nds-button--fullWidth": isFullWidth,
         },
       ])}
       disabled={(isButtonElement && disabled) || isLoading ? true : undefined}

--- a/src/SplitButton/index.scss
+++ b/src/SplitButton/index.scss
@@ -13,6 +13,11 @@
   }
 }
 
+.nds-splitButton--fullWidth {
+  display: flex;
+  width: 100%;
+}
+
 .nds-splitButton-action {
   cursor: pointer;
   height: 100%;

--- a/src/SplitButton/index.stories.js
+++ b/src/SplitButton/index.stories.js
@@ -126,7 +126,7 @@ FullWidth.parameters = {
   docs: {
     description: {
       story:
-        "When `isFullWidth` is `true`, the main action button expands to fill the available width of its container, while the dropdown trigger retains its fixed width. Useful for narrow layouts such as mobile views or sidebars.",
+        "When `isFullWidth` is `true`, the split button expands to fill the available width of its container. Useful for narrow layouts such as mobile views or sidebars.",
     },
   },
 };

--- a/src/SplitButton/index.stories.js
+++ b/src/SplitButton/index.stories.js
@@ -97,6 +97,40 @@ export const KindsAndSizes = () => {
   );
 };
 
+export const FullWidth = () => (
+  <div style={{ maxWidth: "320px" }}>
+    <SplitButton
+      label="Send"
+      kind="secondary"
+      isFullWidth
+      onClick={() => alert("Send button clicked")}
+    >
+      <SplitButton.Menu>
+        <SplitButton.MenuItem
+          label="Schedule"
+          onSelect={() => {
+            alert("Scheduling");
+          }}
+        />
+        <SplitButton.MenuItem
+          label="Save as draft"
+          onSelect={() => {
+            alert("Saving draft");
+          }}
+        />
+      </SplitButton.Menu>
+    </SplitButton>
+  </div>
+);
+FullWidth.parameters = {
+  docs: {
+    description: {
+      story:
+        "When `isFullWidth` is `true`, the main action button expands to fill the available width of its container, while the dropdown trigger retains its fixed width. Useful for narrow layouts such as mobile views or sidebars.",
+    },
+  },
+};
+
 export default {
   title: "Components/SplitButton",
   component: SplitButton,

--- a/src/SplitButton/index.tsx
+++ b/src/SplitButton/index.tsx
@@ -42,6 +42,7 @@ const SplitButton = ({
   label,
   disabled,
   isLoading,
+  isFullWidth = false,
   children,
   ...otherProps
 }: SplitButtonProps) => {
@@ -78,7 +79,12 @@ const SplitButton = ({
   );
 
   return (
-    <div className="nds-splitButton">
+    <div
+      className={cc([
+        "nds-splitButton",
+        { "nds-splitButton--fullWidth": isFullWidth },
+      ])}
+    >
       {/** Main button */}
       <Button
         label={label}
@@ -86,6 +92,7 @@ const SplitButton = ({
         isLoading={isLoading}
         size={size}
         kind={kind}
+        isFullWidth={isFullWidth}
         {...otherProps}
       />
 


### PR DESCRIPTION
Closes NDS-2552

Add an `isFullWidth` prop to `Button` and it's dependent, `SplitButton`.
When true, the button will take up 100% width of the parent container and the label will justify start.

<img width="374" height="98" alt="Screenshot 2026-05-28 at 7 57 16 PM" src="https://github.com/user-attachments/assets/eed05bc1-605b-4511-8995-d8b48d8b7701" />
<img width="463" height="188" alt="Screenshot 2026-05-28 at 7 56 06 PM" src="https://github.com/user-attachments/assets/889a309a-c10d-4ab1-9611-919e86562391" />
