### PR TITLE
fix(types): convert CollapsibleCard to TypeScript

### DIFF
--- a/src/CollapsibleCard/index.test.tsx
+++ b/src/CollapsibleCard/index.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CollapsibleCard from "./";
+
+describe("CollapsibleCard", () => {
+  it("renders title and subtitle, and hides children, when closed", () => {
+    render(
+      <CollapsibleCard isOpen={false} title="My title" subtitle="My subtitle">
+        <p>card content</p>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("My title")).toBeInTheDocument();
+    expect(screen.getByText("My subtitle")).toBeInTheDocument();
+    expect(screen.queryByText("card content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when `isOpen` is true", () => {
+    render(
+      <CollapsibleCard isOpen={true} title="My title">
+        <p>card content</p>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("card content")).toBeInTheDocument();
+  });
+
+  it("fires onOpen when closed and onClose when open, via the header trigger", async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <CollapsibleCard isOpen={false} onOpen={onOpen} onClose={onClose}>
+        <p>c</p>
+      </CollapsibleCard>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    rerender(
+      <CollapsibleCard isOpen={true} onOpen={onOpen} onClose={onClose}>
+        <p>c</p>
+      </CollapsibleCard>,
+    );
+    await userEvent.click(screen.getAllByRole("button")[0]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onDisabledClick instead of onOpen when `isDisabled`", async () => {
+    const onOpen = vi.fn();
+    const onDisabledClick = vi.fn();
+    render(
+      <CollapsibleCard
+        isOpen={false}
+        isDisabled
+        onOpen={onOpen}
+        onDisabledClick={onDisabledClick}
+      >
+        <p>c</p>
+      </CollapsibleCard>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(onDisabledClick).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("renders a caret trigger that toggles the card", async () => {
+    const onOpen = vi.fn();
+    render(
+      <CollapsibleCard isOpen={false} trigger="caret-end" onOpen={onOpen}>
+        <p>c</p>
+      </CollapsibleCard>,
+    );
+    const caret = screen.getByRole("button", { name: "Open" });
+    await userEvent.click(caret);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses `renderTitle` in place of the default title, passing `isOpen`", () => {
+    const renderTitle = vi.fn((isOpen: boolean) => (
+      <span>{isOpen ? "custom open" : "custom closed"}</span>
+    ));
+    render(
+      <CollapsibleCard isOpen={true} title="ignored" renderTitle={renderTitle}>
+        <p>c</p>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("custom open")).toBeInTheDocument();
+    expect(screen.queryByText("ignored")).not.toBeInTheDocument();
+    expect(renderTitle).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/CollapsibleCard/index.tsx
+++ b/src/CollapsibleCard/index.tsx
@@ -1,11 +1,54 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cc from "classcat";
 import Row from "../Row";
 import IconButton from "../IconButton";
 import DisabledShim from "../DisabledShim";
 
 const noop = () => {};
+
+export type CollapsibleCardTrigger = "header" | "caret-start" | "caret-end";
+export type CollapsibleCardKind = "ai" | "default";
+export type CollapsibleCardRadiusSize = "s" | "m" | "l";
+
+export interface CollapsibleCardProps {
+  /** Accepts any content as children */
+  children: React.ReactNode;
+  /** Card title */
+  title?: string;
+  /** Card subtitle */
+  subtitle?: string;
+  /** Card status text, placed on the right side of the title container. Can be a JSX fragment. */
+  statusText?: React.ReactNode;
+  /** Controls whether card is opened */
+  isOpen: boolean;
+  /** Callback to handle user opening card */
+  onOpen?: () => void;
+  /** Callback to handle user closing card */
+  onClose?: () => void;
+  /** Disabled cards are greyed out and do not open */
+  isDisabled?: boolean;
+  /** Callback to handle user clicking on disabled card */
+  onDisabledClick?: () => void;
+  /** Displays a red border on the card. Does not interfere with user interactions */
+  hasError?: boolean;
+  /** Disable hover. Useful for cards that are always open */
+  disableHover?: boolean;
+  /** Controls which element is used as the open/close trigger */
+  trigger?: CollapsibleCardTrigger;
+  /**
+   * User-defined render prop that returns JSX.
+   * Called with `(isOpen)` arg you may use for conditional rendering in your custom title JSX.
+   */
+  renderTitle?: (isOpen: boolean) => React.ReactNode;
+  /**
+   * Amount of border radius to add on all sides of card.
+   */
+  radiusSize?: CollapsibleCardRadiusSize;
+  /**
+   * Visual variant of the Collapsible card.
+   */
+  kind?: CollapsibleCardKind;
+}
 
 const CollapsibleCard = ({
   title,
@@ -23,10 +66,13 @@ const CollapsibleCard = ({
   children,
   radiusSize = "l",
   kind = "default",
-}) => {
+}: CollapsibleCardProps) => {
   const [hover, setHover] = React.useState(false);
 
-  const onTitleContainerClick = (disabled = false, action) => {
+  const onTitleContainerClick = (
+    disabled = false,
+    action?: "open" | "close",
+  ) => {
     if (disabled) {
       onDisabledClick();
       return;
@@ -67,7 +113,7 @@ const CollapsibleCard = ({
         onClick={onCaretClick}
         name={`chevron-${isOpen ? "up" : "down"}`}
         textSize="l"
-        onKeyUp={({ key }) => {
+        onKeyUp={({ key }: React.KeyboardEvent) => {
           if (key === "Enter") onCaretClick();
         }}
       />
@@ -153,7 +199,7 @@ const CollapsibleCard = ({
     "bgColor--white",
   ]);
 
-  const headerTriggerProps =
+  const headerTriggerProps: React.HTMLAttributes<HTMLDivElement> =
     trigger === "header"
       ? {
           role: "button",
@@ -195,49 +241,6 @@ const CollapsibleCard = ({
       )}
     </div>
   );
-};
-
-CollapsibleCard.propTypes = {
-  /** Accepts any content as children */
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]).isRequired,
-  /** Card title */
-  title: PropTypes.string,
-  /** Card subtitle */
-  subtitle: PropTypes.string,
-  /** Card status text, placed on the right side of the title container. Can be a JSX fragment. */
-  statusText: PropTypes.node,
-  /** Controls whether card is opened */
-  isOpen: PropTypes.bool.isRequired,
-  /** Callback to handle user opening card */
-  onOpen: PropTypes.func,
-  /** Callback to handle user closing card */
-  onClose: PropTypes.func,
-  /** Disabled cards are greyed out and do not open */
-  isDisabled: PropTypes.bool,
-  /** Callback to handle user clicking on disabled card */
-  onDisabledClick: PropTypes.func,
-  /** Displays a red border on the card. Does not interfere with user interactions */
-  hasError: PropTypes.bool,
-  /** Disable hover. Useful for cards that are always open */
-  disableHover: PropTypes.bool,
-  /** Controls which element is used as the open/close trigger */
-  trigger: PropTypes.oneOf(["header", "caret-start", "caret-end"]),
-  /**
-   * User-defined render prop that returns JSX.
-   * Called with `(isOpen)` arg you may use for conditional rendering in your custom title JSX.
-   */
-  renderTitle: PropTypes.func,
-  /**
-   * Amount of border radius to add on all sides of card.
-   */
-  radiusSize: PropTypes.oneOf(["s", "m", "l"]),
-  /**
-   * Visual variant of the Collapsible card.
-   */
-  kind: PropTypes.oneOf(["ai", "default"]),
 };
 
 export default CollapsibleCard;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import Button from "./Button";
 import ContentCard from "./ContentCard";
 import Checkbox from "./Checkbox";
 import Chip from "./Chip";
+import CollapsibleCard from "./CollapsibleCard";
 import ContextMenu from "./ContextMenu";
 import Count from "./Count";
 import Dialog from "./Dialog";
@@ -55,7 +56,6 @@ import formatNumber from "./formatters/formatNumber";
 /**
  * Untyped Components
  */
-declare const CollapsibleCard;
 declare const Combobox;
 declare const DateInput;
 declare const Drawer;
@@ -92,6 +92,12 @@ export type { AvatarProps } from "./Avatar";
 export type { ButtonProps, ButtonKind } from "./Button";
 export type { CheckboxProps } from "./Checkbox";
 export type { ChipProps } from "./Chip";
+export type {
+  CollapsibleCardProps,
+  CollapsibleCardTrigger,
+  CollapsibleCardKind,
+  CollapsibleCardRadiusSize,
+} from "./CollapsibleCard";
 export type { ContentCardProps } from "./ContentCard";
 export type { ContextMenuProps } from "./ContextMenu";
 export type { ContextMenuItemProps } from "./ContextMenu/ContextMenuItem";


### PR DESCRIPTION
## What

Converts `src/CollapsibleCard/index.jsx` → `.tsx` and removes the `declare const CollapsibleCard;` stub. **Untyped stubs: 12 → 11.**

Third of Wave 1.

## Every change is type-only

`dist/index.js` is **byte-identical** to `main` (`80760cfe`). The component body diff is four annotations and nothing else:

```diff
- }) => {
+ }: CollapsibleCardProps) => {

- const onTitleContainerClick = (disabled = false, action) => {
+ const onTitleContainerClick = (disabled = false, action?: "open" | "close") => {

- onKeyUp={({ key }) => {
+ onKeyUp={({ key }: React.KeyboardEvent) => {

- const headerTriggerProps =
+ const headerTriggerProps: React.HTMLAttributes<HTMLDivElement> =
```

That last one is needed because `headerTriggerProps` is a conditional object (`{role, tabIndex, onKeyUp, onClick}` or `{}`) spread into two different `<div>`s.

`propTypes` removed as part of the conversion. As with `Toggle`, these were already stripped from the bundle by `babel-plugin-transform-react-remove-prop-types` (verified: 0 occurrences of `onDisabledClick`, `disableHover`, `renderTitle`, `radiusSize`), so removal contributes nothing at runtime.

## The `collapisble` misspelling is preserved — deliberately

`index.tsx:142` emits `` `collapisble-card--${kind}` ``. This looks exactly like the dead `.sidebar-icon` class fixed in #2192, but **it is not dead**:

```scss
/* src/CollapsibleCard/index.scss:67 */
.collapisble-card--ai {
  @extend %ai-card-border;
}
```

Both sides are consistently misspelled, so the `ai` variant renders correctly today. Renaming would change an emitted class name that consumer stylesheets may target — a deliberate product decision, not conversion cleanup. Left exactly as-is.

## Tests

`CollapsibleCard` had none, and it's the most stateful component in Wave 1. Added 6 covering the branches that carry logic:

1. Closed — renders title/subtitle, hides children
2. Open — renders children
3. Header trigger — `onOpen` when closed, `onClose` when open
4. `isDisabled` — routes to `onDisabledClick`, **not** `onOpen`
5. `trigger="caret-end"` — caret button toggles
6. `renderTitle` — replaces default title, receives `isOpen`

Verified non-vacuous: mutating the `if (disabled)` guard to a no-op makes test 4 fail, and only test 4.

## Consumer impact

`CollapsibleCard` was `any`, so none of this was checked:

```tsx
<CollapsibleCard>c</CollapsibleCard>                          // TS2741 — isOpen required
<CollapsibleCard isOpen={false} trigger="caret-middle">       // TS2322
<CollapsibleCard isOpen={false} kind="fancy">                 // TS2322
<CollapsibleCard isOpen={false} radiusSize="xl">              // TS2322
<CollapsibleCard isOpen={false} renderTitle={(s: string) => s}> // TS2322
```

Verified against the built package with a strict consumer config; valid usage across all 15 props compiles clean.

Exports `CollapsibleCardProps` plus the `Trigger`, `Kind` and `RadiusSize` unions from the root, per #2191.