### PR TITLE
refactor(components): align component styles with 'ink' tokens

### DIFF
--- a/src/Button/states.scss
+++ b/src/Button/states.scss
@@ -1,7 +1,7 @@
 %_btn-state-disabled-base {
   pointer-events: none;
   user-select: none;
-  color: var(--color-mediumGrey);
+  color: var(--font-color-secondary);
   border: var(--border-size-default) solid var(--border-color-default);
 }
 

--- a/src/Button/variants.scss
+++ b/src/Button/variants.scss
@@ -33,7 +33,7 @@
 
 %btn-kind-tertiary {
   position: relative;
-  color: var(--color-darkGrey);
+  color: var(--font-color-primary);
   background-color: var(--color-white);
   border: var(--border-size-default) solid var(--border-color-default);
 

--- a/src/CollapsibleCard/index.scss
+++ b/src/CollapsibleCard/index.scss
@@ -6,7 +6,7 @@
   width: 100%;
   text-align: left;
   background-color: var(--color-white);
-  border: 1px solid var(--color-lightGrey);
+  border: 1px solid var(--border-color-light);
 }
 
 .collapsible-card-trigger {
@@ -14,7 +14,7 @@
 }
 
 .collapsible-card--content-card.content-card--disabled {
-  border: 1px solid var(--color-lightGrey) !important;
+  border: 1px solid var(--border-color-light) !important;
   overflow: hidden;
 }
 
@@ -36,7 +36,7 @@
   cursor: pointer;
 }
 .collapsible-card--content-card.content-card--hasCaretTrigger.content-card--closed:hover {
-  border: 1px solid var(--color-lightGrey) !important;
+  border: 1px solid var(--border-color-light) !important;
   cursor: unset !important;
 }
 .collapsible-card-titleBar {
@@ -56,11 +56,11 @@
 }
 
 .collapsible-card--content-card .subtitle {
-  color: var(--color-grey) !important;
+  color: var(--font-color-secondary) !important;
 }
 
 .collapsible-card--statusText {
-  color: var(--color-mediumGrey);
+  color: var(--font-color-secondary);
   height: 100%;
 }
 

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -78,6 +78,6 @@
 .nds-combobox-list-heading--hint {
   font-weight: var(--font-weight-normal) !important;
   font-size: var(--font-size-xs) !important;
-  color: var(--color-mediumGrey) !important;
+  color: var(--font-color-secondary) !important;
   padding: var(--space-xs) var(--space-s) var(--space-xxs);
 }

--- a/src/ContentCard/index.scss
+++ b/src/ContentCard/index.scss
@@ -11,7 +11,7 @@
 }
 
 .nds-contentCard--bordered {
-  border: 1px solid var(--color-lightGrey) !important;
+  border: 1px solid var(--border-color-light) !important;
 }
 
 .nds-contentCard--ai {
@@ -21,7 +21,7 @@
 .nds-contentCard--interactive, // DEPRECATED
 .nds-contentCard--button,
 .nds-contentCard--toggle {
-  border: 1px solid var(--color-lightGrey) !important;
+  border: 1px solid var(--border-color-light) !important;
 
   &:hover,
   &:active,

--- a/src/DateInput/index.scss
+++ b/src/DateInput/index.scss
@@ -84,7 +84,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--color-black);
+    color: var(--font-color-heading);
     font-family: var(--font-family-body);
     user-select: none;
   }
@@ -138,7 +138,7 @@ body {
   .flatpickr-day.today:hover {
     background-color: transparent;
     border-color: #e9e9e9;
-    color: var(--color-black);
+    color: var(--font-color-heading);
 
     &:before {
       position: absolute;

--- a/src/Drawer/index.scss
+++ b/src/Drawer/index.scss
@@ -136,7 +136,7 @@ because we need to replace the left/right controls with controls that are inside
 
 /* Buttons */
 .navigation-button {
-  color: var(--color-lightGrey);
+  color: var(--font-color-hint);
   width: 50px;
   height: 50px;
   border-radius: 100%;

--- a/src/DropdownTrigger/index.scss
+++ b/src/DropdownTrigger/index.scss
@@ -26,14 +26,14 @@
   &--disabled {
     user-select: none;
     pointer-events: none;
-    color: var(--color-mediumGrey);
+    color: var(--font-color-secondary);
     background-color: var(--bgColor-smokeGrey);
   }
 }
 
 .nds-dropdownTrigger-label {
   pointer-events: none;
-  color: var(--color-mediumGrey);
+  color: var(--font-color-secondary);
   font-weight: var(--font-weight-default);
   text-rendering: geometricPrecision; // match input placeholder weight
 }

--- a/src/Input/index.scss
+++ b/src/Input/index.scss
@@ -21,7 +21,7 @@
   .nds-input-box {
     box-sizing: border-box;
     min-height: rem(48px);
-    border: 1px solid var(--color-lightGrey);
+    border: 1px solid var(--border-color-light);
     background: var(--color-white);
     position: relative;
     width: 100%;
@@ -53,7 +53,7 @@
 
   .nds-input-subline {
     font-size: var(--font-size-xs);
-    color: var(--color-mediumGrey);
+    color: var(--font-color-secondary);
     display: flex;
     justify-content: space-between;
     flex-direction: row-reverse;
@@ -108,7 +108,7 @@
     font-family: var(--font-family-body);
     font-weight: 400;
     font-size: var(--font-size-xs);
-    color: var(--color-mediumGrey);
+    color: var(--font-color-secondary);
     line-height: var(--font-lineHeight-bodyText);
     white-space: nowrap;
     overflow: hidden;

--- a/src/Radio/index.scss
+++ b/src/Radio/index.scss
@@ -147,7 +147,7 @@
   }
 
   &:hover .narmi-icon-check:before {
-    color: var(--color-lightGrey);
+    color: var(--font-color-hint);
   }
 
   &:has(input:checked) {

--- a/src/Select/index.scss
+++ b/src/Select/index.scss
@@ -62,5 +62,5 @@
 .select-category-title--label {
   font-weight: var(--font-weight-normal) !important;
   font-size: var(--font-size-xs) !important;
-  color: var(--color-mediumGrey) !important;
+  color: var(--font-color-secondary) !important;
 }

--- a/src/TimelineEvent/index.scss
+++ b/src/TimelineEvent/index.scss
@@ -54,7 +54,7 @@
   border-radius: 50%;
   overflow: hidden;
   background-color: var(--theme-primary);
-  border: 1px solid var(--color-lightGrey);
+  border: 1px solid var(--border-color-light);
 
   // support for icons
   color: var(--color-white);

--- a/src/base-styles/typography.scss
+++ b/src/base-styles/typography.scss
@@ -56,7 +56,7 @@
     font-weight: var(--font-weight-bold);
     font-size: var(--font-size-xs);
     text-transform: uppercase;
-    color: var(--color-black);
+    color: var(--font-color-heading);
   }
 
   p {


### PR DESCRIPTION
Many of our component-level styles in NDS use _primitive_ tokens instead of _semantic_ tokens.

This PR updates token usage in components to use the appropriate semantic token, which enables reassignment through forced color modes.