### PR TITLE
fix(storybook): restore docgen for TypeScript components

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,3 +54,9 @@ jobs:
       # every file in `src/` rather than just the `src/index.ts` entry graph.
       - name: tsc
         run: npm run typecheck
+
+      # Storybook's react-docgen-typescript pipeline fails silently when its
+      # tsconfig stops covering `src/`, leaving every TS component without
+      # controls or prop descriptions. See scripts/checkDocgen.mjs.
+      - name: Storybook docgen
+        run: npm run check:docgen

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,25 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default {
   typescript: {
     reactDocgen: "react-docgen-typescript",
+    // `@joshwooding/vite-plugin-react-docgen-typescript` (used by
+    // `@storybook/react-vite` for the `react-docgen-typescript` option) skips
+    // any file that is not a root file of the resolved TypeScript project.
+    //
+    // It defaults to the root `tsconfig.json`, which is a build-only config
+    // (`files: ["src/index.ts", "src/json.d.ts"]`). Under that config no `.tsx`
+    // file qualifies, so every TypeScript component silently loses its docgen:
+    // no controls and no prop descriptions in Storybook. Point it at
+    // `tsconfig.check.json` instead, which covers all of `src/`.
+    //
+    // `scripts/checkDocgen.mjs` guards this in CI. Do not remove these options
+    // without running `npm run check:docgen`.
+    reactDocgenTypescriptOptions: {
+      tsconfigPath: "tsconfig.check.json",
+      // Explicit `include` avoids the plugin's default `**/*.tsx` glob, which
+      // walks `node_modules` on every cold start.
+      include: ["src/**/*.tsx"],
+      exclude: ["**/*.stories.tsx", "**/*.test.tsx", "**/*.figma.tsx"],
+    },
   },
 
   stories: [

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:watch": "vitest",
     "lint": "eslint \"./src/**\" \"./scripts/**\" \"./tokens/**\" --no-error-on-unmatched-pattern",
     "typecheck": "tsc -p tsconfig.check.json",
+    "check:docgen": "tsx ./scripts/checkDocgen.mjs",
     "release": "semantic-release",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build --stats-json",

--- a/scripts/checkDocgen.mjs
+++ b/scripts/checkDocgen.mjs
@@ -65,7 +65,11 @@ const main = async () => {
   });
   const pluginContext = {
     warn: (message) => warnings.push(String(message)),
-    error: (message) => warnings.push(String(message)),
+    error: (message) => {
+      const err = new Error(String(message));
+      warnings.push(err.message);
+      throw err;
+    },
     getModuleInfo: () => null,
     meta: {},
   };

--- a/scripts/checkDocgen.mjs
+++ b/scripts/checkDocgen.mjs
@@ -1,0 +1,134 @@
+/**
+ * Guards Storybook's react-docgen-typescript output.
+ *
+ * `@joshwooding/vite-plugin-react-docgen-typescript` (used by
+ * `@storybook/react-vite` when `typescript.reactDocgen` is
+ * `"react-docgen-typescript"`) skips any file that is not a root file of the
+ * resolved TypeScript project. When that happens it emits a `warn` and returns
+ * the source untouched: the Storybook build still succeeds, but every
+ * TypeScript component loses its controls and prop descriptions.
+ *
+ * That exact failure shipped once already, so this script runs the real plugin
+ * with the real options from `.storybook/main.ts` over a few representative
+ * components and fails if the docgen output is missing or has no props.
+ *
+ * Run with `npm run check:docgen`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import reactDocgenTypescript from "@joshwooding/vite-plugin-react-docgen-typescript";
+import mainConfig from "../.storybook/main.ts";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Representative components covering the shapes we care about: a plain
+ * function component, one with a compound subcomponent, and one whose props
+ * come from a shared interface.
+ */
+const SAMPLE_COMPONENTS = [
+  "src/Toggle/index.tsx",
+  "src/Row/index.tsx",
+  "src/Sidebar/index.tsx",
+];
+
+/** Extracts every `__docgenInfo = {...};` payload the plugin appended. */
+const parseDocgenInfo = (code) =>
+  [...code.matchAll(/__docgenInfo = (\{.*\});$/gm)].flatMap(([, json]) => {
+    try {
+      return [JSON.parse(json)];
+    } catch {
+      return [];
+    }
+  });
+
+const main = async () => {
+  // `.storybook/main.ts` is CJS (the package is not `type: "module"`), so the
+  // default export may arrive wrapped depending on the interop path.
+  const config = mainConfig.default ?? mainConfig;
+  const { reactDocgen, reactDocgenTypescriptOptions } = config.typescript ?? {};
+
+  if (reactDocgen !== "react-docgen-typescript") {
+    console.error(
+      `.storybook/main.ts sets typescript.reactDocgen to "${reactDocgen}".\n` +
+        "This check only covers the react-docgen-typescript pipeline; update " +
+        "or remove it if that was intentional.",
+    );
+    process.exit(1);
+  }
+
+  const warnings = [];
+  // Matches how @storybook/react-vite instantiates the plugin.
+  const plugin = reactDocgenTypescript({
+    ...reactDocgenTypescriptOptions,
+    savePropValueAsString: true,
+  });
+  const pluginContext = {
+    warn: (message) => warnings.push(String(message)),
+    error: (message) => warnings.push(String(message)),
+    getModuleInfo: () => null,
+    meta: {},
+  };
+
+  const configResolved = plugin.configResolved.handler ?? plugin.configResolved;
+  await configResolved.call(pluginContext, {
+    root: ROOT_DIR,
+    command: "build",
+    mode: "production",
+    build: {},
+  });
+
+  const transform = (plugin.transform.handler ?? plugin.transform).bind(
+    pluginContext,
+  );
+
+  const failures = [];
+  for (const relativePath of SAMPLE_COMPONENTS) {
+    const id = path.join(ROOT_DIR, relativePath);
+    const result = await transform(fs.readFileSync(id, "utf8"), id);
+    const code = String(result?.code ?? result ?? "");
+    const docs = parseDocgenInfo(code);
+
+    if (docs.length === 0) {
+      failures.push(`${relativePath}: no __docgenInfo was emitted`);
+      continue;
+    }
+
+    const undocumented = docs.filter(
+      (doc) => Object.keys(doc.props ?? {}).length === 0,
+    );
+    if (undocumented.length > 0) {
+      failures.push(
+        `${relativePath}: __docgenInfo has no props for ` +
+          undocumented.map((doc) => doc.displayName).join(", "),
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error("Storybook docgen is broken. Affected components:\n");
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    if (warnings.length > 0) {
+      console.error("\nPlugin warnings:\n");
+      for (const warning of warnings) {
+        console.error(`  - ${warning}`);
+      }
+    }
+    console.error(
+      "\nWithout docgen, these components render in Storybook with no " +
+        "controls and no prop descriptions.\nCheck " +
+        "`typescript.reactDocgenTypescriptOptions` in .storybook/main.ts — the " +
+        "configured\ntsconfig must include the component files.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Storybook docgen OK (${SAMPLE_COMPONENTS.length} components checked).`,
+  );
+};
+
+await main();

--- a/scripts/checkDocgen.mjs
+++ b/scripts/checkDocgen.mjs
@@ -44,8 +44,7 @@ const parseDocgenInfo = (code) =>
   });
 
 const main = async () => {
-  // `.storybook/main.ts` is CJS (the package is not `type: "module"`), so the
-  // default export may arrive wrapped depending on the interop path.
+  // Depending on module interop, the default export may arrive wrapped.
   const config = mainConfig.default ?? mainConfig;
   const { reactDocgen, reactDocgenTypescriptOptions } = config.typescript ?? {};
 


### PR DESCRIPTION
## Problem

Storybook shows no controls and no prop descriptions for every TypeScript component. Reproducible on the deployed site: [Toggle](https://narmi.github.io/design_system/?path=/docs/components-toggle--docs) has an empty Controls table, while [Drawer](https://narmi.github.io/design_system/?path=/docs/components-drawer--docs) (still `.jsx`) is fine.

## Root cause

The [Storybook 9 → 10 bump](https://github.com/narmi/design_system/pull/2107) pulled in `@joshwooding/vite-plugin-react-docgen-typescript@0.7.0`, which was rewritten to use the TypeScript project service. It now **skips any file that is not a root file of the resolved TypeScript project**:

```
Skipping docgen for ".../src/Toggle/index.tsx" because it is not included in
the active TypeScript project.
```

The plugin defaults to `<root>/tsconfig.json`. Ours is a build-only config — `"files": ["src/index.ts", "src/json.d.ts"]`, no `include` — so the project's root-file set is those two files, the intersection with `**/*.tsx` is empty, and **every component is skipped**.

The failure is silent: the plugin emits a `warn`, returns the source unchanged, and the build succeeds. Chromatic stayed green because the rendered stories are unaffected — only the docs metadata is gone.

`.jsx` components still work because `@storybook/react-vite` routes `.js/.jsx/.mjs` through plain `react-docgen` and only sends `.ts/.tsx` to this plugin. That's why the breakage has been growing: each `chore(ts): convert X to TypeScript` PR moves one more component from the working path onto the broken one.

Verified against the deployed bundles — `Drawer` ships full `__docgenInfo` with prop descriptions; `Toggle`, `Row`, `Sidebar` and every other `.tsx` chunk ship none.

## Changes

- **`.storybook/main.ts`** — point the plugin at `tsconfig.check.json`, which covers all of `src/`. Explicit `include: ["src/**/*.tsx"]` also avoids the plugin's default `**/*.tsx` glob walking `node_modules` on cold start.
- **`scripts/checkDocgen.mjs`** — runs the real plugin with the real options from `.storybook/main.ts` over three representative components and fails if `__docgenInfo` is missing or has no props.
- **`.github/workflows/lint.yaml`** — run the guard in the existing `run-typecheck` job.

I chose to reuse `tsconfig.check.json` rather than add another config; it already includes `src/**/*.ts(x)` and excludes tests/stories/figma files.

## Verification

- `NODE_ENV=production npm run build-storybook` — zero "not included in the active TypeScript project" warnings, and 89 emitted assets now carry `__docgenInfo`.
- Confirmed props + descriptions in the built output for TSX components (`Toggle`, `Row`, `Row.Item`, `Sidebar`, `Sidebar.Item`, `IconButton`) and that JSX components (`Drawer`, `TokenInput`) are unchanged.
- Prop counts stay sensible (`IconButton` = 11), so the plugin's default `propFilter` is still stripping `node_modules`-inherited props — no bloated control tables.
- `npm run check:docgen` passes, and fails with a clear message when `reactDocgenTypescriptOptions` is removed.
