### PR TITLE
fix(Select,Combobox): restore forced maxedWidth on dropdowns without breaking mobile

### DIFF
--- a/src/Combobox/index.js
+++ b/src/Combobox/index.js
@@ -12,7 +12,6 @@ import TextInput from "../TextInput";
 import Row from "../Row";
 import { getItemIndex } from "../Select";
 import useDropdownLayer from "../hooks/useDropdownLayer";
-import useBreakpoints from "../hooks/useBreakpoints";
 
 const noop = () => {};
 
@@ -258,14 +257,12 @@ const Combobox = ({
     },
   });
 
-  const { m } = useBreakpoints();
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
     setIsOpen: (open) => {
       if (!open) closeMenu();
     },
     polyfillScrollBug: true,
-    matchWidth: !m, // mobile-only
   });
 
   // Update displayed items passed to `useCombobox` when `items` change

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -3,7 +3,7 @@ import React, { useState, useMemo } from "react";
 import PropTypes from "prop-types";
 import { useSelect } from "downshift";
 import useDropdownLayer from "../hooks/useDropdownLayer";
-import useBreakpoints from "../hooks/useBreakpoints";
+
 import cc from "classcat";
 import Row from "../Row";
 import DropdownTrigger from "../DropdownTrigger";
@@ -228,14 +228,12 @@ const Select = ({
     closeMenu,
   } = useSelect(downshiftOpts);
 
-  const { m } = useBreakpoints();
   const { anchorProps, layerProps } = useDropdownLayer({
     isOpen,
     setIsOpen: (open) => {
       if (!open) closeMenu();
     },
     polyfillScrollBug: true,
-    matchWidth: !m, // mobile-only
   });
 
   const hasCategories = categories.length > 0;


### PR DESCRIPTION
Closes NDS-3098

It looks like we removed the option to fix a mobile bug instead of setting it conditionally for mobile. This PR restores the old behavior of Select and Combobox on desktop where the width of the dropdown layer matches the triggering element.