### PR TITLE
ci(npm): Add min release age to npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 access=public
+min-release-age=7


### PR DESCRIPTION
Tests are currently failing on main (see https://github.com/narmi/design_system/pull/2130 as an example). Until this project adopts pnpm, we need to manually set the cooldown period to reduce the supply chain risk. I'll create a separate PR to address the fact that semgrep is apparently not pinned.