### PR TITLE
chore(ts): convert IconButton to TypeScript

### DIFF
--- a/src/IconButton/index.tsx
+++ b/src/IconButton/index.tsx
@@ -1,10 +1,42 @@
 import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
-import { VALID_ICON_NAMES } from "src/icons/iconNames";
+import { VALID_ICON_NAMES } from "../icons/iconNames";
 import AsElement from "../util/AsElement";
+import type { IconName } from "../types/Icon.types";
 
 export { VALID_ICON_NAMES };
+
+export type IconButtonKind = "action" | "plain" | "themed";
+
+export interface IconButtonProps {
+  /** Name of Narmi icon */
+  name: IconName;
+  /** Renders the icon button label */
+  label?: string;
+  /** disables the icon button when set to `true` */
+  disabled?: boolean;
+  /** style of icon button to render */
+  kind?: IconButtonKind;
+  /** type attribute for underlying HTML button element */
+  type?: string;
+  /** Optional text size of the icon in the icon button defaults different for different kinds (plain/action)*/
+  textSize?: "xs" | "s" | "m" | "l";
+  /** Click callback, with event object passed as argument */
+  onClick?: (event: React.MouseEvent) => void;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** className for adding classNames to the icon button  */
+  className?: string;
+  /**
+   * The html element to render as the root node of `Button`.
+   *
+   * When rendering as an "a" you **MUST** pass an `href` attribute
+   * for the anchor to be valid.
+   */
+  as?: "a" | "button";
+  [x: string]: unknown; // spread props
+}
 
 /**
  * Narmi style Icon Button.
@@ -23,7 +55,7 @@ const IconButton = ({
   type,
   as = "button",
   ...otherProps
-}) => {
+}: IconButtonProps) => {
   return (
     <AsElement
       elementType={as}


### PR DESCRIPTION
## What

`src/IconButton/index.js` → `src/IconButton/index.tsx`.

## Consumer impact: none yet

`IconButton` is still a `declare const` stub in `src/index.ts`, so consumers keep seeing `any` until a follow-up expose PR.

The immediate improvement is in-repo: `src/Tabs/Arrow.tsx` imports `../IconButton` and was silently resolving it to `any`. It is now type-checked and compiles unchanged.

## Shape

Mirrors `Button/index.tsx`, the closest analogue — it also renders through `AsElement`, takes `as?: "a" | "button"`, and carries an `[x: string]: unknown` index signature for spread props.

Verified against the new types:

```tsx
<IconButton name="info" />                 // ok
<IconButton name="not-a-real-icon" />      // TS2322
<IconButton kind="bogus" />                // TS2322
<IconButton as="a" name="info" href="/" /> // ok, spread passthrough
```

## Two deliberate choices

- **`name` is typed as `IconName`** — the generated union already exported from the package, matching how `Button`, `Chip`, `Alert` and `Field` type their icon props. This will be the main source of new errors when IconButton is eventually exposed: any typo'd or removed icon name fails.
- **`type` is left as `string`**, not tightened to `"submit" | "button" | "reset"` as `Button` has it. The existing propTypes say `PropTypes.string`, and narrowing here would introduce an error class the conversion didn't previously have. Worth a follow-up, but not smuggled into a conversion.

## One thing reviewers should look at

I switched `import { VALID_ICON_NAMES } from "src/icons/iconNames"` to a relative path.

The `src/*` alias is resolved by Vite but has **no matching `paths` entry in tsconfig**, so it fails to resolve the moment the file is genuinely reachable by tsc. Other files using that alias (e.g. `SidebarItem.tsx`) only get away with it today because they sit behind untyped stubs and are never type-checked — this will resurface as more components convert.

Adding a tsconfig `paths` mapping would fix it globally. Kept local here to hold the PR to one concern; happy to do the global fix separately if preferred.