### PR TITLE
fix(types): make FormSection title and children optional

### DIFF
--- a/src/FormSection/index.tsx
+++ b/src/FormSection/index.tsx
@@ -4,7 +4,7 @@ import Row from "../Row";
 
 interface FormSectionProps {
   /** Title of form section */
-  title: string;
+  title?: string;
   /** Optional content rendered below the section heading */
   children?: React.ReactNode;
 }
@@ -47,7 +47,7 @@ const FormSection = ({ title, children }: FormSectionProps) => (
 
 FormSection.propTypes = {
   /** Title of form section */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   children: PropTypes.node,
 };
 

--- a/src/FormSection/index.tsx
+++ b/src/FormSection/index.tsx
@@ -5,7 +5,8 @@ import Row from "../Row";
 interface FormSectionProps {
   /** Title of form section */
   title: string;
-  children: React.ReactNode;
+  /** Optional content rendered below the section heading */
+  children?: React.ReactNode;
 }
 
 /**
@@ -47,7 +48,7 @@ const FormSection = ({ title, children }: FormSectionProps) => (
 FormSection.propTypes = {
   /** Title of form section */
   title: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 export default FormSection;


### PR DESCRIPTION
The TypeScript conversion in #2165 typed both of `FormSection`'s props as required. Actual usage in the `banking` repo is looser than that:

- ~50 of 64 callsites are self-closing headings with no children, e.g. `<FormSection title={...} />`
- 5 more callsites pass no `title` at all, using the component purely as a divider

Rather than try to fix all those now, I think it's better to loosen these types for now and tighten later. I'm intentionally not adding stories to cover this use case because I don't _think_ we want to encourage it.

## Changes

- `children` is now `children?: React.ReactNode`
- `title` is now `title?: string`
- Dropped `.isRequired` from both propTypes so they no longer warn at runtime

No render changes were made — `{children}` already renders nothing when undefined.