### PR TITLE
feat(Button): add tonal variant

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -74,6 +74,11 @@
   @extend %btn-kind-tonal;
 }
 
+.nds-button--inverted,
+.nds-button--inverted.resetButton {
+  @extend %btn-kind-inverted;
+}
+
 .nds-button--negative,
 .nds-button--negative.resetButton {
   @extend %btn-kind-negative;

--- a/src/Button/index.stories.tsx
+++ b/src/Button/index.stories.tsx
@@ -4,16 +4,62 @@ import iconSelection from "../icons/selection.json";
 import Row from "../Row";
 import Select from "../Select";
 import type { IconName } from "../types/Icon.types";
+import type { ButtonKind } from "./";
 
 const VALID_ICON_NAMES = iconSelection.icons.map(
   (icon) => icon.properties.name,
 );
+
+const BUTTON_KINDS: ButtonKind[] = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "tonal",
+  "negative",
+  "plain",
+  "ai",
+  "inverted",
+];
 
 const Template = (args) => <Button {...args} />;
 
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Submit",
+};
+
+export const ButtonKinds = () => (
+  <div
+    style={{
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: "var(--space-l)",
+    }}
+  >
+    {BUTTON_KINDS.map((kind) => (
+      // The `inverted` kind is designed for dark/colored surfaces,
+      // so it is shown on a themed background swatch.
+      <div
+        key={kind}
+        className={
+          kind === "inverted"
+            ? "bgColor--theme--primary padding--all--s rounded--all"
+            : undefined
+        }
+      >
+        <Button kind={kind} label={kind} />
+      </div>
+    ))}
+  </div>
+);
+ButtonKinds.parameters = {
+  docs: {
+    description: {
+      story:
+        "The `kind` prop controls the visual style of the button. The `inverted` kind is intended for use on dark or colored surfaces and is shown here on a themed background swatch.",
+    },
+  },
 };
 
 export const PlainButton = () => (
@@ -48,6 +94,44 @@ AiButton.parameters = {
     description: {
       story:
         'A Button of `kind="ai"` is used for AI-related actions. It renders with a white background, amethyst text, and an animated rotating gradient border.',
+    },
+  },
+};
+
+export const InvertedButton = () => {
+  const backgrounds = [
+    { className: "bgColor--theme--primary", label: "theme--primary" },
+    { className: "bgColor--theme--secondary", label: "theme--secondary" },
+    { className: "bgColor--pine", label: "pine" },
+    { className: "bgColor--moss", label: "moss" },
+    { className: "bgColor--azul", label: "azul" },
+    { className: "bgColor--cove", label: "cove" },
+  ];
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-m)" }}>
+      {backgrounds.map(({ className, label }) => (
+        <div
+          key={label}
+          className={`${className} padding--all--l rounded--all`}
+        >
+          <Button kind="inverted" label={label} />
+        </div>
+      ))}
+      <div
+        className="padding--all--l rounded--all"
+        style={{ backgroundColor: "var(--color-amethyst)" }}
+      >
+        <Button kind="inverted" label="amethyst" />
+      </div>
+    </div>
+  );
+};
+InvertedButton.parameters = {
+  docs: {
+    description: {
+      story:
+        'A Button of `kind="inverted"` is designed to sit on top of dark or colored surfaces. It renders with a translucent white background and theme-colored text, so it is shown here across multiple backgrounds to demonstrate its versatility.',
     },
   },
 };

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -12,7 +12,8 @@ export type ButtonKind =
   | "tonal"
   | "negative"
   | "plain"
-  | "ai";
+  | "ai"
+  | "inverted";
 
 export interface ButtonProps {
   /** Renders the button label */

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -63,6 +63,17 @@
   }
 }
 
+%btn-kind-inverted {
+  color: rgba(0, 0, 0, 0.86);
+  background-color: rgba(255, 255, 255, 0.86);
+
+  &:hover,
+  &:active {
+    color: var(--theme-primary);
+    background-color: var(--color-white);
+  }
+}
+
 %_btn-kind-plain-base {
   color: var(--theme-secondary);
   border-radius: 0;


### PR DESCRIPTION
Closes NDS-3024

Add `inverted` variant for Button. Matches `tonal` styling, but with a transparent white background to let darker colors bleed through a little.

On hover, it becomes solid white with primary theme text.


<img width="993" height="273" alt="Screenshot 2026-07-08 at 1 05 39 PM" src="https://github.com/user-attachments/assets/2b934ba1-d728-454a-b9ce-13388d98b731" />
<img width="987" height="279" alt="Screenshot 2026-07-08 at 1 05 33 PM" src="https://github.com/user-attachments/assets/6ab6b475-6848-49a5-be93-7d898be58ebc" />
<img width="947" height="226" alt="Screenshot 2026-07-08 at 1 05 51 PM" src="https://github.com/user-attachments/assets/833c3365-88a1-4481-b466-6b6a96bde755" />
