### PR TITLE
fix(TextInput): accept form-integration `field` prop in types

### DIFF
--- a/src/TextInput/index.tsx
+++ b/src/TextInput/index.tsx
@@ -53,6 +53,12 @@ interface TextInputBaseProps {
     | "datetime-local";
   /** Native element prop passed to the underlying input/textarea element. Defaults to false. */
   required?: boolean;
+  /**
+   * Form-integration key read by parent form wrappers (e.g. cerulean
+   * `ContextForm.Field`) via element props. Not used by this component
+   * and not forwarded to the DOM.
+   */
+  field?: string;
 }
 
 // children: TextInput renders its own input element; stray children
@@ -115,6 +121,7 @@ const nativeProps = <P extends TextInputProps>({
   error,
   renderError,
   required,
+  field,
   ...rest
 }: P) => rest;
 /* eslint-enable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
## What

Adds an optional, documented `field?: string` to `TextInputBaseProps`, and strips it from the native-element spread in `nativeProps`. `DateInputProps` extends `SingleLineTextInputProps`, so it picks the prop up automatically.

## Why

The Input-chain TypeScript migration (#2201) made `TextInputProps` strict, rejecting unknown props. But banking passes `field="..."` directly on `TextInput`/`DateInput` elements at ~45 call sites so cerulean's `ContextForm.Field` can discover and wire inputs — it scans direct children for `child.props.field`, adopts it as the form-state key, and `cloneElement`s in `value`/`onChange`/`error`. The prop is never used by TextInput itself, but it must be allowed on the element or those forms fail to typecheck (and deleting it at call sites would silently unwire them at runtime).

Verified against banking: with this change the `field`-related type errors in ao and azul disappear.

Clearly this should probably be refactored on the `banking` side in the fullness of time, but this is necessary to respect what's happening in practice today.