### PR TITLE
refactor(Tag): migrate to TypeScript

### DIFF
--- a/src/Tag/index.tsx
+++ b/src/Tag/index.tsx
@@ -1,22 +1,46 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cc from "classcat";
 
 const noop = () => {};
+
+export interface TagProps {
+  /** Variant of Tag. The "dismissible" kind is deprecated in favor of the dismissible property. */
+  kind?:
+    | "subdued"
+    | "subdued-secondary"
+    | "dismissible"
+    | "outline"
+    | "success"
+    | "warn"
+    | "error";
+  /**
+   * Callback for user dismissal action
+   * (only applicable for `dismissible` kind)
+   */
+  onDismiss?: () => void;
+  /** Whether the tag is dismissible */
+  dismissible?: boolean;
+  /** Label content of tag. */
+  label?: React.ReactNode;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+}
 
 /**
  * ⚠️ DEPRECATED - Will be removed in a future release. Use `Chip` instead.
  *
  * A rounded rectangle inline label.
  * The user has the option of firing a callback for 'dismissible' Tags.
+ *
+ * @deprecated Will be removed in a future release. Use `Chip` instead.
  */
 const Tag = ({
-  kind = "subdued", // outline, subdued, x-tag (cactus400) #7fbc5b; #7FBC5B oneof
+  kind = "subdued",
   onDismiss = noop,
   dismissible,
   label,
   testId,
-}) => {
+}: TagProps) => {
   return (
     <div
       className={cc(["nds-typography", "nds-tag", `nds-tag--${kind}`])}
@@ -38,30 +62,6 @@ const Tag = ({
       )}
     </div>
   );
-};
-
-Tag.propTypes = {
-  /** Variant of Tag. The "dismissible" kind is deprecated in favor of the dismissible property. */
-  kind: PropTypes.oneOf([
-    "subdued",
-    "subdued-secondary",
-    "dismissible",
-    "outline",
-    "success",
-    "warn",
-    "error",
-  ]),
-  /**
-   * Callback for user dismissal action
-   * (only applicable for `dismissible` kind)
-   */
-  onDismiss: PropTypes.func,
-  /** Whether the tag is dismissible */
-  dismissible: PropTypes.bool,
-  /** Label text of tag. */
-  label: PropTypes.string,
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
 };
 
 export default Tag;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import TableDateInput from "./TableDateInput";
 import TableInput from "./TableInput";
 import TableSelect from "./TableSelect";
 import Tabs from "./Tabs";
+import Tag from "./Tag"; // ⚠️ DEPRECATED - Will be removed in a future release. Use `Chip` instead.
 import TimelineEvent from "./TimelineEvent";
 import Toggle from "./Toggle";
 import Tooltip from "./Tooltip";
@@ -64,7 +65,6 @@ declare const MenuButton;
 declare const MultiSelect;
 declare const Popover;
 declare const Select;
-declare const Tag; // ⚠️ DEPRECATED - Will be removed in a future release. Use `Chip` instead.
 declare const TextInput;
 declare const TokenInput;
 
@@ -155,6 +155,7 @@ export type { TabsKind } from "./Tabs/context";
 export type { TabsListProps } from "./Tabs/TabsList";
 export type { TabsPanelProps } from "./Tabs/TabsPanel";
 export type { TabsTabProps } from "./Tabs/TabsTab";
+export type { TagProps } from "./Tag";
 export type { TimelineEventProps, TimelineEventKind } from "./TimelineEvent";
 export type { ToggleProps } from "./Toggle";
 export type { TooltipProps } from "./Tooltip";


### PR DESCRIPTION
## Summary

Migrates `Tag` to TypeScript, following the convention from #2200/#2201: colocated `Props` interface, PropTypes dropped, component moved from the `declare const` block into the typed import block in `src/index.ts`, and `TagProps` re-exported. 

Yes, `Tag` is deprecated, but there's no reason it needs to be _both_ deprecated and untyped.

## Typing decisions (runtime unchanged)

- **`label` typed `React.ReactNode`** — propTypes declared `string`, but banking consumers widely pass JSX (`Row` compositions, `<Localized>` elements).
- **`onDismiss` typed `() => void`** — the keyup path invokes it with no arguments, and every consumer handler is a zero-arg closure, so this stays safe under `strictFunctionTypes`.
- **`kind` keeps the exact propTypes union** — traced every dynamic `kind` expression in banking (`colorByState`, `TAG_KIND_MAP`, `getStatusTagKind`, …); all resolve to members of the union.
- **Deprecation notice upgraded to a `@deprecated` JSDoc tag** — editors now flag `Tag` at consumer callsites, and the tag flows into the published `.d.ts`. The `⚠️ DEPRECATED` comment in `src/index.ts` moves to the import line.

