### PR TITLE
ci: install dependencies with --ignore-scripts in all workflows

### DIFF
--- a/.github/workflows/chromatic-main.yaml
+++ b/.github/workflows/chromatic-main.yaml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --loglevel=warn
+        run: npm ci --ignore-scripts --loglevel=warn
 
       - name: Build
         run: npm run build && npm run build-storybook

--- a/.github/workflows/chromatic-pr.yaml
+++ b/.github/workflows/chromatic-pr.yaml
@@ -56,7 +56,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --loglevel=warn
+        run: npm ci --ignore-scripts --loglevel=warn
 
       - name: Cache build
         id: build-cache

--- a/.github/workflows/figma-variables.yaml
+++ b/.github/workflows/figma-variables.yaml
@@ -29,7 +29,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Fetch Figma variables
         env:

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Build static storybook
         run: |
           npm ci --ignore-scripts --loglevel=warn
+          npm run build
           npm run build-storybook
 
       - name: Deploy

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build static storybook
         run: |
-          npm ci -loglevel=warn
+          npm ci --ignore-scripts --loglevel=warn
           npm run build-storybook
 
       - name: Deploy

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -18,4 +18,4 @@ jobs:
       - run: |
           npm ci --ignore-scripts
           npm run build
-          npx license-checker --onlyAllow "MIT;0BSD;Apache 2.0;Apache-2.0;Artistic-2.0;BSD*;BSD-2-Clause;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT*;MPL-2.0;ODC-By-1.0;Python-2.0;Unlicense;WTFPL;BlueOak-1.0.0" --excludePackages "taffydb@2.6.2"
+          npm_config_ignore_scripts=true npx --yes license-checker@25.0.1 --onlyAllow "MIT;0BSD;Apache 2.0;Apache-2.0;Artistic-2.0;BSD*;BSD-2-Clause;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT*;MPL-2.0;ODC-By-1.0;Python-2.0;Unlicense;WTFPL;BlueOak-1.0.0" --excludePackages "taffydb@2.6.2"

--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -16,6 +16,6 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
       - run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
           npx license-checker --onlyAllow "MIT;0BSD;Apache 2.0;Apache-2.0;Artistic-2.0;BSD*;BSD-2-Clause;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT*;MPL-2.0;ODC-By-1.0;Python-2.0;Unlicense;WTFPL;BlueOak-1.0.0" --excludePackages "taffydb@2.6.2"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,5 +21,5 @@ jobs:
       - name: eslint
         run: |
           echo "The job was automatically triggered by a ${{ github.event_name }} event."
-          npm ci
+          npm ci --ignore-scripts
           npm run lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build Dist
         run: npm run build

--- a/.github/workflows/vitest.yaml
+++ b/.github/workflows/vitest.yaml
@@ -20,7 +20,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Cache build
         id: build-cache


### PR DESCRIPTION
## Summary
Adds `--ignore-scripts` to every `npm ci` across all 8 workflows. Dependency postinstall scripts execute arbitrary code on the CI runner with access to the job's environment (including secrets like `CHROMATIC_PROJECT_TOKEN`, `NDS_FIGMA_TOKEN`, and the release token), making them the most common npm supply-chain attack vector. This complements the `min-release-age=7` cooldown added in #2132.

Two related cleanups:
- `vitest.yaml` used `npm install` instead of `npm ci`, so tests could run against a drifted (and silently mutated) dependency tree rather than the committed lockfile
- `npm ci` was implicitly running the legacy root `prepublish` hook → `npm run build`, so the release workflow was building twice; every workflow that needs `dist/` already builds it explicitly (or restores it from the build cache)

## Why this is safe
None of our dependencies need lifecycle scripts: esbuild and sass platform binaries ship via `optionalDependencies` (still installed with `--ignore-scripts`), and husky hooks are irrelevant in CI.

## Verification
Locally, after a clean `npm ci --ignore-scripts`:
- `npm run build` → full dist build succeeds (tokens, tsc, css, jsdoc, vite, classdoc)
- `npm run test` → full suite passes, including `src/index.test.js` which imports the built `dist/` (294 passed / 4 skipped)
- `npm run lint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)