### PR TITLE
fix(types): convert Toggle to TypeScript

### DIFF
--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -1,7 +1,40 @@
 import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 import cc from "classcat";
 import LoadingShim from "../LoadingShim";
+
+export interface ToggleProps {
+  /**
+   * Callback invoked with current active state (bool) as the function argument
+   * when user changes the active state of the Toggle
+   */
+  onChange?: (isActive: boolean) => void;
+  /** When set to `true`, the toggle will initially render as active */
+  defaultActive?: boolean;
+  /**
+   * Sets active state of toggle; makes the component fully controlled.
+   * When using `isActive` you **must** use the `onChange` callback
+   * to update the active state of the toggle.
+   */
+  isActive?: boolean;
+  /**
+   * Shows a disabled state for the toggle when set to `true`.
+   */
+  disabled?: boolean;
+  /**
+   * Shows a loading state for the toggle when set to `true`.
+   */
+  isLoading?: boolean;
+  /** Label element to render to the right of the toggle */
+  label?: string;
+  /** ID of element that labels the toggle control (e.g. `my-label-element`)*/
+  labelledBy?: string;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** Label for enabled state. Not displayed, used for screen readers. */
+  enabledLabel?: string;
+  /** Label for disabled state. Not displayed, used for screen readers. */
+  disabledLabel?: string;
+}
 
 /**
  * Checkbox behavior with the visual treatment of a physical toggle switch.
@@ -17,12 +50,12 @@ const Toggle = ({
   testId,
   enabledLabel = "on",
   disabledLabel = "off",
-}) => {
+}: ToggleProps) => {
   const isControlled = isActive !== undefined;
   const [active, setActive] = useState(defaultActive);
 
   useEffect(() => {
-    if (isControlled) {
+    if (isActive !== undefined) {
       setActive(isActive);
     }
   }, [isActive, isControlled]);
@@ -79,40 +112,6 @@ const Toggle = ({
   ) : (
     buttonJsx
   );
-};
-
-Toggle.propTypes = {
-  /**
-   * Callback invoked with current active state (bool) as the function argument
-   * when user changes the active state of the Toggle
-   */
-  onChange: PropTypes.func,
-  /** When set to `true`, the toggle will initially render as active */
-  defaultActive: PropTypes.bool,
-  /**
-   * Sets active state of toggle; makes the component fully controlled.
-   * When using `isActive` you **must** use the `onChange` callback
-   * to update the active state of the toggle.
-   */
-  isActive: PropTypes.bool,
-  /**
-   * Shows a disabled state for the toggle when set to `true`.
-   */
-  disabled: PropTypes.bool,
-  /**
-   * Shows a loading state for the toggle when set to `true`.
-   */
-  isLoading: PropTypes.bool,
-  /** Label element to render to the right of the toggle */
-  label: PropTypes.string,
-  /** ID of element that labels the toggle control (e.g. `my-label-element`)*/
-  labelledBy: PropTypes.string,
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
-  /** Label for enabled state. Not displayed, used for screen readers. */
-  enabledLabel: PropTypes.string,
-  /** Label for disabled state. Not displayed, used for screen readers. */
-  disabledLabel: PropTypes.string,
 };
 
 export default Toggle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import TableInput from "./TableInput";
 import TableSelect from "./TableSelect";
 import Tabs from "./Tabs";
 import TimelineEvent from "./TimelineEvent";
+import Toggle from "./Toggle";
 import Tooltip from "./Tooltip";
 import TruncatedAccount from "./TruncatedAccount";
 import useSupportsAnchorPositioning from "./hooks/useSupportsAnchorPositioning";
@@ -65,7 +66,6 @@ declare const Select;
 declare const Sidebar;
 declare const Tag; // ⚠️ DEPRECATED - Will be removed in a future release. Use `Chip` instead.
 declare const TextInput;
-declare const Toggle;
 declare const TokenInput;
 
 export * from "./types/Icon.types";
@@ -148,6 +148,7 @@ export type { TabsListProps } from "./Tabs/TabsList";
 export type { TabsPanelProps } from "./Tabs/TabsPanel";
 export type { TabsTabProps } from "./Tabs/TabsTab";
 export type { TimelineEventProps, TimelineEventKind } from "./TimelineEvent";
+export type { ToggleProps } from "./Toggle";
 export type { TooltipProps } from "./Tooltip";
 export type { TruncatedAccountProps } from "./TruncatedAccount";
 export type { UseBreakpointsResult } from "./hooks/useBreakpoints";


### PR DESCRIPTION
## What

Converts `src/Toggle/index.js` → `.tsx` and removes the `declare const Toggle;` stub. **Untyped stubs: 14 → 13.**

Second of Wave 1. `Toggle` is self-contained — no sub-components, no children introspection — so this is a straight prop-type extraction with the JSDoc carried over verbatim from the `propTypes` block.

## `onChange` is not an event handler

Worth flagging for review. `Toggle` invokes it with a boolean:

```js
const handleToggle = () => {
  if (!isControlled) setActive(!active);
  onChange(!active);      // <- boolean, not an event
};
```

So it's typed `(isActive: boolean) => void`. That is deliberately **unlike `Checkbox`**, whose `onChange` takes a `React.ChangeEvent<HTMLInputElement>`. The existing test already asserts the boolean form (`toHaveBeenLastCalledWith(true)`), so this is faithful — but it's a real inconsistency in the library, and the new type will now catch anyone who assumed the `Checkbox` shape.

## One deliberate runtime change

Narrows the controlled-mode guard:

```diff
  useEffect(() => {
-   if (isControlled) {
+   if (isActive !== undefined) {
      setActive(isActive);
    }
  }, [isActive, isControlled]);
```

These are identical by construction — `isControlled` is defined as exactly `isActive !== undefined` two lines above. But a `boolean` doesn't act as a type predicate, so the original form fails to narrow `isActive` and would error the moment `strictNullChecks` is enabled, which is on the roadmap.

`isControlled` is still used by `handleToggle`, and its dependency-array entry is left untouched — I didn't want to change effect-trigger semantics during a type conversion.

## Bundle impact: 9 bytes

This narrowing is the *entire* runtime delta:

```
common prefix : 501,284 bytes  (identical)
common suffix :   4,400 bytes  (identical)
differing mid :       1 byte -> 10 bytes

baseline: "d"
current : "n!==void 0"
```

That single expression is the whole diff. It also confirms the `propTypes` removal contributed **zero** bytes — unlike `SidebarItem` in #2192, `Toggle`'s were already being stripped by `babel-plugin-transform-react-remove-prop-types` (verified: 0 occurrences of `defaultActive`, `enabledLabel`, `disabledLabel`, `labelledBy` in any `propTypes` object in the shipped bundle).

## Consumer impact

`Toggle` was `any`, so none of this was checked before:

```tsx
<Toggle isActive="yes" />                            // TS2322 — string vs boolean
<Toggle onChange={(e: React.ChangeEvent) => e} />    // TS2322 — see above
<Toggle labell="typo" />                             // TS2322 — "Did you mean 'label'?"
<Toggle label={<span />} />                          // TS2322 — label is string
```

Verified against the built package with a strict consumer config; valid usage across all 10 props compiles clean.

That last one is faithful to the current `PropTypes.string` and matches `Checkbox`'s `label?: string`, but `label` is rendered into a `<span>` and could reasonably be `ReactNode`. Left as-is; widening is a separate call.

Exports `ToggleProps` from the root, per #2191.