### PR TITLE
ci(typecheck): add dedicated type checking job

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,3 +30,27 @@ jobs:
         run: |
           echo "The job was automatically triggered by a ${{ github.event_name }} event."
           npm run lint
+
+  run-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # `npm run build` runs `tsc`, but only inside jobs that are skipped on a
+      # `dist` cache hit. This runs the type checker unconditionally, and over
+      # every file in `src/` rather than just the `src/index.ts` entry graph.
+      - name: tsc
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint \"./src/**\" \"./scripts/**\" \"./tokens/**\" --no-error-on-unmatched-pattern",
+    "typecheck": "tsc -p tsconfig.check.json",
     "release": "semantic-release",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build --stats-json",

--- a/src/MenuButton/MenuButtonItem.tsx
+++ b/src/MenuButton/MenuButtonItem.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from "react";
 import PropTypes from "prop-types";
-import { VALID_ICON_NAMES } from "src/icons/iconNames";
+import { VALID_ICON_NAMES } from "../icons/iconNames";
 
 export { VALID_ICON_NAMES };
 

--- a/src/Sidebar/SidebarItem.tsx
+++ b/src/Sidebar/SidebarItem.tsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { VALID_ICON_NAMES } from "src/icons/iconNames";
+import { VALID_ICON_NAMES } from "../icons/iconNames";
 import React from "react";
 
 export { VALID_ICON_NAMES };

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.*", "src/**/*.stories.*", "src/**/*.figma.tsx"]
+}


### PR DESCRIPTION
## What

Adds `tsconfig.check.json`, an `npm run typecheck` script, and a `run-typecheck` CI job that runs unconditionally in parallel with lint (~2s).

Also fixes two pre-existing type errors it immediately caught.

## Why

**Type checking is not currently a gate.** `npx tsc` runs only as a side effect of `npm run build`, inside two jobs that both skip it:

- `chromatic-pr.yaml:41` gates the entire job on `has_relevant_changes` (`src/` or `tokens/`). A PR touching only `tsconfig.json`, `package.json` or `scripts/` is never type checked.
- `vitest.yaml:35` and `chromatic-pr.yaml:69` both guard the build with `if: steps.build-cache.outputs.cache-hit != 'true'`, keyed on `hashFiles('src/**', 'package-lock.json')`. Cache hit → no build → no `tsc`.

**The scope is also too narrow.** `tsconfig.json` sets `files: ["src/index.ts", "src/json.d.ts"]`, so only the entry graph is checked. Anything not reachable from `src/index.ts` is invisible.

That combination is how the `LoadingShim` `aria-busy` error survived until #2189, and how five converted components sat stubbed as `any` across four releases.

Demonstration — introducing a deliberate error into `SidebarItem.tsx`, a file orphaned from the entry graph:

```
$ npx tsc --noEmit                    # old config
  -> exit 0                           # silently passes

$ npx tsc -p tsconfig.check.json      # new config
src/Sidebar/SidebarItem.tsx(40,7): error TS2322: Type 'string' is not assignable to type 'number'.
  -> exit 2
```

## The two errors it caught

```
src/Sidebar/SidebarItem.tsx(2,34):       TS2307: Cannot find module 'src/icons/iconNames'
src/MenuButton/MenuButtonItem.tsx(4,34): TS2307: Cannot find module 'src/icons/iconNames'
```

Both import via the `src/` path alias, which vite resolves through `resolve.alias` but which `tsconfig.json` has no matching `paths` entry for — bundler/checker config drift. Both files are orphaned from the entry graph (their parents are still `.js`), so nothing caught them.

## Scope

`src/**/*.{ts,tsx}` — 98 files, versus the ~90 in the entry graph.

Tests and stories are **excluded for now**. Including them surfaces ~440 errors, but 426 are `TS2304`/`TS2582` `Cannot find name 'describe'/'expect'` — missing vitest globals in tsconfig. That is a separate concern I'll follow up to fix it.

`*.figma.tsx` is excluded to match the existing entry in `.eslintignore`. Noting for the record that `SplitButton/index.figma.tsx` has 2 real errors (`TS2739`, Code Connect example missing `startIcon`/`endIcon`).