### PR TITLE
ci: read Node version from .nvmrc in all workflows

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/figma-variables.yaml
+++ b/.github/workflows/figma-variables.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
 
       - name: Build static storybook

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
       - run: |
           npm ci

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
 
       - name: eslint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
         with:
-          node-version: 22
+          node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
           cache: "npm"
 


### PR DESCRIPTION
Workflows pinned `node-version: 22` while `.nvmrc` specifies v24.13.0 (and `engines` says `>=22`), so CI and local development were testing different runtimes. This switches every `actions/setup-node` step to `node-version-file: ".nvmrc"` so there is a single source of truth.


An example of this working successfully: https://github.com/narmi/design_system/actions/runs/28750503919/job/85248596705#step:3:10
