### PR TITLE
fix(types): export real types for FormSection, useLockBodyScroll, formatNumber

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import Count from "./Count";
 import Dialog from "./Dialog";
 import DisabledShim from "./DisabledShim";
 import Field from "./Field";
+import FormSection from "./FormSection";
 import Pagination from "./Pagination";
 import ProgressBar from "./ProgressBar";
 import Radio from "./Radio";
@@ -38,6 +39,8 @@ import TruncatedAccount from "./TruncatedAccount";
 import useSupportsAnchorPositioning from "./hooks/useSupportsAnchorPositioning";
 import useBreakpoints from "./hooks/useBreakpoints";
 import useDropdownLayer from "./hooks/useDropdownLayer";
+import useLockBodyScroll from "./hooks/useLockBodyScroll";
+import formatNumber from "./formatters/formatNumber";
 
 /**
  * Untyped Components
@@ -49,7 +52,6 @@ declare const Drawer;
 declare const DropdownTrigger;
 declare const Error;
 declare const FieldToken;
-declare const FormSection;
 declare const IconButton;
 declare const Input;
 declare const LoadingShim;
@@ -64,8 +66,6 @@ declare const TextInput;
 declare const TimelineEvent;
 declare const Toggle;
 declare const TokenInput;
-declare const useLockBodyScroll;
-declare const formatNumber;
 declare const formatDate;
 
 export * from "./types/Icon.types";


### PR DESCRIPTION
## What

Removes three `declare const` stubs from `src/index.ts` and replaces them with real imports.

**No source changes.** The types already existed and are already correct.

## Why

`src/index.ts` is a type-only shadow of the `src/index.js` runtime barrel. Everything under its `/** Untyped Components */` block is stubbed as a bare `declare const X;`, which resolves to `any` for consumers.

These three modules were converted to TypeScript a while ago, but their stubs were never removed — so the types they already ship were being thrown away at the package boundary:

| Export | Source | Converted in |
|---|---|---|
| `FormSection` | `src/FormSection/index.tsx` | e152b906 |
| `useLockBodyScroll` | `src/hooks/useLockBodyScroll/index.ts` | 4f1c1ba0 |
| `formatNumber` | `src/formatters/formatNumber.ts` | f1a95a80 |

## Result

`dist/types` goes from `any` to real signatures, JSDoc included:

```ts
declare const formatNumber: (
  input: string | number,
  style?: FormatNumberStyle,
  signDisplay?: FormatNumberSignDisplay,
  showCents?: boolean,
) => string;
```

## Consumer impact

Low. `FormSection` requires `title: string` + `children`, `useLockBodyScroll` takes a `boolean`, and `formatNumber` accepts `string | number` — all permissive relative to real usage.