### PR TITLE
fix(Chip): use theme primary border for secondary chip

### DIFF
--- a/src/Chip/index.scss
+++ b/src/Chip/index.scss
@@ -43,7 +43,7 @@
   }
   &--secondary {
     background-color: var(--color-white);
-    border: 1px solid var(--font-color-primary);
+    border: 1px solid var(--theme-primary);
   }
   &--primary {
     background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));


### PR DESCRIPTION
Closes NDS-2740

Design intended for the secondary chip to have a _themed_ border rather than a primary font color border.