### PR TITLE
fix(Drawer): give the content panel a stable id via useId

### DIFF
--- a/src/Drawer/index.jsx
+++ b/src/Drawer/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions,react/require-default-props */
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useId } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import cc from "classcat";
@@ -31,7 +31,7 @@ const Drawer = ({
   footer,
   testId,
 }) => {
-  const panelId = `content-panel-${Date.now()}`;
+  const panelId = `content-panel-${useId()}`;
   const shimRef = useRef(null);
   const navRef = useRef(null);
 


### PR DESCRIPTION
`panelId` was `content-panel-${Date.now()}`, evaluated inline on every render. Three consequences:

- **Churns per render** — the panel `id` and the `aria-controls` on the nav buttons change every render, so the association is unstable for assistive tech.
- **Collisions** — two Drawers constructed within the same millisecond get identical ids.
- **Duplicate testid** — unrelated, but the same value ends up shared across elements.

Swapped in `useId()` — stable across renders, unique per instance, SSR-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)