### PR TITLE
chore(ts): convert ResponsiveFlex to TypeScript

### DIFF
--- a/src/ResponsiveFlex/index.tsx
+++ b/src/ResponsiveFlex/index.tsx
@@ -6,30 +6,62 @@ const VALID_GAPS = ["xs", "s", "m", "l", "xl"];
 const VALID_SIZES = ["s", "m", "l", "xl"];
 const VALID_DIRECTIONS = ["row", "column"];
 
+/** Standard Narmi breakpoint names */
+export type ResponsiveFlexSize = "s" | "m" | "l" | "xl";
+export type ResponsiveFlexGap = "xs" | "s" | "m" | "l" | "xl";
+export type ResponsiveFlexDirection = "row" | "column";
+export type FlexDirection =
+  | ResponsiveFlexDirection
+  | "row-reverse"
+  | "column-reverse";
+
+export interface GetFlexDirectionArgs {
+  viewportMatches: Record<ResponsiveFlexSize, boolean>;
+  direction: ResponsiveFlexDirection;
+  toColumnAt?: ResponsiveFlexSize;
+  toRowAt?: ResponsiveFlexSize;
+  reverseAt?: ResponsiveFlexSize;
+}
+
 export const getFlexDirection = ({
   viewportMatches,
   direction,
   toColumnAt,
   toRowAt,
   reverseAt,
-}) => {
-  let flexDirection = direction; // use initial direction as the default
+}: GetFlexDirectionArgs): FlexDirection => {
+  let flexDirection: FlexDirection = direction; // use initial direction as the default
 
-  if (viewportMatches[toRowAt]) {
+  if (toRowAt && viewportMatches[toRowAt]) {
     flexDirection = "row";
   }
 
-  if (viewportMatches[toColumnAt]) {
+  if (toColumnAt && viewportMatches[toColumnAt]) {
     flexDirection = "column";
   }
 
   // must be the final override, as we treat reverse as a separate concept from row/column
-  if (viewportMatches[reverseAt]) {
-    flexDirection = `${flexDirection}-reverse`;
+  if (reverseAt && viewportMatches[reverseAt]) {
+    flexDirection = `${flexDirection}-reverse` as FlexDirection;
   }
 
   return flexDirection;
 };
+
+export interface ResponsiveFlexProps {
+  /** Implicit flex children */
+  children?: React.ReactNode;
+  /** Size of flex gap by token size (e.g. "xl") */
+  gapSize?: ResponsiveFlexGap;
+  /** Initial flex direction  */
+  direction?: ResponsiveFlexDirection;
+  /** Breakpoint at which to reverse order of flex items */
+  reverseAt?: ResponsiveFlexSize;
+  /** Breakpoint at which to change flex direction to column */
+  toColumnAt?: ResponsiveFlexSize;
+  /** Breakpoint at which to change flex direction to row */
+  toRowAt?: ResponsiveFlexSize;
+}
 
 /**
  * Responsive layout helper that allows developers to declaratively control
@@ -42,7 +74,7 @@ const ResponsiveFlex = ({
   reverseAt,
   toColumnAt,
   toRowAt,
-}) => {
+}: ResponsiveFlexProps) => {
   const viewportMatches = useBreakpoints();
   const flexDirection = getFlexDirection({
     viewportMatches,
@@ -51,7 +83,7 @@ const ResponsiveFlex = ({
     toRowAt,
     reverseAt,
   });
-  const style = {
+  const style: React.CSSProperties = {
     display: "flex",
     flexDirection,
     gap: `var(--space-${gapSize})`,


### PR DESCRIPTION
## What

`src/ResponsiveFlex/index.jsx` → `src/ResponsiveFlex/index.tsx`.

Types the exported `getFlexDirection` helper and ties `viewportMatches` to the shape `useBreakpoints` actually returns. Adds named exports for `ResponsiveFlexSize`, `ResponsiveFlexGap`, `ResponsiveFlexDirection` and `FlexDirection`.

I'm not bothering with changing `propTypes` for now, since it's not long for this world as a pattern.

## Consumer impact: none

`ResponsiveFlex` is still a `declare const` stub in `src/index.ts`.

## One change worth reviewing closely

The original indexed the breakpoint map with a possibly-undefined key:

```js
if (viewportMatches[toRowAt]) { ... }
```

When `toRowAt` is undefined this evaluates `viewportMatches[undefined]` → `undefined` → falsy, so the branch is skipped. TypeScript rejects indexing with a possibly-undefined key, so it's now:

```ts
if (toRowAt && viewportMatches[toRowAt]) { ... }
```

These are exactly equivalent: an undefined key was already falsy, and the key's type permits no falsy string.

**This is directly covered by the existing tests** — every `getFlexDirection` case passes `toColumnAt: undefined` and/or `reverseAt: undefined`, and all 7 pass unchanged.