### PR TITLE
feat(Table): add scroll behavior and pinning

### DIFF
--- a/src/Table/HeaderCell.tsx
+++ b/src/Table/HeaderCell.tsx
@@ -21,8 +21,8 @@ export interface HeaderCellProps {
  * A cell unique to the table header.
  * This component renders as a button when an `onClick` handler is passed.
  *
- * This component is wrapped in an ARIA live region so the header cell content
- * is re-announced if it changes as the result of user interaction.
+ * This component is an ARIA live region so the header cell content is
+ * re-announced if it changes as the result of user interaction.
  */
 const HeaderCell = ({
   children,
@@ -37,26 +37,24 @@ const HeaderCell = ({
 
   if (!isVisible) return null;
 
-  return (
-    <div aria-live="polite">
-      {isButton ? (
-        <button
-          onClick={onClick}
-          className="nds-table-cell button--reset"
-          role="columnheader"
-          style={{ textAlign }}
-        >
-          {children}
-        </button>
-      ) : (
-        <div
-          className="nds-table-cell"
-          role="columnheader"
-          style={{ textAlign }}
-        >
-          {children}
-        </div>
-      )}
+  return isButton ? (
+    <button
+      aria-live="polite"
+      onClick={onClick}
+      className="nds-table-cell button--reset"
+      role="columnheader"
+      style={{ textAlign }}
+    >
+      {children}
+    </button>
+  ) : (
+    <div
+      aria-live="polite"
+      className="nds-table-cell"
+      role="columnheader"
+      style={{ textAlign }}
+    >
+      {children}
     </div>
   );
 };

--- a/src/Table/index.scss
+++ b/src/Table/index.scss
@@ -72,7 +72,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  // Edge padding (moved from row to cell for full-bleed backgrounds)
+  // Padding for edge cells
   .nds-table-row > &:first-child,
   .nds-table-row > .nds-table-cell-wrapper:first-child & {
     padding-inline-start: rem(8px);
@@ -95,38 +95,36 @@
     color: var(--font-color-primary);
     text-overflow: unset;
   }
-
-  // Pinned column styles — applied via ancestor class + structural selectors
 }
 
 // Pinned start column
 .nds-table--pinned-start {
-  .nds-table-row > .nds-table-cell:first-child,
-  .nds-table-row > .nds-table-cell-wrapper:first-child {
+  .nds-table-row > :is(.nds-table-cell, .nds-table-cell-wrapper):first-child {
     position: sticky;
     inset-inline-start: 0;
     z-index: 2;
     border-inline-end: 1px solid var(--pinned-column-border);
     box-shadow: var(--elevation-middle);
   }
-  .nds-table-body .nds-table-row > .nds-table-cell:first-child,
-  .nds-table-body .nds-table-row > .nds-table-cell-wrapper:first-child {
+  .nds-table-body
+    .nds-table-row
+    > :is(.nds-table-cell, .nds-table-cell-wrapper):first-child {
     background-color: var(--color-white);
   }
 }
 
 // Pinned end column
 .nds-table--pinned-end {
-  .nds-table-row > .nds-table-cell:last-child,
-  .nds-table-row > .nds-table-cell-wrapper:last-child {
+  .nds-table-row > :is(.nds-table-cell, .nds-table-cell-wrapper):last-child {
     position: sticky;
     inset-inline-end: 0;
     z-index: 2;
     border-inline-start: 1px solid var(--pinned-column-border);
     box-shadow: var(--elevation-middle);
   }
-  .nds-table-body .nds-table-row > .nds-table-cell:last-child,
-  .nds-table-body .nds-table-row > .nds-table-cell-wrapper:last-child {
+  .nds-table-body
+    .nds-table-row
+    > :is(.nds-table-cell, .nds-table-cell-wrapper):last-child {
     background-color: var(--color-white);
   }
 }
@@ -143,45 +141,35 @@
     height: rem(48px);
   }
 
-  // Header row: rounded top, flat bottom (flush with body)
+  // Editable table header appears "attached" to the body with flat edges
   .nds-table-row:has([role="columnheader"]) {
     background: rgba(var(--theme-rgb-primary), var(--alpha-5));
     border-radius: var(--border-radius-default) var(--border-radius-default) 0 0;
   }
+  .nds-table-body {
+    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+  }
+  .nds-table-body .nds-table-row:first-of-type {
+    border-radius: 0;
+  }
+  .nds-table-body .nds-table-row:only-of-type {
+    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+  }
 
+  // Pinned cells allow overflow to reveal shadows
   &.nds-table--pinned-start .nds-table-header,
   &.nds-table--pinned-end .nds-table-header {
     overflow: visible;
   }
 
-  // Body: flat top (flush with header), rounded bottom
-  .nds-table-body {
-    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
-  }
-
-  // First body row: flat top
-  .nds-table-body .nds-table-row:first-of-type {
-    border-radius: 0;
-  }
-
-  // Single body row: flat top, rounded bottom
-  .nds-table-body .nds-table-row:only-of-type {
-    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
-  }
-
-  // Pinned cells in header row: opaque composited tint over white
+  // Header cells for the editable table use a semi-transparent color.
+  // When a column is sticky, its header cell needs to be composited with white.
   &.nds-table--pinned-start
     .nds-table-row:has([role="columnheader"])
-    > .nds-table-cell:first-child,
-  &.nds-table--pinned-start
-    .nds-table-row:has([role="columnheader"])
-    > .nds-table-cell-wrapper:first-child,
+    > :is(.nds-table-cell, .nds-table-cell-wrapper):first-child,
   &.nds-table--pinned-end
     .nds-table-row:has([role="columnheader"])
-    > .nds-table-cell:last-child,
-  &.nds-table--pinned-end
-    .nds-table-row:has([role="columnheader"])
-    > .nds-table-cell-wrapper:last-child {
+    > :is(.nds-table-cell, .nds-table-cell-wrapper):last-child {
     background:
       linear-gradient(
         rgba(var(--theme-rgb-primary), var(--alpha-5)),

--- a/src/Table/index.scss
+++ b/src/Table/index.scss
@@ -1,7 +1,13 @@
 .nds-table {
+  --pinned-column-border: oklch(0% 0 0 / 0.06);
   display: grid;
   grid-auto-rows: auto;
   row-gap: 0;
+}
+
+.nds-table-scroll-container {
+  overflow-x: auto;
+  border-radius: var(--border-radius-default);
 }
 
 .nds-table-body,
@@ -22,14 +28,12 @@
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1; // participate in all parent columns
-  align-items: center;
-  padding: 0 rem(8px);
+  align-items: stretch;
 
   // rowDensity variants
   // compact density AND editable kind use 48px
   height: rem(64px);
-  .nds-table--compact &,
-  .nds-table--editable & {
+  .nds-table--compact & {
     height: rem(48px);
   }
 
@@ -56,21 +60,27 @@
       var(--alpha-10)
     ) !important;
   }
-
-  // Editable table header
-  .nds-table--editable &:has([role="columnheader"]) {
-    height: rem(48px) !important;
-    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
-  }
 }
 
 .nds-table-cell {
+  display: flex;
+  align-items: center;
   padding: var(--space-xxs) var(--space-xs);
   overflow: hidden;
 
   // default wrapping behavior
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  // Edge padding (moved from row to cell for full-bleed backgrounds)
+  .nds-table-row > &:first-child,
+  .nds-table-row > .nds-table-cell-wrapper:first-child & {
+    padding-inline-start: rem(8px);
+  }
+  .nds-table-row > &:last-child,
+  .nds-table-row > .nds-table-cell-wrapper:last-child & {
+    padding-inline-end: rem(8px);
+  }
 
   // Allow overflow when containing TableField components
   &:has([class^="nds-tableField"]) {
@@ -84,5 +94,99 @@
     text-transform: uppercase;
     color: var(--font-color-primary);
     text-overflow: unset;
+  }
+
+  // Pinned column styles — applied via ancestor class + structural selectors
+}
+
+// Pinned start column
+.nds-table--pinned-start {
+  .nds-table-row > .nds-table-cell:first-child,
+  .nds-table-row > .nds-table-cell-wrapper:first-child {
+    position: sticky;
+    inset-inline-start: 0;
+    z-index: 2;
+    border-inline-end: 1px solid var(--pinned-column-border);
+    box-shadow: var(--elevation-middle);
+  }
+  .nds-table-body .nds-table-row > .nds-table-cell:first-child,
+  .nds-table-body .nds-table-row > .nds-table-cell-wrapper:first-child {
+    background-color: var(--color-white);
+  }
+}
+
+// Pinned end column
+.nds-table--pinned-end {
+  .nds-table-row > .nds-table-cell:last-child,
+  .nds-table-row > .nds-table-cell-wrapper:last-child {
+    position: sticky;
+    inset-inline-end: 0;
+    z-index: 2;
+    border-inline-start: 1px solid var(--pinned-column-border);
+    box-shadow: var(--elevation-middle);
+  }
+  .nds-table-body .nds-table-row > .nds-table-cell:last-child,
+  .nds-table-body .nds-table-row > .nds-table-cell-wrapper:last-child {
+    background-color: var(--color-white);
+  }
+}
+
+// HeaderCell wrapper — stretches to fill row, centers content
+.nds-table-cell-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+// Editable variant overrides
+.nds-table--editable {
+  .nds-table-row {
+    height: rem(48px);
+  }
+
+  // Header row: rounded top, flat bottom (flush with body)
+  .nds-table-row:has([role="columnheader"]) {
+    background: rgba(var(--theme-rgb-primary), var(--alpha-5));
+    border-radius: var(--border-radius-default) var(--border-radius-default) 0 0;
+  }
+
+  &.nds-table--pinned-start .nds-table-header,
+  &.nds-table--pinned-end .nds-table-header {
+    overflow: visible;
+  }
+
+  // Body: flat top (flush with header), rounded bottom
+  .nds-table-body {
+    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+  }
+
+  // First body row: flat top
+  .nds-table-body .nds-table-row:first-of-type {
+    border-radius: 0;
+  }
+
+  // Single body row: flat top, rounded bottom
+  .nds-table-body .nds-table-row:only-of-type {
+    border-radius: 0 0 var(--border-radius-default) var(--border-radius-default);
+  }
+
+  // Pinned cells in header row: opaque composited tint over white
+  &.nds-table--pinned-start
+    .nds-table-row:has([role="columnheader"])
+    > .nds-table-cell:first-child,
+  &.nds-table--pinned-start
+    .nds-table-row:has([role="columnheader"])
+    > .nds-table-cell-wrapper:first-child,
+  &.nds-table--pinned-end
+    .nds-table-row:has([role="columnheader"])
+    > .nds-table-cell:last-child,
+  &.nds-table--pinned-end
+    .nds-table-row:has([role="columnheader"])
+    > .nds-table-cell-wrapper:last-child {
+    background:
+      linear-gradient(
+        rgba(var(--theme-rgb-primary), var(--alpha-5)),
+        rgba(var(--theme-rgb-primary), var(--alpha-5))
+      ),
+      linear-gradient(var(--color-white), var(--color-white));
   }
 }

--- a/src/Table/index.stories.js
+++ b/src/Table/index.stories.js
@@ -471,6 +471,104 @@ TableWithOverflow.parameters = {
   },
 };
 
+export const ScrollableWithPinnedColumns = ({ pinColumns }) => (
+  <div
+    style={{
+      background: "var(--bgColor-blueGrey)",
+      padding: "16px",
+    }}
+  >
+    <Table
+      colVisibility={["*", "*", "*", "*", "*", "*", "*", "*", "*", "*"]}
+      colLayout={{
+        s: "max-content 200px 180px 180px 150px max-content 180px 150px 180px max-content",
+        m: "max-content 220px 200px 200px 180px max-content 200px 180px 200px max-content",
+        l: "max-content 240px 220px 220px 200px max-content 220px 200px 220px max-content",
+      }}
+      pinColumns={pinColumns}
+      kind="editable"
+    >
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Name</Table.HeaderCell>
+          <Table.HeaderCell>Email</Table.HeaderCell>
+          <Table.HeaderCell>Phone</Table.HeaderCell>
+          <Table.HeaderCell>Department</Table.HeaderCell>
+          <Table.HeaderCell>Location</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell>Start Date</Table.HeaderCell>
+          <Table.HeaderCell>Salary</Table.HeaderCell>
+          <Table.HeaderCell>Manager</Table.HeaderCell>
+          <Table.HeaderCell>Actions</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>John Doe</Table.Cell>
+          <Table.Cell>john@example.com</Table.Cell>
+          <Table.Cell>(555) 123-4567</Table.Cell>
+          <Table.Cell>Engineering</Table.Cell>
+          <Table.Cell>New York</Table.Cell>
+          <Table.Cell>Active</Table.Cell>
+          <Table.Cell>Jan 15, 2022</Table.Cell>
+          <Table.Cell>$120,000</Table.Cell>
+          <Table.Cell>Sarah Connor</Table.Cell>
+          <Table.Cell>
+            <button>Edit</button>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Jane Smith</Table.Cell>
+          <Table.Cell>jane@example.com</Table.Cell>
+          <Table.Cell>(555) 987-6543</Table.Cell>
+          <Table.Cell>Marketing</Table.Cell>
+          <Table.Cell>San Francisco</Table.Cell>
+          <Table.Cell>Active</Table.Cell>
+          <Table.Cell>Mar 3, 2021</Table.Cell>
+          <Table.Cell>$105,000</Table.Cell>
+          <Table.Cell>Tom Bradley</Table.Cell>
+          <Table.Cell>
+            <button>Edit</button>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <Table.Cell>Bob Johnson</Table.Cell>
+          <Table.Cell>bob@example.com</Table.Cell>
+          <Table.Cell>(555) 456-7890</Table.Cell>
+          <Table.Cell>Sales</Table.Cell>
+          <Table.Cell>Chicago</Table.Cell>
+          <Table.Cell>On Leave</Table.Cell>
+          <Table.Cell>Nov 20, 2023</Table.Cell>
+          <Table.Cell>$95,000</Table.Cell>
+          <Table.Cell>Lisa Park</Table.Cell>
+          <Table.Cell>
+            <button>Edit</button>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  </div>
+);
+ScrollableWithPinnedColumns.args = {
+  pinColumns: "both",
+};
+ScrollableWithPinnedColumns.argTypes = {
+  pinColumns: {
+    control: { type: "inline-radio" },
+    options: ["none", "start", "end", "both"],
+  },
+};
+ScrollableWithPinnedColumns.parameters = {
+  docs: {
+    description: {
+      story:
+        "A scrollable table with the first column (Name) pinned to the start and the last column (Actions) pinned to the end. " +
+        'Middle columns scroll horizontally. Use `columnOverflow="scroll"` with `pinnedStart` and `pinnedEnd` to configure. ' +
+        "Pinned columns require fixed widths in `colLayout` (not `fr` units).",
+    },
+  },
+};
+
 export default {
   title: "Components/Table",
   component: Table,

--- a/src/Table/index.stories.js
+++ b/src/Table/index.stories.js
@@ -471,6 +471,7 @@ TableWithOverflow.parameters = {
   },
 };
 
+// eslint-disable-next-line react/prop-types
 export const ScrollableWithPinnedColumns = ({ pinColumns }) => (
   <div
     style={{

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -48,6 +48,16 @@ export interface TableProps {
   colLayout?: ColLayoutConfig;
   rowDensity?: "default" | "compact";
   kind?: "default" | "editable";
+  /**
+   * Pin edge columns while middle columns scroll horizontally.
+   * - `"none"` (default): no pinning, no horizontal scroll
+   * - `"start"` — pin the first column
+   * - `"end"` — pin the last column
+   * - `"both"` — pin both first and last columns
+   *
+   * When set to a value other than `"none"`, the table becomes horizontally scrollable.
+   */
+  pinColumns?: "none" | "start" | "end" | "both";
 }
 
 export const DEFAULT_COLS = 5;
@@ -70,6 +80,7 @@ const Table = ({
   colLayout = { s: "auto", m: "auto", l: "auto" },
   rowDensity = "default",
   kind = "default",
+  pinColumns = "none",
 }: TableProps) => {
   const { largestSatisfiedBreakpoint } = useBreakpoints();
   const currentBreakpoint =
@@ -110,7 +121,11 @@ const Table = ({
     visibleCols,
   );
 
-  return (
+  const isPinnedStart = pinColumns === "start" || pinColumns === "both";
+  const isPinnedEnd = pinColumns === "end" || pinColumns === "both";
+  const isScrollable = isPinnedStart || isPinnedEnd;
+
+  const tableEl = (
     <ColVisibilityContext.Provider
       value={{
         colVisibility,
@@ -123,6 +138,10 @@ const Table = ({
           "nds-table",
           `nds-table--${rowDensity}`,
           `nds-table--${kind}`,
+          {
+            "nds-table--pinned-start": isPinnedStart,
+            "nds-table--pinned-end": isPinnedEnd,
+          },
         ])}
         /**
          * We apply a CSS value for grid-tempalte-columns on the root
@@ -135,6 +154,12 @@ const Table = ({
       </div>
     </ColVisibilityContext.Provider>
   );
+
+  if (isScrollable) {
+    return <div className="nds-table-scroll-container">{tableEl}</div>;
+  }
+
+  return tableEl;
 };
 
 Table.Header = Header;

--- a/src/Table/util/colVisibilityContext.ts
+++ b/src/Table/util/colVisibilityContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import type { ColMinBreakpoint, ViewportBreakpoint } from "..";
 
-interface ColVisibilityContextProps {
+export interface ColVisibilityContextProps {
   currentBreakpoint: ViewportBreakpoint;
   colVisibility: ColMinBreakpoint[];
 }


### PR DESCRIPTION
Closes NDS-3004

**Targeting the .8 banking release**

### Changes
- The `Row` used to control block padding. This responsibility was moved to the `Cell` which is positioned by `stretch` alignment to fit row height.
- Header cell DOM simplified
- Moved editable `kind` CSS into one place
- Added `pinnedColumns` prop to turn the start, end, or both start and end columns into sticky columns

### How to use it

`start`, `end`, or `both`

```jsx
<Table pinnedColumns="start" ... />
```

### The CSS added
The all-CSS implementation means we don't have to measure anything, listen to any events, and consider how such things are calculated or stored in the react lifecycle. 

With the Cells sitting flush against each other, we have control over backgrounds at the cell level. With that, we only need `position: sticky` on a per-cell basis using some modern, well-supported selectors. They appear as one column because they are flush.

you can't jank up the main thread with scroll events if you don't use them


https://github.com/user-attachments/assets/61ef4503-c614-40d0-94d1-7b6e93e40fe8

