### PR TITLE
fix: correct PropTypes declarations that raised warnings

### DIFF
--- a/src/AutocompleteModal/Item.tsx
+++ b/src/AutocompleteModal/Item.tsx
@@ -19,7 +19,7 @@ AutocompleteModalItem.propTypes = {
    * Use this prop to pass in a custom string you'd like the user to search
    * against when using typeahead.
    */
-  searchValue: PropTypes.string.isRequired,
+  searchValue: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -89,7 +89,7 @@ DateInput.propTypes = {
   /** Disables dates. See [flatpickr docs](https://flatpickr.js.org/examples/#disabling-dates) for usage instructions */
   disableDates: PropTypes.array,
   /** Sets the minimum selectable date (inclusive) */
-  minDate: PropTypes.bool,
+  minDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   /** Alternate date format to show in input when a date is selected (e.g. 'm/d/Y')*/
   altFormat: PropTypes.string,
   /**

--- a/src/Error/index.tsx
+++ b/src/Error/index.tsx
@@ -49,7 +49,7 @@ const Error = ({ error, marginTop = "xxs" }: ErrorProps) => {
   return <ErrorLine errorLine={error} marginTop={marginTop} />;
 };
 Error.propTypes = {
-  error: PropTypes.oneOf([
+  error: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]),

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -145,7 +145,7 @@ TextInput.propTypes = {
   /** When false, the consumer can take full control over where the error renders */
   renderError: PropTypes.bool,
   /** Text of error message to display under the input */
-  error: PropTypes.oneOf([
+  error: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),
   ]),


### PR DESCRIPTION
Addresses some warning that were being thrown:

- `Error`/`TextInput`: `error` used `PropTypes.oneOf` with type validators as the allowed values (should be `oneOfType`) — every legitimate string/array error value triggered an "Invalid prop" console warning.
- `DateInput`: `minDate` was typed as `PropTypes.bool`; it's documented and used as a date string or `Date` instance passed through to flatpickr.
- `AutocompleteModal.Item`: `searchValue` was marked `isRequired` even though it's documented and consumed as optional (typeahead falls back to `value` when omitted) — every documented usage warned.