### PR TITLE
chore(checkbox): adds `renderLabel` prop to Checkbox for custom label elements

### DIFF
--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Checkbox from "./";
+import Alert from "../Alert";
 
 const Template = (args) => <Checkbox {...args} />;
 
@@ -76,6 +77,28 @@ Markdown.parameters = {
   docs: {
     description: {
       story: "Renders markdown when markdownLabel prop is set",
+    },
+  },
+};
+
+export const CustomLabelElements = Template.bind({});
+CustomLabelElements.args = {
+  name: "Custom display with stuff",
+  defaultChecked: false,
+  renderLabel: (isChecked) => {
+    const alertKind = isChecked ? "primary" : "warn";
+    return (
+      <Alert kind={alertKind} isActive isDismissable={false}>
+        I will turn green if you check the box!
+      </Alert>
+    );
+  },
+};
+CustomLabelElements.parameters = {
+  docs: {
+    description: {
+      story:
+        "Renders a custom label element when `renderLabel` prop is set. Will provide the `isChecked` state to the custom element.",
     },
   },
 };

--- a/src/Checkbox/index.test.js
+++ b/src/Checkbox/index.test.js
@@ -95,4 +95,30 @@ describe("Checkbox", () => {
     const a = screen.getByText("Google");
     expect(a.tagName).toBe("A");
   });
+
+  it("renders a custom label element when `renderLabel` prop is set", () => {
+    render(
+      <Checkbox
+        renderLabel={() => <button type="button">Button in a checkbox</button>}
+      />,
+    );
+    const customElement = screen.getByRole("button");
+    expect(customElement.innerHTML).toEqual("Button in a checkbox");
+  });
+
+  it("`renderLabel` provides the `isChecked` state to its custom element", () => {
+    render(
+      <Checkbox
+        defaultChecked={false}
+        renderLabel={(isChecked) => <p>{`checkbox state: ${isChecked}`}</p>}
+      />,
+    );
+    const customElement = screen.getByRole("paragraph");
+    expect(customElement.innerHTML).toEqual("checkbox state: false");
+
+    const input = screen.getByRole("checkbox");
+    fireEvent.click(input);
+
+    expect(customElement.innerHTML).toEqual("checkbox state: true");
+  });
 });

--- a/src/Checkbox/index.test.js
+++ b/src/Checkbox/index.test.js
@@ -113,12 +113,12 @@ describe("Checkbox", () => {
         renderLabel={(isChecked) => <p>{`checkbox state: ${isChecked}`}</p>}
       />,
     );
-    const customElement = screen.getByRole("paragraph");
-    expect(customElement.innerHTML).toEqual("checkbox state: false");
+    const customElement = screen.getByText(/checkbox state:/);
+    expect(customElement).toHaveTextContent("checkbox state: false");
 
     const input = screen.getByRole("checkbox");
     fireEvent.click(input);
 
-    expect(customElement.innerHTML).toEqual("checkbox state: true");
+    expect(customElement).toHaveTextContent("checkbox state: true");
   });
 });

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -12,7 +12,7 @@ import DisabledShim from "../DisabledShim";
 
 export interface CheckboxProps {
   /** Content of `label` element */
-  label?: React.ReactElement;
+  label?: React.ReactNode;
   /** Markdown to use in place of the `label` field */
   markdownLabel?: string;
   /** Change callback invoked when the value of the `input` changes */

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -1,5 +1,5 @@
 // https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_custom_checkbox
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useMemo } from "react";
 import cc from "classcat";
 import DOMPurify from "dompurify";
 import { marked, Renderer } from "marked";
@@ -12,7 +12,9 @@ import DisabledShim from "../DisabledShim";
 
 export interface CheckboxProps {
   /** Content of `label` element */
-  label?: React.ReactNode;
+  label?: string;
+  /** Optionally renders a `ReactNode` in place of the `label` */
+  renderLabel?: (isChecked: boolean) => React.ReactNode;
   /** Markdown to use in place of the `label` field */
   markdownLabel?: string;
   /** Change callback invoked when the value of the `input` changes */
@@ -65,6 +67,7 @@ export interface CheckboxProps {
  */
 const Checkbox = ({
   label,
+  renderLabel,
   markdownLabel, // DEPRECATED
   onChange = () => {},
   id,
@@ -115,6 +118,29 @@ const Checkbox = ({
     setIsFocused(false);
   };
 
+  const labelDisplay = useMemo(() => {
+    if (renderLabel) {
+      return renderLabel(isChecked);
+    }
+    if (markdownLabel) {
+      return (
+        <div
+          dangerouslySetInnerHTML={{
+            // nosemgrep: react-dangerouslysetinnerhtml -- sanitized by DOMPurify
+            __html: DOMPurify.sanitize(
+              marked.parse(markdownLabel, {
+                renderer: markdownRenderer,
+              }) as string,
+              { ADD_ATTR: ["target"] },
+            ),
+          }}
+        />
+      );
+    }
+
+    return <>{label}</>;
+  }, [isChecked, renderLabel, markdownLabel, label]);
+
   return (
     <div className={`nds-checkbox-container nds-checkbox-container--${kind}`}>
       <DisabledShim isDisabled={resolvedIsDisabled && kind === "card"}>
@@ -139,22 +165,7 @@ const Checkbox = ({
               },
             ])}
           ></span>
-          <div className="nds-checkbox-label">
-            {markdownLabel && (
-              <div
-                dangerouslySetInnerHTML={{
-                  // nosemgrep: react-dangerouslysetinnerhtml -- sanitized by DOMPurify
-                  __html: DOMPurify.sanitize(
-                    marked.parse(markdownLabel, {
-                      renderer: markdownRenderer,
-                    }) as string,
-                    { ADD_ATTR: ["target"] },
-                  ),
-                }}
-              />
-            )}
-            {!markdownLabel && <>{label}</>}
-          </div>
+          <div className="nds-checkbox-label">{labelDisplay}</div>
           <input
             ref={inputRef}
             onFocus={handleFocus}

--- a/src/Checkbox/index.tsx
+++ b/src/Checkbox/index.tsx
@@ -12,7 +12,7 @@ import DisabledShim from "../DisabledShim";
 
 export interface CheckboxProps {
   /** Content of `label` element */
-  label?: string;
+  label?: React.ReactElement;
   /** Markdown to use in place of the `label` field */
   markdownLabel?: string;
   /** Change callback invoked when the value of the `input` changes */

--- a/src/Field/FauxInput/index.tsx
+++ b/src/Field/FauxInput/index.tsx
@@ -19,10 +19,7 @@ export interface FauxInputProps {
  * Accepts arbitrary props (e.g. from downshift's getToggleButtonProps)
  * which are spread onto the underlying `<button>`.
  */
-export const FauxInput = forwardRef<
-  HTMLButtonElement,
-  FauxInputProps & Record<string, any>
->(
+export const FauxInput = forwardRef<HTMLButtonElement, FauxInputProps>(
   (
     {
       children,


### PR DESCRIPTION
~~Since the `label` prop is rendered within the JSX the prop type should accept it as `ReactElement` (or ReactNode, following convention with element).~~

Adds the `renderLabel` prop which will render custom elements as the label. Provides the `isChecked` state.

<img width="497" height="210" alt="Screenshot 2026-08-04 at 11 07 35 AM" src="https://github.com/user-attachments/assets/b0297a04-d20b-46e1-9ca1-2934f1a4880f" />
<img width="471" height="211" alt="Screenshot 2026-08-04 at 11 07 41 AM" src="https://github.com/user-attachments/assets/aa9efe8a-fee8-4f4a-8879-c52eb47c8f09" />

