### PR TITLE
fix(types): export real types for formatDate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import TruncatedAccount from "./TruncatedAccount";
 import useSupportsAnchorPositioning from "./hooks/useSupportsAnchorPositioning";
 import useBreakpoints from "./hooks/useBreakpoints";
 import useDropdownLayer from "./hooks/useDropdownLayer";
+import formatDate from "./formatters/formatDate";
 
 /**
  * Untyped Components
@@ -66,7 +67,6 @@ declare const Toggle;
 declare const TokenInput;
 declare const useLockBodyScroll;
 declare const formatNumber;
-declare const formatDate;
 
 export * from "./types/Icon.types";
 export {


### PR DESCRIPTION
## What

Removes the `declare const formatDate;` stub from `src/index.ts` and replaces it with a real import.

**No source changes.**

## Consumer impact

Expect three error classes when upgrading:

```ts
formatDate(isoString)      // TS2345 — real bug, needs new Date(...)
formatDate(epochNumber)    // TS2345 — see below
formatDate(d, "medium")    // TS2345 — not a real style
```

## One judgment call worth a second opinion

Epoch numbers **do** work at runtime (`format` accepts `number | Date`) but are rejected by this type.

I left it strict because seconds-vs-milliseconds epochs fail silently with a wrong date, whereas `new Date(n)` is explicit. It's trivial to widen this later to `Date | number` if real call sites turn out to need it.