### PR TITLE
chore(dev-deps): remove unused Vite CSS plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,7 @@
         "typescript": "^5.2.2",
         "use-clipboard-copy": "^0.2.0",
         "vite": "^8.0.16",
-        "vite-plugin-css-injected-by-js": "^3.5.2",
         "vite-plugin-dts": "^4.5.4",
-        "vite-plugin-libcss": "^1.1.2",
         "vitest": "^4.1.2"
       },
       "engines": {
@@ -22813,16 +22811,6 @@
         }
       }
     },
-    "node_modules/vite-plugin-css-injected-by-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
-      "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "vite": ">2.0.0-0"
-      }
-    },
     "node_modules/vite-plugin-dts": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
@@ -22848,19 +22836,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-libcss": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-libcss/-/vite-plugin-libcss-1.1.2.tgz",
-      "integrity": "sha512-nM1vqIibhKPvzpa6aPc8DahGcKS82cUE/Jiap6r9aIrsNno105RIDI8XnLmP1nKU8nhGb08eNrWjSOhO53c6NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^9.0.1"
-      },
-      "peerDependencies": {
-        "vite": "*"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -101,9 +101,7 @@
     "typescript": "^5.2.2",
     "use-clipboard-copy": "^0.2.0",
     "vite": "^8.0.16",
-    "vite-plugin-css-injected-by-js": "^3.5.2",
     "vite-plugin-dts": "^4.5.4",
-    "vite-plugin-libcss": "^1.1.2",
     "vitest": "^4.1.2"
   },
   "author": "@narmi",


### PR DESCRIPTION
Removes the `vite-plugin-css-injected-by-js` and `vite-plugin-libcss` devDependencies. Neither are referenced in `vite.config.js`, `.storybook/`, or `scripts/`