### PR TITLE
chore(ts): convert LoadingShim to TypeScript

### DIFF
--- a/src/LoadingShim/index.tsx
+++ b/src/LoadingShim/index.tsx
@@ -2,11 +2,27 @@ import React from "react";
 import PropTypes from "prop-types";
 import cc from "classcat";
 
+export interface LoadingShimProps {
+  /** Loadable content area - will render normally unless `isLoading` is true */
+  children?: React.ReactNode;
+  /** When `true`, the loading shim appears over child content */
+  isLoading?: boolean;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** Size of the loading indicator */
+  size?: "s" | "l";
+}
+
 /**
  * Used to wrap a block of loadable content. When `isLoading` is set to true,
  * the content area will have an overlay and loading animation.
  */
-const LoadingShim = ({ isLoading = false, children, testId, size = "l" }) => (
+const LoadingShim = ({
+  isLoading = false,
+  children,
+  testId,
+  size = "l",
+}: LoadingShimProps) => (
   <div
     data-testid={testId || "nds-loadingshim"}
     aria-live="polite"
@@ -39,7 +55,7 @@ const LoadingShim = ({ isLoading = false, children, testId, size = "l" }) => (
 
 LoadingShim.propTypes = {
   /** Loadable content area - will render normally unless `isLoading` is true */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /** When `true`, the loading shim appears over child content */
   isLoading: PropTypes.bool,
   /** Optional value for `data-testid` attribute */


### PR DESCRIPTION
## What

`src/LoadingShim/index.js` → `src/LoadingShim/index.tsx`. Unblocks `Toggle`.

## Consumer impact: none

`LoadingShim` is still a `declare const` stub in `src/index.ts`.

## One pre-existing propTypes bug corrected

`children` was marked `PropTypes.node.isRequired`, but `Toggle/index.js:62` renders it with no children at all:

```jsx
<LoadingShim size="s" isLoading />
```

That's a live propTypes violation logging a console warning in dev today. The component renders `{children}` unguarded, so `undefined` has always been fine at runtime.

`children` is now optional in both the interface and propTypes.

**This one isn't a preference — it's required for correctness.** Typing `children` as required would have made the upcoming Toggle conversion fail to compile against a call site that works fine in production.
