### PR TITLE
fix(ContentCard): use typeof to correctly check type of onClick

### DIFF
--- a/src/ContentCard/index.tsx
+++ b/src/ContentCard/index.tsx
@@ -151,7 +151,7 @@ ContentCard.propTypes = {
       );
     }
     // onClick invalid for non-interactive types
-    if (props[propName] == "function" && !isInteractive) {
+    if (typeof props[propName] === "function" && !isInteractive) {
       return new Error(
         "ContentCard: `onClick` is only valid for `toggle` and `button` types",
       );


### PR DESCRIPTION
`props[propName] == "function"` would always return `false`, because it was comparing a stringified version of the `onClick` prop (coerced by `==`, which was a typo) to the literal string `"function"`.

This prevented the guard from actually validating the prop. This PR uses the correct comparison -- strict equality of the prop `type` against the literal string `"function"`.