### PR TITLE
fix(Combobox): detect broken Safari anchor placement

### DIFF
--- a/src/hooks/useSupportsAnchorPositioning/index.test.ts
+++ b/src/hooks/useSupportsAnchorPositioning/index.test.ts
@@ -1,0 +1,37 @@
+import { isAnchorLayoutValid } from ".";
+
+const anchorRect = {
+  width: 100,
+  left: 20,
+  bottom: 70,
+};
+
+describe("isAnchorLayoutValid", () => {
+  it("accepts a layer aligned below the anchor", () => {
+    expect(
+      isAnchorLayoutValid(anchorRect, {
+        width: 100,
+        left: 20,
+        top: 70,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["width", { width: 0, left: 20, top: 70 }],
+    ["horizontal position", { width: 100, left: 0, top: 70 }],
+    ["vertical position", { width: 100, left: 20, top: 0 }],
+  ])("rejects an incorrect %s", (_description, layerRect) => {
+    expect(isAnchorLayoutValid(anchorRect, layerRect)).toBe(false);
+  });
+
+  it("allows subpixel layout differences", () => {
+    expect(
+      isAnchorLayoutValid(anchorRect, {
+        width: 99.5,
+        left: 20.5,
+        top: 70.5,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/hooks/useSupportsAnchorPositioning/index.ts
+++ b/src/hooks/useSupportsAnchorPositioning/index.ts
@@ -4,8 +4,8 @@
  * Detection strategy:
  * 1. CSS.supports() checks for property/value support (fast path).
  * 2. A separate exported constant `HAS_SCROLL_CONTAINER_BUG` runs a runtime
- *    test to detect Safari's broken anchor-size/position-try-fallbacks inside
- *    scroll containers. Components opt into this check via
+ *    test to detect Safari's broken anchor sizing and placement inside scroll
+ *    containers. Components opt into this check via
  *    `polyfillScrollBug: true` on useDropdownLayer.
  *
  * Both checks run once at module load and are cached.
@@ -29,11 +29,23 @@ const cssChecksPass = (): boolean => {
  * Runtime check for Safari's specific scroll container bug.
  *
  * Creates 3 hidden elements (scroll container + anchor + positioned layer),
- * measures the layer width, and cleans up. If the layer doesn't match the
- * anchor's 100px width, the browser has the bug.
+ * measures the anchor and layer, and cleans up. If the layer doesn't match the
+ * anchor's width and position, the browser has the bug.
  *
  * Only called when cssChecksPass() is true (browser claims support).
  */
+export const isAnchorLayoutValid = (
+  anchorRect: Pick<DOMRect, "width" | "left" | "bottom">,
+  layerRect: Pick<DOMRect, "width" | "left" | "top">,
+): boolean => {
+  const tolerance = 1;
+  return (
+    Math.abs(layerRect.width - anchorRect.width) <= tolerance &&
+    Math.abs(layerRect.left - anchorRect.left) <= tolerance &&
+    Math.abs(layerRect.top - anchorRect.bottom) <= tolerance
+  );
+};
+
 const detectScrollContainerBug = (): boolean => {
   if (typeof document === "undefined") return false;
 
@@ -50,10 +62,11 @@ const detectScrollContainerBug = (): boolean => {
 
   container.append(anchor, layer);
   document.body.appendChild(container);
-  const layerWidth = layer.getBoundingClientRect().width;
+  const anchorRect = anchor.getBoundingClientRect();
+  const layerRect = layer.getBoundingClientRect();
   document.body.removeChild(container);
 
-  return layerWidth !== 100;
+  return !isAnchorLayoutValid(anchorRect, layerRect);
 };
 
 /** Whether the browser supports CSS anchor positioning (CSS checks only). */


### PR DESCRIPTION
## Summary
- validate CSS anchor positioning coordinates in addition to anchor width
- force the existing JavaScript positioning fallback when Safari misplaces a dropdown layer
- cover incorrect width, horizontal placement, vertical placement, and subpixel tolerance

## Testing
- `npm test -- src/hooks/useSupportsAnchorPositioning/index.test.ts`
- `npm run typecheck`