### PR TITLE
style(dialog): adding an optional max-height parameter for dialog so we can tweak it on the fly

### DIFF
--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -8,6 +8,7 @@ const BaseTemplate = (args) => <Dialog {...args} />;
 
 const InteractiveTemplate = (args) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  
   return (
     <>
       <Button

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -9,6 +9,7 @@ const BaseTemplate = (args) => <Dialog {...args} />;
 const InteractiveTemplate = (args) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
+  console.log("args", args);
   return (
     <>
       <Button
@@ -53,6 +54,7 @@ Overview.args = {
   headerStyle: "bordered",
   onUserDismiss: () => {},
   width: "500px",
+  height: "80vh",
 };
 Overview.argTypes = {
   footer: { control: false }, // hide control for `footer` prop

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -8,7 +8,7 @@ const BaseTemplate = (args) => <Dialog {...args} />;
 
 const InteractiveTemplate = (args) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  
+
   return (
     <>
       <Button
@@ -53,7 +53,7 @@ Overview.args = {
   headerStyle: "bordered",
   onUserDismiss: () => {},
   width: "500px",
-  height: "80vh",
+  maxHeight: "80vh",
 };
 Overview.argTypes = {
   footer: { control: false }, // hide control for `footer` prop

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -8,8 +8,6 @@ const BaseTemplate = (args) => <Dialog {...args} />;
 
 const InteractiveTemplate = (args) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  console.log("args", args);
   return (
     <>
       <Button

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -48,10 +48,10 @@ export interface DialogProps {
    */
   width?: string;
   /**
-   * Sets a custom modal height.
-   * Use the full CSS value with the unit (e.g. "400px, 80vh")
+   * Sets a custom modal max height.
+   * Use the full CSS value with the unit (e.g. "400px" or "80vh")
    */
-  height?: string;
+  maxHeight?: string;
   /** Optional value for `data-testid` attribute */
   testId?: string;
   id?: string;
@@ -72,7 +72,7 @@ const Dialog = ({
   notification,
   footer,
   width = "500px",
-  height = "80vh",
+  maxHeight = "80vh",
   testId,
 }: DialogProps) => {
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
@@ -142,7 +142,7 @@ const Dialog = ({
               aria-modal="true"
               className="nds-dialog"
               // @ts-expect-error DetailedHTMLProps does not specify arbitrary custom properties
-              style={{ "--dialog-preferred-width": width, "max-height": height }}
+              style={{ "--dialog-preferred-width": width, "max-height": maxHeight }}
               data-testid={testId}
             >
               <div

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -47,6 +47,11 @@ export interface DialogProps {
    * Use the full CSS value with the unit (e.g. "400px")
    */
   width?: string;
+  /**
+   * Sets a custom modal height.
+   * Use the full CSS value with the unit (e.g. "400px, 80vh")
+   */
+  height?: string;
   /** Optional value for `data-testid` attribute */
   testId?: string;
   id?: string;
@@ -67,6 +72,7 @@ const Dialog = ({
   notification,
   footer,
   width = "500px",
+  height = "80vh",
   testId,
 }: DialogProps) => {
   const [isContentOverflowing, setIsContentOverflowing] = useState(false);
@@ -136,7 +142,7 @@ const Dialog = ({
               aria-modal="true"
               className="nds-dialog"
               // @ts-expect-error DetailedHTMLProps does not specify arbitrary custom properties
-              style={{ "--dialog-preferred-width": width }}
+              style={{ "--dialog-preferred-width": width, "height": height }}
               data-testid={testId}
             >
               <div

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -142,7 +142,7 @@ const Dialog = ({
               aria-modal="true"
               className="nds-dialog"
               // @ts-expect-error DetailedHTMLProps does not specify arbitrary custom properties
-              style={{ "--dialog-preferred-width": width, "height": height }}
+              style={{ "--dialog-preferred-width": width, "max-height": height }}
               data-testid={testId}
             >
               <div


### PR DESCRIPTION
I ran into an issue where if there is a lot of content or if its spaced out enough the dialog would be scrollable but this behavior is not needed for this project. I added a optional height parameter that will set/override the max height of dialog component. The default max-height will be the set 80vh that was set before this change
<img width="1504" height="776" alt="Screenshot 2026-07-27 at 11 55 52 AM" src="https://github.com/user-attachments/assets/6ce68228-ca41-49fb-8aa9-cbeaf3454101" />
<img width="1504" height="776" alt="Screenshot 2026-07-27 at 11 55 59 AM" src="https://github.com/user-attachments/assets/709eea2e-7d0d-4d14-a14a-d5f239744ecf" />


This change stems from the Institution Setting Redesign Project:  https://linear.app/narmi/project/institution-settings-20-4e6f51d6e0ef/overview 

More specifically the edit product modal: https://linear.app/narmi/issue/ADMIN-6798/frontend-warn-user-when-disabling-setting

<img width="1430" height="778" alt="Screenshot 2026-07-21 at 10 05 27 AM" src="https://github.com/user-attachments/assets/f5120e12-58db-4ab5-9b07-ec9e0c34cbed" />

Note: The warning will be set further down the modal was just trying to fit everything in the modal without scrolling without making a pr to NDS

Figma link to design/mock: https://www.figma.com/design/6hdahrdi7CgdnKI2fHjzNI/institution-settings?node-id=17264-11937&m=dev

The ideal scenario would be the ability to fit everything in the modal without scrolling. 
