### PR TITLE
fix(Tooltip): portal tooltip always

### DIFF
--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useId, useRef } from "react";
+import ReactDOM from "react-dom";
 import useDropdownLayer from "../hooks/useDropdownLayer";
 
 export interface TooltipProps {
@@ -71,6 +72,25 @@ const Tooltip = ({
     "aria-expanded": anchorExpanded,
   } = anchorProps;
   const { ref: layerRef, ...layerRest } = layerProps;
+  const layerContent = (
+    <div
+      ref={layerRef as React.Ref<HTMLDivElement>}
+      id={tooltipId}
+      role="tooltip"
+      className="nds-typography nds-tooltip elevation--middle"
+      data-placement={side}
+      {...layerRest}
+      style={{
+        ...layerRest.style,
+        maxWidth: maxWidth,
+      }}
+      data-testid={testId}
+      onMouseEnter={openPopover}
+      onMouseLeave={closePopover}
+    >
+      {shouldRenderTooltip ? text : null}
+    </div>
+  );
 
   return (
     <>
@@ -90,23 +110,7 @@ const Tooltip = ({
       >
         {children}
       </div>
-      <div
-        ref={layerRef as React.Ref<HTMLDivElement>}
-        id={tooltipId}
-        role="tooltip"
-        className="nds-typography nds-tooltip elevation--middle"
-        data-placement={side}
-        {...layerRest}
-        style={{
-          ...layerRest.style,
-          maxWidth: maxWidth,
-        }}
-        data-testid={testId}
-        onMouseEnter={openPopover}
-        onMouseLeave={closePopover}
-      >
-        {shouldRenderTooltip ? text : null}
-      </div>
+      {ReactDOM.createPortal(layerContent, document.body)}
     </>
   );
 };

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -62,6 +62,7 @@ const Tooltip = ({
     matchWidth: false,
     ariaPopupType: "false",
     placement: side,
+    isPortalled: true,
   });
 
   const {


### PR DESCRIPTION
Closes NDS-2879

The modular dashboard has a few more adversarial styles where things are positioned and z-indexed for reasons not immediately clear to me. This causes `Tooltip` to appear under some other UI elements.

The best way to resolve this is to make sure the `Tooltip` is always portalled to `document.body` to resolve stacking context separately.

This option is stable; `TableSelect` has been setting this `useDropdownLayer` option for months now, as Tables/rows are often overflow hidden.