### PR TITLE
fix(Tabs): update segmented controls for NDS-2808 patches

### DIFF
--- a/src/Tabs/TabsList.tsx
+++ b/src/Tabs/TabsList.tsx
@@ -151,16 +151,32 @@ const TabsList = ({ children, xPadding = "none" }: TabsListProps) => {
     }
   };
 
+  // When the next paged scroll would land near a scroll limit, snap exactly
+  // to the limit. Otherwise the trailing/leading tab can come to rest under
+  // the fade mask (`--mask-width`) and read as cut off mid-word.
+  const getSnapBuffer = (el: HTMLElement) => {
+    const raw = getComputedStyle(el).getPropertyValue("--mask-width").trim();
+    const parsed = parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
   const onLeftClick = () => {
-    tabsListRef.current.scroll({
-      left: tabsListRef.current.scrollLeft - tabsListRef.current.clientWidth,
+    const el = tabsListRef.current;
+    const naive = el.scrollLeft - el.clientWidth;
+    const buffer = getSnapBuffer(el);
+    el.scroll({
+      left: naive <= buffer ? 0 : naive,
       behavior: "smooth",
     });
   };
 
   const onRightClick = () => {
-    tabsListRef.current.scroll({
-      left: tabsListRef.current.scrollLeft + tabsListRef.current.clientWidth,
+    const el = tabsListRef.current;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    const naive = el.scrollLeft + el.clientWidth;
+    const buffer = getSnapBuffer(el);
+    el.scroll({
+      left: naive >= maxScroll - buffer ? maxScroll : naive,
       behavior: "smooth",
     });
   };

--- a/src/Tabs/TabsList.tsx
+++ b/src/Tabs/TabsList.tsx
@@ -177,6 +177,7 @@ const getSnapBuffer = (el: HTMLElement) => {
 
   const onRightClick = () => {
     const el = tabsListRef.current;
+    if (!el) return;
     const maxScroll = el.scrollWidth - el.clientWidth;
     const naive = el.scrollLeft + el.clientWidth;
     const buffer = getSnapBuffer(el);

--- a/src/Tabs/TabsList.tsx
+++ b/src/Tabs/TabsList.tsx
@@ -151,14 +151,19 @@ const TabsList = ({ children, xPadding = "none" }: TabsListProps) => {
     }
   };
 
-  // When the next paged scroll would land near a scroll limit, snap exactly
-  // to the limit. Otherwise the trailing/leading tab can come to rest under
-  // the fade mask (`--mask-width`) and read as cut off mid-word.
-  const getSnapBuffer = (el: HTMLElement) => {
-    const raw = getComputedStyle(el).getPropertyValue("--mask-width").trim();
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) ? parsed : 0;
-  };
+// When the next paged scroll would land near a scroll limit, snap exactly
+// to the limit. Otherwise the trailing/leading tab can come to rest under
+// the fade mask (`--mask-width`) and read as cut off mid-word.
+const getSnapBuffer = (el: HTMLElement) => {
+  // `--mask-width` is a custom property (often `var(--space-...)`) and won't
+  // resolve via `getPropertyValue("--mask-width")`. Read a real computed length
+  // that uses the variable instead.
+  const raw = getComputedStyle(el)
+    .getPropertyValue("scroll-padding-inline-start")
+    .trim();
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
 
   const onLeftClick = () => {
     const el = tabsListRef.current;

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -140,11 +140,6 @@
 
   .nds-tabs-tabsList {
     position: relative;
-    background: color-mix(
-      in srgb,
-      rgb(var(--theme-rgb-primary)) var(--alpha-5),
-      white
-    );
     display: flex;
     gap: rem(2px);
     border: 1px solid var(--border-color-default);

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -2,7 +2,7 @@
 * Root element shared styles
 */
 .nds-tabs-tabsList {
-  --mask-width: var(--space-l);
+  --mask-width: var(--space-m);
 
   display: flex;
   justify-content: flex-start;
@@ -64,7 +64,7 @@
 }
 
 .arrow-reponsive {
-  flex: 0 0 32px;
+  flex: 0 0 min-content;
 }
 
 .panel-responsive {
@@ -128,19 +128,36 @@
   --transition-duration-width: 0.2s;
   --transition-duration-x: 0.3s;
 
-  // all children have semi-transparent backgrounds;
-  // this component should visually resolve to the same color
-  // regardless of where it is placed
-  background: var(--bgColor-white);
-  border-radius: var(--border-radius-m);
+  // When the user uses the arrow to scroll to the last tab,
+  // the mask covers a bit too much, so we use this padding to
+  // push the text at least 3 characters away from the fade.
+  //
+  // This is a workaround for an issue where the arrow scroll behavior
+  // will not unclip the last item when scrolled to the end.
+  &.nds-tabs--isResponsive .nds-tabs-tabItem:last-child button {
+    padding-right: calc(var(--mask-width) + 3ch);
+  }
 
   .nds-tabs-tabsList {
     position: relative;
-    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
+    background: color-mix(
+      in srgb,
+      rgb(var(--theme-rgb-primary)) var(--alpha-5),
+      white
+    );
     display: flex;
     gap: rem(2px);
     border: 1px solid var(--border-color-default);
     border-radius: var(--border-radius-m);
+
+    // Multiple backgrounds, with white on the bottom to ensure
+    // rgba theme color resolves the same way regardless of where it's used.
+    background-image:
+      linear-gradient(
+        rgba(var(--theme-rgb-primary), var(--alpha-5)),
+        rgba(var(--theme-rgb-primary), var(--alpha-5))
+      ),
+      linear-gradient(white, white);
 
     // The pill shape defined here will move to whichever element
     // has the anchor name `--active`. The `anchor()` functions

--- a/src/Tabs/index.tsx
+++ b/src/Tabs/index.tsx
@@ -86,7 +86,10 @@ const Tabs = ({
         className={cc([
           "nds-tabs",
           `nds-tabs--${kind}`,
-          { "nds-tabs--bordered": hasBorder && kind === "default" },
+          {
+            "nds-tabs--isResponsive": isResponsive,
+            "nds-tabs--bordered": hasBorder && kind === "default",
+          },
         ])}
         data-testid={testId}
       >


### PR DESCRIPTION
Closes NDS-2808

- Fix white background shim by layering multiple gradients instead of positioning a shim.
- Apply the segmented tabs background to only the tabs list; not the entire component including panels
- Account for mask size in arrow scrolling so the end tab never gets cut off.