### PR TITLE
fix(Input): apply multiline class from destructured prop

### DIFF
--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -43,7 +43,7 @@ const Input = ({
   const className = [
     "nds-input",
     disabled ? "disabled" : "",
-    props.multiline ? "multiline" : "",
+    multiline ? "multiline" : "",
     error ? "error" : "",
     search ? "search" : "",
   ].join(" ");

--- a/src/Input/index.js
+++ b/src/Input/index.js
@@ -38,7 +38,6 @@ const Input = ({
   style,
   renderError = true,
   children,
-  ...props
 }) => {
   const className = [
     "nds-input",

--- a/src/Input/index.test.jsx
+++ b/src/Input/index.test.jsx
@@ -53,19 +53,6 @@ describe("Input", () => {
     expect(getRoot(container)).toHaveClass(className);
   });
 
-  /**
-   * NOTE: documents a pre-existing bug rather than desired behavior.
-   *
-   * `Input` destructures `multiline` out of props, then checks
-   * `props.multiline` when building the root className. That is always
-   * `undefined`, so the "multiline" class has never actually been emitted.
-   * There is no bare `.multiline` CSS selector, so nothing depends on it.
-   */
-  it("does NOT apply a `multiline` class to the root (known dead code)", () => {
-    const { container } = render(<Input multiline />);
-    expect(getRoot(container)).not.toHaveClass("multiline");
-  });
-
   it("renders the error message by default", () => {
     render(<Input error="Something broke" />);
     expect(screen.getByText("Something broke")).toBeInTheDocument();


### PR DESCRIPTION
`multiline` is destructured out of props (with a `false` default), so the classname line reading `props.multiline` is always `undefined` — the `multiline` class never gets applied to the input wrapper. Read the destructured local instead.

Internal component (no stories), so blast radius is limited to consumers rendering multiline `TextInput`s that were silently missing their layout class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)