### PR TITLE
refactor(Drawer): migrate to TypeScript

### DIFF
--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -23,12 +23,14 @@ export interface DrawerProps {
   onUserDismiss?: () => void;
   /**
    * Callback to handle user taking an action to go to the next element
-   * (click on the next arrow, right/down arrow key)
+   * (click on the next arrow, right/down arrow key).
+   * Pass `null` to render the next arrow disabled.
    */
   onNext?: (() => void) | null;
   /**
    * Callback to handle user taking an action to go to the previous element
-   * (click on the previous arrow, left/up arrow key)
+   * (click on the previous arrow, left/up arrow key).
+   * Pass `null` to render the previous arrow disabled.
    */
   onPrev?: (() => void) | null;
   /**
@@ -83,6 +85,9 @@ const Drawer = ({
   const panelId = `content-panel-${useId()}`;
   const shimRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
+
+  const nextHandler = onNext ?? undefined;
+  const prevHandler = onPrev ?? undefined;
 
   const isTransitioning = useMountTransition(isOpen, 300);
   const { m } = useBreakpoints();
@@ -165,7 +170,7 @@ const Drawer = ({
                     : onPrev == null,
                 },
               ])}
-              onClick={(isHorizontal ? onNext : onPrev) ?? undefined}
+              onClick={isHorizontal ? nextHandler : prevHandler}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Next" : "Previous"}
             >
@@ -184,7 +189,7 @@ const Drawer = ({
                     : onNext == null,
                 },
               ])}
-              onClick={(isHorizontal ? onPrev : onNext) ?? undefined}
+              onClick={isHorizontal ? prevHandler : nextHandler}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Previous" : "Next"}
             >
@@ -221,7 +226,7 @@ const Drawer = ({
               <>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--prev"
-                  onClick={onPrev ?? undefined}
+                  onClick={prevHandler}
                   aria-controls={panelId}
                   aria-label="Previous"
                 >
@@ -229,7 +234,7 @@ const Drawer = ({
                 </button>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--next"
-                  onClick={onNext ?? undefined}
+                  onClick={nextHandler}
                   aria-controls={panelId}
                   aria-label="Next"
                 >

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions,react/require-default-props */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useRef, useEffect, useId } from "react";
 import ReactDOM from "react-dom";
-import PropTypes from "prop-types";
 import cc from "classcat";
 import useBreakpoints from "../hooks/useBreakpoints";
 import useMountTransition from "./useMountTransition";
@@ -9,6 +8,56 @@ import useLockBodyScroll from "../hooks/useLockBodyScroll";
 import FocusLock from "react-focus-lock";
 
 const noop = () => {};
