### PR TITLE
test(Input): add unit test coverage ahead of TS conversion

### DIFF
--- a/src/Input/index.test.jsx
+++ b/src/Input/index.test.jsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Input from "./";
+
+/**
+ * `Input` is an internal base component with no stories, so these tests are
+ * its only regression net. They intentionally lock in *current* behavior
+ * ahead of the TypeScript conversion, including the quirks noted below.
+ */
+
+const getRoot = (container) => container.querySelector(".nds-input");
+const getColumn = (container) => container.querySelector(".nds-input-column");
+
+describe("Input", () => {
+  it("renders children inside the input column", () => {
+    const { container } = render(
+      <Input>
+        <input type="text" />
+      </Input>,
+    );
+    expect(getColumn(container).querySelector("input")).toBeInTheDocument();
+  });
+
+  it("renders a label bound to the given id", () => {
+    const { container } = render(<Input id="my-input" label="My Label" />);
+    const label = container.querySelector("label");
+    expect(label).toHaveTextContent("My Label");
+    expect(label).toHaveAttribute("for", "my-input");
+  });
+
+  it("does not render a label when multiline is true", () => {
+    const { container } = render(<Input id="x" label="My Label" multiline />);
+    expect(container.querySelector("label")).not.toBeInTheDocument();
+  });
+
+  it("adds `no-label` to the column when no label is given", () => {
+    const { container } = render(<Input />);
+    expect(getColumn(container)).toHaveClass("no-label");
+  });
+
+  it("does not add `no-label` when a label is given", () => {
+    const { container } = render(<Input label="My Label" />);
+    expect(getColumn(container)).not.toHaveClass("no-label");
+  });
+
+  it.each([
+    ["disabled", { disabled: true }],
+    ["error", { error: "Something broke" }],
+    ["search", { search: true }],
+  ])("applies the `%s` class to the root", (className, props) => {
+    const { container } = render(<Input {...props} />);
+    expect(getRoot(container)).toHaveClass(className);
+  });
+
+  /**
+   * NOTE: documents a pre-existing bug rather than desired behavior.
+   *
+   * `Input` destructures `multiline` out of props, then checks
+   * `props.multiline` when building the root className. That is always
+   * `undefined`, so the "multiline" class has never actually been emitted.
+   * There is no bare `.multiline` CSS selector, so nothing depends on it.
+   */
+  it("does NOT apply a `multiline` class to the root (known dead code)", () => {
+    const { container } = render(<Input multiline />);
+    expect(getRoot(container)).not.toHaveClass("multiline");
+  });
+
+  it("renders the error message by default", () => {
+    render(<Input error="Something broke" />);
+    expect(screen.getByText("Something broke")).toBeInTheDocument();
+  });
+
+  it("suppresses the error message when renderError is false", () => {
+    render(<Input error="Something broke" renderError={false} />);
+    expect(screen.queryByText("Something broke")).not.toBeInTheDocument();
+  });
+
+  it("renders start, end and tail content", () => {
+    render(
+      <Input
+        startContent={<span>start</span>}
+        endContent={<span>end</span>}
+        tailContent={<span>tail</span>}
+      />,
+    );
+    expect(screen.getByText("start")).toBeInTheDocument();
+    expect(screen.getByText("end")).toBeInTheDocument();
+    expect(screen.getByText("tail")).toBeInTheDocument();
+  });
+
+  it("renders start and end icon classes", () => {
+    const { container } = render(
+      <Input startIconClass="narmi-icon-search" endIconClass="narmi-icon-x" />,
+    );
+    expect(container.querySelector(".narmi-icon-search")).toHaveClass(
+      "nds-input-icon",
+    );
+    expect(container.querySelector(".narmi-icon-x")).toHaveClass(
+      "nds-input-icon",
+    );
+  });
+
+  it("renders decoration content", () => {
+    render(<Input decoration={<span>decoration</span>} />);
+    expect(screen.getByText("decoration")).toBeInTheDocument();
+  });
+
+  it("does not render a clear button unless showClearButton is set", () => {
+    render(<Input />);
+    expect(screen.queryByLabelText("Clear")).not.toBeInTheDocument();
+  });
+
+  it("renders a clear button and fires clearInput when clicked", async () => {
+    const clearInput = vi.fn();
+    render(<Input showClearButton clearInput={clearInput} />);
+    const clearButton = screen.getByTestId("nds-icon-button");
+    expect(clearButton).toBeInTheDocument();
+    await userEvent.click(clearButton);
+    expect(clearInput).toHaveBeenCalled();
+  });
+
+  it("fires onClick when the input area is clicked", async () => {
+    const onClick = vi.fn();
+    const { container } = render(<Input onClick={onClick} />);
+    await userEvent.click(getRoot(container));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("applies inline styles to the root", () => {
+    const { container } = render(<Input style={{ width: "300px" }} />);
+    expect(getRoot(container)).toHaveStyle({ width: "300px" });
+  });
+});


### PR DESCRIPTION
## What

Adds 18 tests for `src/Input`. **No production code is touched** — this PR adds a single new tests file.

## Why

`Input` is the base primitive under `TextInput`, and therefore under `DateInput`, `TokenInput` and `Combobox`. It's also the only component in the library with **neither unit tests nor stories** — so today it has no unit coverage and no Chromatic coverage.

That makes it the riskiest remaining conversion on the critical path, so this builds the net before touching it.

I'm not creating any stories here, just tests, because the docstring on the components says it intentionally has no stories.

Worth noting separately: `Input` is documented as `PRIVATE` but **is still exported from `src/index.js`** and stubbed in the barrel. Might be worth deciding whether that's intended — un-exporting would be breaking, so not touching it here.

## Coverage

Children rendering, label/`htmlFor` binding, the `no-label` column modifier, the disabled/error/search root classes, error rendering and `renderError={false}` suppression, start/end/tail/decoration content, icon classes, the clear button and its callback, root `onClick`, and inline styles.

## One test documents a bug rather than desired behavior

`Input` destructures `multiline` out of props and then checks `props.multiline` when building the root className:

```js
const Input = ({ ..., multiline = false, ...props }) => {
  const className = [
    "nds-input",
    /* ... */
    props.multiline ? "multiline" : "",   // <- always undefined
```

`props.multiline` is therefore always `undefined`, and the `"multiline"` class **has never once been emitted**. I checked: there's no bare `.multiline` CSS selector (only `%shared-multiline-styles` and `.nds-input-multiline-grid`), so nothing depends on it.

TypeScript will reject `props.multiline` as soon as the props are typed, so the conversion can't avoid this. Pinning current behavior now means that PR can prove it changed nothing, and whether the class was ever intended can be settled on its own merits.