### PR TITLE
fix(ci): resolve backport actions from main, not the switched working tree

### DIFF
--- a/.github/workflows/release-backport.yaml
+++ b/.github/workflows/release-backport.yaml
@@ -64,17 +64,18 @@ jobs:
 
       # The checkout-maintenance-branch action switches the working tree to
       # the maintenance branch, whose tree may predate .github/actions/*.
-      # Reference the actions repo-qualified so they resolve from main
-      # instead of the (switched) working tree.
+      # Reference the actions repo-qualified so they resolve from the pinned
+      # main commit instead of the (switched) working tree.
+      # NOTE: bump these pins when editing .github/actions/*.
       - name: Checkout maintenance branch
         id: branch
-        uses: narmi/design_system/.github/actions/checkout-maintenance-branch@main
+        uses: narmi/design_system/.github/actions/checkout-maintenance-branch@b8d46ba8af843468758961b677e5f97a21b9fd06 # main
         with:
           target_version: ${{ inputs.target_version }}
 
       - name: Cherry-pick
         id: cherry_pick
-        uses: narmi/design_system/.github/actions/cherry-pick@main
+        uses: narmi/design_system/.github/actions/cherry-pick@b8d46ba8af843468758961b677e5f97a21b9fd06 # main
         with:
           merge_sha: ${{ steps.resolve.outputs.merge_sha }}
           branch: ${{ steps.branch.outputs.branch }}
@@ -93,7 +94,7 @@ jobs:
 
       - name: Create conflict PR
         if: steps.cherry_pick.outputs.result == 'conflict'
-        uses: narmi/design_system/.github/actions/create-conflict-pr@main
+        uses: narmi/design_system/.github/actions/create-conflict-pr@b8d46ba8af843468758961b677e5f97a21b9fd06 # main
         with:
           merge_sha: ${{ steps.resolve.outputs.merge_sha }}
           branch: ${{ steps.branch.outputs.branch }}

--- a/.github/workflows/release-backport.yaml
+++ b/.github/workflows/release-backport.yaml
@@ -62,15 +62,19 @@ jobs:
           echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
           echo "Resolved PR #${PR_NUMBER} to merge commit $MERGE_SHA"
 
+      # The checkout-maintenance-branch action switches the working tree to
+      # the maintenance branch, whose tree may predate .github/actions/*.
+      # Reference the actions repo-qualified so they resolve from main
+      # instead of the (switched) working tree.
       - name: Checkout maintenance branch
         id: branch
-        uses: ./.github/actions/checkout-maintenance-branch
+        uses: narmi/design_system/.github/actions/checkout-maintenance-branch@main
         with:
           target_version: ${{ inputs.target_version }}
 
       - name: Cherry-pick
         id: cherry_pick
-        uses: ./.github/actions/cherry-pick
+        uses: narmi/design_system/.github/actions/cherry-pick@main
         with:
           merge_sha: ${{ steps.resolve.outputs.merge_sha }}
           branch: ${{ steps.branch.outputs.branch }}
@@ -89,7 +93,7 @@ jobs:
 
       - name: Create conflict PR
         if: steps.cherry_pick.outputs.result == 'conflict'
-        uses: ./.github/actions/create-conflict-pr
+        uses: narmi/design_system/.github/actions/create-conflict-pr@main
         with:
           merge_sha: ${{ steps.resolve.outputs.merge_sha }}
           branch: ${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
## Problem

The first real use of the **Release Backport** workflow ([run 30652305849](https://github.com/narmi/design_system/actions/runs/30652305849)) failed at the Cherry-pick step:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/cherry-pick'.
```

Local `uses: ./.github/actions/...` references resolve against the working tree **at the moment the step runs**. The `checkout-maintenance-branch` action switches the working tree to the maintenance branch — and `maintenance/6.15.x` was cut from `v6.15.0`, whose tree predates `.github/actions/*`. After the switch, the composite actions no longer exist on disk, so every subsequent local-action step fails. This affects backports to any maintenance line cut before the actions were added.

## Fix

Reference the composite actions repo-qualified (`narmi/design_system/.github/actions/...@main`) so GitHub fetches them from `main` regardless of working-tree state. The actions are pure-shell composites with no nested local references, and they operate on the workspace via git, so behavior inside the steps is unchanged.

## Verification

- YAML parses cleanly.
- After merge, re-dispatching Release Backport with the same inputs (PR + `6.15`) will take the "branch already exists" path (the branch was created by the earlier run's push) and proceed to the cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)