### PR TITLE
refactor(TextInput): type native attributes per rendered element

### DIFF
--- a/src/TextInput/index.tsx
+++ b/src/TextInput/index.tsx
@@ -7,13 +7,7 @@ export { VALID_ICON_NAMES };
 
 type TextInputElement = HTMLInputElement | HTMLTextAreaElement;
 
-interface TextInputBaseProps extends Omit<
-  React.InputHTMLAttributes<TextInputElement>,
-  // children: TextInput renders its own input element; stray children
-  // would fall through the rest spread onto it (a React error on
-  // <textarea> with a value)
-  "onChange" | "onBlur" | "type" | "value" | "defaultValue" | "children"
-> {
+interface TextInputBaseProps {
   /**
    * Label used as input placeholder _and_ floating label.
    * Also wired to `aria-label` — when omitted, provide an accessible
@@ -46,6 +40,7 @@ interface TextInputBaseProps extends Omit<
   maxLength?: number;
   /** Optional value for `data-testid` attribute */
   testId?: string;
+  /** Native `type` of the input element; ignored when `multiline` is set */
   type?:
     | "text"
     | "tel"
@@ -60,7 +55,23 @@ interface TextInputBaseProps extends Omit<
   required?: boolean;
 }
 
-export interface SingleLineTextInputProps extends TextInputBaseProps {
+// children: TextInput renders its own input element; stray children
+// would fall through the rest spread onto it (a React error on
+// <textarea> with a value)
+type OverriddenNativeKeys =
+  | "onChange"
+  | "onBlur"
+  | "type"
+  | "value"
+  | "defaultValue"
+  | "children"
+  | "maxLength"
+  | "required";
+
+export interface SingleLineTextInputProps
+  extends
+    TextInputBaseProps,
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, OverriddenNativeKeys> {
   /** When true, the input is displayed as an auto-growing textarea */
   multiline?: false;
   /** Callback invoked with event object on input change */
@@ -69,7 +80,13 @@ export interface SingleLineTextInputProps extends TextInputBaseProps {
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
 }
 
-export interface MultilineTextInputProps extends TextInputBaseProps {
+export interface MultilineTextInputProps
+  extends
+    TextInputBaseProps,
+    Omit<
+      React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      OverriddenNativeKeys
+    > {
   /** When true, the input is displayed as an auto-growing textarea */
   multiline: true;
   /** Callback invoked with event object on textarea change */
@@ -79,6 +96,28 @@ export interface MultilineTextInputProps extends TextInputBaseProps {
 }
 
 export type TextInputProps = SingleLineTextInputProps | MultilineTextInputProps;
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+const nativeProps = <P extends TextInputProps>({
+  startIcon,
+  endIcon,
+  startContent,
+  endContent,
+  showClearButton,
+  formatter,
+  multiline,
+  defaultValue,
+  onChange,
+  onBlur,
+  maxLength,
+  testId,
+  type,
+  error,
+  renderError,
+  required,
+  ...rest
+}: P) => rest;
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**
  * Narmi flavored text input with floating label
@@ -92,17 +131,13 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
       endContent,
       showClearButton,
       formatter = (x) => x,
-      multiline,
       defaultValue,
       onChange,
-      onBlur,
       maxLength,
       testId,
-      type = "text",
       error,
       renderError = true,
       required = false,
-      ...nativeElementProps
     } = props;
 
     const [inputValue, setInputValue] = useState(
@@ -120,7 +155,7 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
       setInputValue("");
     }
 
-    const charCount = String(nativeElementProps?.value || inputValue).length;
+    const charCount = String(props.value || inputValue).length;
     const showCharacterCounter = maxLength;
     const characterCounter = showCharacterCounter ? (
       <div className="nds-input-character-counter">
@@ -147,7 +182,7 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
         clearInput={_onClearInput}
         tailContent={characterCounter}
       >
-        {multiline === true ? (
+        {props.multiline === true ? (
           <div
             className="nds-input-multiline-grid"
             data-textarea-value={inputValue}
@@ -158,11 +193,11 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
               ref={forwardedRef as React.Ref<HTMLTextAreaElement>}
               value={inputValue}
               onChange={(e) => {
-                onChange?.(e);
+                props.onChange?.(e);
                 setInputValue(e.target.value);
               }}
               onBlur={(e) => {
-                onBlur?.(e);
+                props.onBlur?.(e);
                 setInputValue(formatter(e.target.value));
               }}
               required={required}
@@ -170,7 +205,7 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
               aria-label={props.label}
               data-testid={testId}
               data-error={inputError}
-              {...nativeElementProps}
+              {...nativeProps(props)}
             />
           </div>
         ) : (
@@ -178,21 +213,21 @@ const TextInput = React.forwardRef<TextInputElement, TextInputProps>(
             key={"nds-text"}
             value={inputValue}
             onChange={(e) => {
-              onChange?.(e);
+              props.onChange?.(e);
               setInputValue(e.target.value);
             }}
             onBlur={(e) => {
-              onBlur?.(e);
+              props.onBlur?.(e);
               setInputValue(formatter(e.target.value));
             }}
             ref={forwardedRef as React.Ref<HTMLInputElement>}
-            type={type}
+            type={props.type ?? "text"}
             required={required}
             aria-label={props.label}
             placeholder={props.label}
             data-testid={testId}
             data-error={inputError}
-            {...nativeElementProps}
+            {...nativeProps(props)}
           />
         )}
       </Input>


### PR DESCRIPTION
## Summary

Stacked on #2201 — completes its discriminated-union design. Instead of both variants sharing one `Omit<InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>>` base, each union member now extends the attribute bag of the element it actually renders: `SingleLineTextInputProps` gets `InputHTMLAttributes<HTMLInputElement>`, `MultilineTextInputProps` gets `TextareaHTMLAttributes<HTMLTextAreaElement>`. `TextInputBaseProps` keeps only the NDS-specific props. (This is the correctly-shaped version of Copilot's intersection suggestion on #2201 — an intersection would advertise every prop on both variants and blur the distinction the discriminant just introduced.)

## What changes for consumers (types only, runtime untouched)

- **Auxiliary handlers (`onKeyDown`, `onFocus`, …) are exactly element-typed per variant** instead of handler-over-element-union. Under `strictFunctionTypes` this makes single-element-annotated handlers type-check on the matching variant — the 2 banking callsites that do this (staff Table.tsx `onKeyDown`, ImagePicker `onClick`) go from would-be errors to compiling as-is. Zero banking multiline sites annotate aux handlers against the input element, so nothing regresses.
- **textarea-only props (`rows`, `cols`, `wrap`, `dirName`) become legal on multiline inputs** — the runtime always spread them through; they were just untypeable.
- **input-only props (`pattern`, `min`, `step`, …) are rejected on multiline** (verified: zero banking callsites pass them).
- `type` stays in the shared base rather than moving to the single-line member: the `nativeProps` helper destructures it, and a property that exists on only one union member can't be destructured from the union. Its doc comment now notes it's ignored when `multiline` is set.

## Internals

The native rest can no longer be split off before narrowing — a union-typed rest does not narrow with the discriminant, so spreading it onto either element would need casts. A `nativeProps` helper strips the same 16 NDS-only keys the old destructure removed (`label`, `value`, and `search` intentionally still fall through to the element, exactly as before) and is called with the narrowed props inside each render branch, keeping each spread exactly typed. The component compiles clean under full `strict` with no suppressions beyond the helper's unused-bindings eslint disable.

## Verification

- Repo `tsc`, eslint, and the full vitest suite pass; the component file also compiles standalone under `strict: true`.
- Strict-mode consumer file: all #2201 banking patterns still compile, plus the new positives (element-annotated aux handler on single-line, `rows`/`wrap` on multiline, `pattern`/`inputMode` on single-line, generic-element handlers). Negatives correctly rejected: `pattern` on multiline, input-annotated aux handler on multiline.
- One known softness: `rows` on a *single-line* TextInput isn't rejected — with the discriminant omitted, TS checks excess props against the whole union. It's inert, matching the runtime passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)