### PR TITLE
fix(Tooltip): fix block axis tooltip arrow position

### DIFF
--- a/issue-test-cases/NDS-2870-LeftEdgeTooltip.stories.js
+++ b/issue-test-cases/NDS-2870-LeftEdgeTooltip.stories.js
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import Tooltip from "src/Tooltip";
+import IconButton from "src/IconButton";
+
+/**
+ * Mimics the fixed-position, overflow-hidden collapsed sidebar nav
+ * from Azul that contains the expand/collapse tooltip trigger.
+ */
+// eslint-disable-next-line react/prop-types
+const CollapsedSidebar = ({ children }) => (
+  <nav
+    style={{
+      position: "fixed",
+      top: 0,
+      left: 0,
+      width: "80px",
+      height: "100vh",
+      overflowX: "hidden",
+      overflowY: "auto",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "flex-start",
+      paddingTop: "30px",
+      borderRight: "1px solid var(--color-lightGrey)",
+    }}
+  >
+    {children}
+  </nav>
+);
+
+/**
+ * Reproduces the Azul sidebar expand/collapse tooltip pattern:
+ * - Trigger is inside a position:fixed, overflow-hidden, 80px-wide sidebar
+ * - Controlled `isOpen` prop on Tooltip
+ * - Mouse events on a parent wrapper div
+ * - Tooltip uses default side="top"
+ */
+export const SidebarExpandCollapse = () => {
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  return (
+    <CollapsedSidebar>
+      <div
+        onMouseEnter={() => setIsTooltipOpen(true)}
+        onMouseLeave={() => setIsTooltipOpen(false)}
+      >
+        <Tooltip text="Expand sidebar" isOpen={isTooltipOpen}>
+          <div
+            style={{
+              width: "40px",
+              height: "40px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <IconButton
+              kind="action"
+              label="Expand sidebar"
+              name="chevrons-left"
+            />
+          </div>
+        </Tooltip>
+      </div>
+    </CollapsedSidebar>
+  );
+};
+
+/**
+ * Same as SidebarExpandCollapse but with isOpen forced to true
+ * so the positioning issue is immediately visible without hovering.
+ */
+export const AlwaysOpen = () => (
+  <CollapsedSidebar>
+    <div>
+      <Tooltip text="Expand sidebar" isOpen={true}>
+        <div
+          style={{
+            width: "40px",
+            height: "40px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <IconButton
+            kind="action"
+            label="Expand sidebar"
+            name="chevrons-left"
+          />
+        </div>
+      </Tooltip>
+    </div>
+  </CollapsedSidebar>
+);
+
+const storyDescription =
+  "Reproduces the Azul sidebar tooltip pattern where the trigger lives " +
+  "inside a position:fixed, overflow-x:hidden, 80px-wide collapsed sidebar. " +
+  "The tooltip (side='top') may clip or misposition at the viewport edge.";
+
+export default {
+  title: "NDS-2870 Left Edge Controlled Tooltip",
+  tags: ["!autodocs", "NDS-2870"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: storyDescription,
+      },
+    },
+  },
+};

--- a/src/Tooltip/index.scss
+++ b/src/Tooltip/index.scss
@@ -85,7 +85,7 @@
 
   // Flipped to below anchor → arrow pointing up
   @container anchored(fallback: --nds-try-below) {
-    .nds-tooltip::before {
+    .nds-tooltip[data-placement="top"]::before {
       width: calc(var(--nds-layer-gap) * 2);
       height: var(--nds-layer-gap);
       top: auto;
@@ -101,7 +101,7 @@
 
   // Flipped to above anchor → arrow pointing down
   @container anchored(fallback: --nds-dropdown-above) {
-    .nds-tooltip::before {
+    .nds-tooltip[data-placement="bottom"]::before {
       width: calc(var(--nds-layer-gap) * 2);
       height: var(--nds-layer-gap);
       left: anchor(var(--nds-anchor-name) center);
@@ -115,7 +115,7 @@
 
   // Flipped to right of anchor → arrow pointing left
   @container anchored(fallback: --nds-try-right) {
-    .nds-tooltip::before {
+    .nds-tooltip[data-placement="left"]::before {
       width: var(--nds-layer-gap);
       height: calc(var(--nds-layer-gap) * 2);
       left: auto;
@@ -129,7 +129,7 @@
 
   // Flipped to left of anchor → arrow pointing right
   @container anchored(fallback: --nds-try-left) {
-    .nds-tooltip::before {
+    .nds-tooltip[data-placement="right"]::before {
       width: var(--nds-layer-gap);
       height: calc(var(--nds-layer-gap) * 2);
       right: auto;


### PR DESCRIPTION
Closes NDS-2870

While the `useDropdownLayer` hook was providing the data attribute, we didn't wire up the directional styles correctly for the Tooltip arrow. This PR adds the required data attribute to raise specificity as needed to make the arrow shape work again.

**We didn't notice this until a Tooltip got within 30px of the top edge of the viewport.** The collapse/expand sidebar tooltip is fairly prominent so we noticed that one right away.

#### Test case added
Before/After
<img width="286" height="201" alt="Screenshot 2026-07-08 at 6 11 25 PM" src="https://github.com/user-attachments/assets/01549416-f3bc-472d-9196-519305bab2ce" />
<img width="206" height="133" alt="Screenshot 2026-07-08 at 6 21 07 PM" src="https://github.com/user-attachments/assets/b7fcadec-5d39-4e68-afa3-a08b1e2fc813" />
