### PR TITLE
chore(*): prefer strict comparison in JS/TS

### DIFF
--- a/src/CollapsibleCard/index.tsx
+++ b/src/CollapsibleCard/index.tsx
@@ -102,8 +102,8 @@ const CollapsibleCard = ({
         "collapsible-card-trigger",
         "alignChild--center--center",
         {
-          "padding--left": trigger == "caret-start",
-          "padding--right--l": trigger == "caret-end",
+          "padding--left": trigger === "caret-start",
+          "padding--right--l": trigger === "caret-end",
         },
       ])}
     >

--- a/src/ContentCard/index.tsx
+++ b/src/ContentCard/index.tsx
@@ -141,7 +141,7 @@ ContentCard.propTypes = {
       (kind) => kind === props.kind,
     );
     // must be a function
-    if (isInteractive && typeof props[propName] != "function") {
+    if (isInteractive && typeof props[propName] !== "function") {
       return new Error("ContentCard: `onClick` must be a function");
     }
     // onClick required for interactive types

--- a/src/FieldToken/index.tsx
+++ b/src/FieldToken/index.tsx
@@ -61,7 +61,7 @@ const FieldToken = React.forwardRef<HTMLDivElement, FieldTokenProps>(
               onDismiss(label);
             }}
             onKeyUp={({ key }) => {
-              if (key === "Enter" || key == " ") {
+              if (key === "Enter" || key === " ") {
                 onDismiss(label);
               }
             }}

--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -30,7 +30,7 @@ const Tag = ({
           tabIndex={0}
           onClick={onDismiss}
           onKeyUp={({ key }) => {
-            if (key === "Enter" || key == " ") {
+            if (key === "Enter" || key === " ") {
               onDismiss();
             }
           }}


### PR DESCRIPTION
Drive-by noticed during https://github.com/narmi/design_system/pull/2196

This PR fixes 5 examples of us using `==` when it was more correct to use `===`. I doubt any of these loose comparisons put us at risk of anything -- they were in TypeScript files or a place where we'd only expect a string -- but we gotta Keep Our Code Correct.