+
+export interface DrawerProps {
+  /** Scrollable contents of the Drawer */
+  children:
+    | React.ReactNode
+    | ((args: { isVisible: boolean }) => React.ReactNode);
+  /** Controls open/close state of the modal. Use the `onUserDismiss` callback to update. */
+  isOpen?: boolean;
+  /**
+   * Callback to handle user taking an action to dismiss the modal
+   * (click outside, Escape key, click close button)
+   */
+  onUserDismiss?: () => void;
+  /**
+   * Callback to handle user taking an action to go to the next element
+   * (click on the next arrow, right/down arrow key)
+   */
+  onNext?: (() => void) | null;
+  /**
+   * Callback to handle user taking an action to go to the previous element
+   * (click on the previous arrow, left/up arrow key)
+   */
+  onPrev?: (() => void) | null;
+  /**
+   * Sets how far the drawer opens out (width or height).
+   * Use the full CSS value with the percentage (e.g. `"400px"` or `"70%"`)
+   */
+  depth?: string;
+  /**
+   * Determines whether the close button shows.
+   */
+  showClose?: boolean;
+  /**
+   * Determines whether the next and prev buttons show.
+   */
+  showControls?: boolean;
+  /**
+   * Sets the position from which the drawers open.
+   * Valid values are `right`, `left`, `bottom`, `top`.
+   */
+  position?: "right" | "left" | "top" | "bottom";
+  /**
+   * Sets the padding amount, or disable padding by passing "none"
+   */
+  paddingSize?: "none" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
+  /** Contents of Drawer footer, typically reserved for action buttons */
+  footer?: React.ReactNode;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+}
 
 /**
  * Renders an animated drawer dialog with an overlay that
@@ -30,10 +79,10 @@ const Drawer = ({
   paddingSize = "xxl",
   footer,
   testId,
-}) => {
+}: DrawerProps) => {
   const panelId = `content-panel-${useId()}`;
-  const shimRef = useRef(null);
-  const navRef = useRef(null);
+  const shimRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
 
   const isTransitioning = useMountTransition(isOpen, 300);
   const { m } = useBreakpoints();
@@ -42,14 +91,16 @@ const Drawer = ({
 
   // The depth is how far the drawer opens out, but the CSS prop depends
   // on whether the Drawer is vertical or not
-  const depthStyle = isHorizontal ? { height: depth } : { width: depth };
+  const depthStyle: React.CSSProperties = isHorizontal
+    ? { height: depth }
+    : { width: depth };
   if (isVerticalMobileDrawer) {
     depthStyle.width = "100%";
   }
 
   useLockBodyScroll(isOpen);
 
-  const handleKeyDown = ({ key }) => {
+  const handleKeyDown = ({ key }: KeyboardEvent) => {
     if (key === "Escape") {
       onUserDismiss();
     }
@@ -63,7 +114,7 @@ const Drawer = ({
     };
   }, [handleKeyDown, isOpen]);
 
-  const handleShimClick = ({ target }) => {
+  const handleShimClick = ({ target }: React.MouseEvent) => {
     if (
       (navRef.current && target === navRef.current) ||
       (shimRef.current && target === shimRef.current)
@@ -114,7 +165,7 @@ const Drawer = ({
                     : onPrev == null,
                 },
               ])}
-              onClick={isHorizontal ? onNext : onPrev}
+              onClick={(isHorizontal ? onNext : onPrev) ?? undefined}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Next" : "Previous"}
             >
@@ -133,7 +184,7 @@ const Drawer = ({
                     : onNext == null,
                 },
               ])}
-              onClick={isHorizontal ? onPrev : onNext}
+              onClick={(isHorizontal ? onPrev : onNext) ?? undefined}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Previous" : "Next"}
             >
@@ -170,7 +221,7 @@ const Drawer = ({
               <>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--prev"
-                  onClick={onPrev}
+                  onClick={onPrev ?? undefined}
                   aria-controls={panelId}
                   aria-label="Previous"
                 >
@@ -178,7 +229,7 @@ const Drawer = ({
                 </button>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--next"
-                  onClick={onNext}
+                  onClick={onNext ?? undefined}
                   aria-controls={panelId}
                   aria-label="Next"
                 >
@@ -240,68 +291,21 @@ const Drawer = ({
 
   function renderDrawerInOutlet() {
     // create a single outlet
-    if (!document.getElementById("outlet")) {
-      const outlet = document.createElement("div");
+    let outlet = document.getElementById("outlet");
+    if (!outlet) {
+      outlet = document.createElement("div");
       outlet.setAttribute("id", "outlet");
       outlet.setAttribute("class", "outlet");
       document.body.appendChild(outlet);
     }
-    return ReactDOM.createPortal(drawerJSX, document.getElementById("outlet"));
+    return ReactDOM.createPortal(drawerJSX, outlet);
   }
 
   if (!isTransitioning && !isOpen) {
     return null;
   }
 
-  return <>{document && renderDrawerInOutlet()}</>;
-};
-
-Drawer.propTypes = {
-  /** Scrollable contents of the Drawer */
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-  /** Controls open/close state of the modal. Use the `onUserDismiss` callback to update. */
-  isOpen: PropTypes.bool,
-  /**
-   * Callback to handle user taking an action to dismiss the modal
-   * (click outside, Escape key, click close button)
-   */
-  onUserDismiss: PropTypes.func,
-  /**
-   * Callback to handle user taking an action to go to the next element
-   * (click on the next arrow, right/down arrow key)
-   */
-  onNext: PropTypes.func,
-  /**
-   * Callback to handle user taking an action to go to the previous element
-   * (click on the previous arrow, left/up arrow key)
-   */
-  onPrev: PropTypes.func,
-  /**
-   * Sets how far the drawer opens out (width or height).
-   * Use the full CSS value with the percentage (e.g. `"400px"` or `"70%"`)
-   */
-  depth: PropTypes.string,
-  /**
-   * Determines whether the close button shows.
-   */
-  showClose: PropTypes.bool,
-  /**
-   * Determines whether the next and prev buttons show.
-   */
-  showControls: PropTypes.bool,
-  /**
-   * Sets the position from which the drawers open.
-   * Valid values are `right`, `left`, `bottom`, `top`.
-   */
-  position: PropTypes.oneOf(["right", "left", "top", "bottom"]),
-  /**
-   * Sets the padding amount, or disable padding by passing "none"
-   */
-  paddingSize: PropTypes.oneOf(["none", "xs", "s", "m", "l", "xl", "xxl"]),
-  /** Contents of Drawer footer, typically reserved for action buttons */
-  footer: PropTypes.node,
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
+  return <>{document ? renderDrawerInOutlet() : null}</>;
 };
 
 export default Drawer;

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -24,15 +24,15 @@ export interface DrawerProps {
   /**
    * Callback to handle user taking an action to go to the next element
    * (click on the next arrow, right/down arrow key).
-   * Pass `null` to render the next arrow disabled.
+   * When omitted, the next arrow renders disabled.
    */
-  onNext?: (() => void) | null;
+  onNext?: () => void;
   /**
    * Callback to handle user taking an action to go to the previous element
    * (click on the previous arrow, left/up arrow key).
-   * Pass `null` to render the previous arrow disabled.
+   * When omitted, the previous arrow renders disabled.
    */
-  onPrev?: (() => void) | null;
+  onPrev?: () => void;
   /**
    * Sets how far the drawer opens out (width or height).
    * Use the full CSS value with the percentage (e.g. `"400px"` or `"70%"`)
@@ -71,8 +71,8 @@ export interface DrawerProps {
 const Drawer = ({
   isOpen = false,
   onUserDismiss = noop,
-  onNext = null,
-  onPrev = null,
+  onNext,
+  onPrev,
   showClose = true,
   showControls = true,
   children,
@@ -85,9 +85,6 @@ const Drawer = ({
   const panelId = `content-panel-${useId()}`;
   const shimRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
-
-  const nextHandler = onNext ?? undefined;
-  const prevHandler = onPrev ?? undefined;
 
   const isTransitioning = useMountTransition(isOpen, 300);
   const { m } = useBreakpoints();
@@ -166,11 +163,11 @@ const Drawer = ({
                   // horizontal ones due to the order of navigation buttons being the opposite
                   // (rows are reversed in parent divs for horizontal drawers)
                   "navigation-button--disabled": isHorizontal
-                    ? onNext == null
-                    : onPrev == null,
+                    ? onNext === undefined
+                    : onPrev === undefined,
                 },
               ])}
-              onClick={isHorizontal ? nextHandler : prevHandler}
+              onClick={isHorizontal ? onNext : onPrev}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Next" : "Previous"}
             >
@@ -185,11 +182,11 @@ const Drawer = ({
                 `button--reset navigation-button navigation-button--${position} alignChild--center--center`,
                 {
                   "navigation-button--disabled": isHorizontal
-                    ? onPrev == null
-                    : onNext == null,
+                    ? onPrev === undefined
+                    : onNext === undefined,
                 },
               ])}
-              onClick={isHorizontal ? prevHandler : nextHandler}
+              onClick={isHorizontal ? onPrev : onNext}
               aria-controls={panelId}
               aria-label={isHorizontal ? "Previous" : "Next"}
             >
@@ -226,7 +223,7 @@ const Drawer = ({
               <>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--prev"
-                  onClick={prevHandler}
+                  onClick={onPrev}
                   aria-controls={panelId}
                   aria-label="Previous"
                 >
@@ -234,7 +231,7 @@ const Drawer = ({
                 </button>
                 <button
                   className="button--reset mobile-navigation-button mobile-navigation-button--next"
-                  onClick={nextHandler}
+                  onClick={onNext}
                   aria-controls={panelId}
                   aria-label="Next"
                 >

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import Count from "./Count";
 import DateInput from "./DateInput";
 import Dialog from "./Dialog";
 import DisabledShim from "./DisabledShim";
+import Drawer from "./Drawer";
 import Error from "./Error";
 import DropdownTrigger from "./DropdownTrigger";
 import Field from "./Field";
@@ -64,7 +65,6 @@ import formatNumber from "./formatters/formatNumber";
  * Untyped Components
  */
 declare const Combobox;
-declare const Drawer;
 declare const MultiSelect;
 declare const Select;
 
@@ -105,6 +105,7 @@ export type { CountProps } from "./Count";
 export type { DateInputProps } from "./DateInput";
 export type { DialogProps } from "./Dialog";
 export type { DisabledShimProps } from "./DisabledShim";
+export type { DrawerProps } from "./Drawer";
 export type { DropdownTriggerProps } from "./DropdownTrigger";
 export type { ErrorProps } from "./Error";
 export type { FieldProps } from "./Field/types";


### PR DESCRIPTION
## Summary

Migrates `Drawer` to TypeScript, following the established convention: colocated `Props` interface, PropTypes dropped, component moved from the `declare const` block into the typed import block in `src/index.ts`, and `DrawerProps` re-exported. With this, the untyped block is down to the downshift trio: Combobox, MultiSelect, Select.

## Typing decisions (runtime unchanged unless noted)

- **`children` keeps both documented shapes**: `ReactNode` or the `({ isVisible }) => ReactNode` render prop. No banking callsite uses the render prop, but it's documented and cheap to keep.
- **`onNext`/`onPrev` are plain optional `() => void`** — the old `null` default was a sentinel choice, never semantics: the disabled-arrow check was loose `== null` and React treats `null`/`undefined` onClick identically, so nothing ever distinguished them. The checks are now explicit `=== undefined` and the handlers flow straight to `onClick` with no coalescing. **Types-only breakage**: four staff wrappers (PaymentDetailDrawer, ScheduledPaymentDetailDrawer, FedNowTransactionDrawer, PaymentDetailDrawerRouter) declare and forward `(() => void) | null` handlers — verified no caller of any of them ever supplies the props, and their derive-helpers' `null` returns behave identically as `undefined`, so flipping them to plain optional in banking is mechanical with zero behavior change.
- **The outlet-portal helper** captures `getElementById` in a local, so the found-or-created element flows to `createPortal` without a non-null assertion.
- **`document && renderDrawerInOutlet()` became a ternary with `null`** — a `Document` isn't a valid JSX child type. Runtime identical: `document` is always truthy in a browser, and `false`/`null` render the same.

