### PR TITLE
chore(ts): convert TimelineEvent to TypeScript

### DIFF
--- a/src/TimelineEvent/index.tsx
+++ b/src/TimelineEvent/index.tsx
@@ -1,10 +1,46 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { VALID_ICON_NAMES } from "src/icons/iconNames";
+import { VALID_ICON_NAMES } from "../icons/iconNames";
 import cc from "classcat";
 import ToolTip from "../Tooltip";
+import type { IconName } from "../types/Icon.types";
 
 export { VALID_ICON_NAMES };
+
+export type TimelineEventKind = "node" | "start" | "pending";
+
+export interface TimelineEventProps {
+  /**
+   * Timeline node variant.
+   */
+  kind?: TimelineEventKind;
+  /**
+   * Name of NDS icon to render inside the timeline node
+   */
+  icon?: IconName;
+  /**
+   * Pass an image url to render the timeline node
+   * as an avatar
+   */
+  imgUrl?: string;
+  /**
+   * Initial to render in the timeline node
+   * Overridden by:
+   * - icon
+   * - imgUrl
+   */
+  initial?: string;
+  /**
+   * Timeline event content (any JSX)
+   */
+  children?: React.ReactNode;
+  /**
+   * Hover tooltip content for the icon
+   */
+  tooltip?: string;
+  /** Render a custom circle node on the line */
+  renderNode?: () => React.ReactNode;
+}
 
 const TimelineEvent = ({
   kind = "node",
@@ -14,7 +50,7 @@ const TimelineEvent = ({
   tooltip,
   children,
   renderNode,
-}) => {
+}: TimelineEventProps) => {
   const useInitial = !icon && !imgUrl && initial;
   return (
     <div


### PR DESCRIPTION
## What

`src/TimelineEvent/index.js` → `src/TimelineEvent/index.tsx`.

## Consumer impact: none

`TimelineEvent` is still a `declare const` stub in `src/index.ts`.

## Shape

- `icon` is typed as `IconName`, the generated union already exported from the package — matching `Button`, `Chip`, `Alert`, `Field` and the IconButton conversion in #2182.
- `renderNode` is typed `() => React.ReactNode`, matching its sole use as `renderNode()` inside a `typeof renderNode === "function"` guard.
- The `export { VALID_ICON_NAMES }` re-export is preserved.

Component body is otherwise untouched.

## Same alias fix as #2182

The `VALID_ICON_NAMES` import is switched from the `src/icons/iconNames` alias to a relative path. The `src/*` alias resolves under Vite but has no tsconfig `paths` entry, so it fails once the file is genuinely reachable by tsc.