### PR TITLE
fix(Pagination): don't emit out-of-range pages from the arrows

### DIFF
--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -32,6 +32,7 @@ const Pagination = ({
 
   const {
     visiblePages,
+    selectedPage: normalizedSelectedPage,
     selectedIndex,
     showPrev,
     showNext,
@@ -52,7 +53,7 @@ const Pagination = ({
 
   const handlePrevClick = () => {
     if (!showPrev) return;
-    const previousPage = selectedPage - 1;
+    const previousPage = normalizedSelectedPage - 1;
     if (!isControlled) {
       setSelectedPageInternal(previousPage);
     }
@@ -61,7 +62,7 @@ const Pagination = ({
 
   const handleNextClick = () => {
     if (!showNext) return;
-    const nextPage = selectedPage + 1;
+    const nextPage = normalizedSelectedPage + 1;
     if (!isControlled) {
       setSelectedPageInternal(nextPage);
     }

--- a/src/Pagination/index.jsx
+++ b/src/Pagination/index.jsx
@@ -51,6 +51,7 @@ const Pagination = ({
   };
 
   const handlePrevClick = () => {
+    if (!showPrev) return;
     const previousPage = selectedPage - 1;
     if (!isControlled) {
       setSelectedPageInternal(previousPage);
@@ -59,6 +60,7 @@ const Pagination = ({
   };
 
   const handleNextClick = () => {
+    if (!showNext) return;
     const nextPage = selectedPage + 1;
     if (!isControlled) {
       setSelectedPageInternal(nextPage);

--- a/src/Pagination/index.test.js
+++ b/src/Pagination/index.test.js
@@ -178,6 +178,23 @@ describe("Pagination", () => {
       expect(handlePageChange).not.toHaveBeenCalled();
     });
 
+    it("Clicking previous arrow with an out-of-range controlled selectedPage emits the clamped page", () => {
+      const handlePageChange = vi.fn();
+      const total = 20;
+      render(
+        <Pagination
+          totalPages={total}
+          selectedPage={999}
+          onPageChange={handlePageChange}
+        />,
+      );
+      const prev = screen.getByLabelText("Previous page");
+
+      fireEvent.click(prev);
+
+      expect(handlePageChange).toHaveBeenCalledWith(total - 1);
+    });
+
     it("Clicking on last page changes selected page", () => {
       const handlePageChange = vi.fn();
       const total = 20;

--- a/src/Pagination/index.test.js
+++ b/src/Pagination/index.test.js
@@ -83,6 +83,101 @@ describe("Pagination", () => {
       expect(page1).toHaveClass(CLASS_SELECTED);
     });
 
+    it("Clicking previous arrow on the first page does not change selected page", () => {
+      const handlePageChange = vi.fn();
+      render(<Pagination totalPages={20} onPageChange={handlePageChange} />);
+      const prev = screen.getByLabelText("Previous page");
+
+      fireEvent.click(prev);
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("Page 1")).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Clicking next arrow on the last page does not change selected page", () => {
+      const handlePageChange = vi.fn();
+      const total = 20;
+      render(
+        <Pagination
+          totalPages={total}
+          onPageChange={handlePageChange}
+          defaultSelectedPage={total}
+        />,
+      );
+      const next = screen.getByLabelText("Next page");
+
+      fireEvent.click(next);
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.getByLabelText(`Page ${total}`)).toHaveClass(
+        CLASS_SELECTED,
+      );
+    });
+
+    it("Pressing Enter on the disabled previous arrow does not change selected page", () => {
+      const handlePageChange = vi.fn();
+      render(<Pagination totalPages={20} onPageChange={handlePageChange} />);
+      const prev = screen.getByLabelText("Previous page");
+
+      fireEvent.keyUp(prev, { key: "Enter" });
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("Page 1")).toHaveClass(CLASS_SELECTED);
+    });
+
+    it("Pressing Enter on the disabled next arrow does not change selected page", () => {
+      const handlePageChange = vi.fn();
+      const total = 20;
+      render(
+        <Pagination
+          totalPages={total}
+          onPageChange={handlePageChange}
+          defaultSelectedPage={total}
+        />,
+      );
+      const next = screen.getByLabelText("Next page");
+
+      fireEvent.keyUp(next, { key: "Enter" });
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+      expect(screen.getByLabelText(`Page ${total}`)).toHaveClass(
+        CLASS_SELECTED,
+      );
+    });
+
+    it("Clicking previous arrow on the first page in controlled mode does not call onPageChange", () => {
+      const handlePageChange = vi.fn();
+      render(
+        <Pagination
+          totalPages={20}
+          selectedPage={1}
+          onPageChange={handlePageChange}
+        />,
+      );
+      const prev = screen.getByLabelText("Previous page");
+
+      fireEvent.click(prev);
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+    });
+
+    it("Clicking next arrow on the last page in controlled mode does not call onPageChange", () => {
+      const handlePageChange = vi.fn();
+      const total = 20;
+      render(
+        <Pagination
+          totalPages={total}
+          selectedPage={total}
+          onPageChange={handlePageChange}
+        />,
+      );
+      const next = screen.getByLabelText("Next page");
+
+      fireEvent.click(next);
+
+      expect(handlePageChange).not.toHaveBeenCalled();
+    });
+
     it("Clicking on last page changes selected page", () => {
       const handlePageChange = vi.fn();
       const total = 20;


### PR DESCRIPTION
The prev/next arrow handlers never checked `showPrev`/`showNext` — the flags only drove the disabled *styling*, not the behavior. So the greyed-out arrow was still fully clickable:

- Previous on page 1 → `onPageChange(0)` (and sets internal state to `0`)
- Next on the last page → `onPageChange(totalPages + 1)`

Consumers had to defend against pages that can't exist. Guard both handlers to bail when their arrow is disabled. The `aria-disabled` attributes already reflect the same flags, so the visual and behavioral states now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)