### PR TITLE
refactor(MultiSelect): migrate to TypeScript

### DIFF
--- a/src/DropdownTrigger/index.tsx
+++ b/src/DropdownTrigger/index.tsx
@@ -2,16 +2,15 @@ import React, { ReactNode, forwardRef } from "react";
 import cc from "classcat";
 import Error from "../Error";
 
-export interface DropdownTriggerProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface DropdownTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Set this to `true` when the associated popup is open */
   isOpen?: boolean;
   /** Set to `false` to hide the chevron icon indicating open state */
   showOpenIndicator?: boolean;
   /** Variant of the trigger. Use "table" when used inside table cells */
   kind?: "default" | "table";
-  /** Text of `label` element */
-  labelText?: string;
+  /** Content of the `label` element */
+  labelText?: ReactNode;
   /** Props to spread onto the `label` element */
   labelProps?: React.LabelHTMLAttributes<HTMLLabelElement>;
   /**

--- a/src/MultiSelect/index.test.jsx
+++ b/src/MultiSelect/index.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import MultiSelect from "./";
+
+const renderMultiSelect = (props = {}) =>
+  render(
+    <MultiSelect label="Numbers" onSelectedItemsChange={() => {}} {...props}>
+      <MultiSelect.Item value="uno">one</MultiSelect.Item>
+      <MultiSelect.Item value="dos">two</MultiSelect.Item>
+    </MultiSelect>,
+  );
+
+describe("MultiSelect", () => {
+  it("selects with Enter and keeps the menu open for more selections", () => {
+    const onSelectedItemsChange = vi.fn();
+    renderMultiSelect({ onSelectedItemsChange });
+    const trigger = screen.getByRole("combobox");
+
+    fireEvent.click(trigger);
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(onSelectedItemsChange).toHaveBeenCalledWith(["uno"]);
+    expect(screen.getByRole("listbox")).not.toBeEmptyDOMElement();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(onSelectedItemsChange).toHaveBeenLastCalledWith(["uno", "dos"]);
+  });
+
+  it("selects with Space and keeps the menu open for more selections", () => {
+    const onSelectedItemsChange = vi.fn();
+    renderMultiSelect({ onSelectedItemsChange });
+    const trigger = screen.getByRole("combobox");
+
+    fireEvent.click(trigger);
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    fireEvent.keyDown(trigger, { key: " " });
+
+    expect(onSelectedItemsChange).toHaveBeenCalledWith(["uno"]);
+    expect(screen.getByRole("listbox")).not.toBeEmptyDOMElement();
+
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    fireEvent.keyDown(trigger, { key: " " });
+    expect(onSelectedItemsChange).toHaveBeenLastCalledWith(["uno", "dos"]);
+  });
+
+  it("selects on item click without closing the menu", () => {
+    const onSelectedItemsChange = vi.fn();
+    renderMultiSelect({ onSelectedItemsChange });
+    const trigger = screen.getByRole("combobox");
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText("two"));
+
+    expect(onSelectedItemsChange).toHaveBeenCalledWith(["dos"]);
+    expect(screen.getByRole("listbox")).not.toBeEmptyDOMElement();
+  });
+});

--- a/src/MultiSelect/index.tsx
+++ b/src/MultiSelect/index.tsx
@@ -1,55 +1,71 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React, { useMemo, useEffect, Children } from "react";
-import PropTypes from "prop-types";
-import { useSelect, useMultipleSelection } from "downshift";
+import {
+  useSelect,
+  useMultipleSelection,
+  UseMultipleSelectionReturnValue,
+} from "downshift";
 import useDropdownLayer from "../hooks/useDropdownLayer";
 import cc from "classcat";
 import DropdownTrigger from "../DropdownTrigger";
 import Button from "../Button";
-import MultiSelectItem from "./MultiSelectItem";
+import MultiSelectItem, { MultiSelectItemProps } from "./MultiSelectItem";
 import FieldToken from "../FieldToken";
 import Row from "../Row";
 
 const noop = () => {};
 
+type MultiSelectItemElement = React.ReactElement<MultiSelectItemProps>;
+
 /**
  * @param item JSX node
  * @returns string
  */
-const itemToString = (item) =>
+const itemToString = (item: MultiSelectItemElement | null | undefined) =>
   !item?.props ? "" : item.props.searchValue || item.props.value;
 
 /**
  * Check an item component against the tokens list to see if it's currently selected
  */
-const isSelected = (selectedItems, item) =>
-  selectedItems.map(itemToString).includes(itemToString(item));
+const isSelected = (
+  selectedItems: MultiSelectItemElement[],
+  item: MultiSelectItemElement | null | undefined,
+) => selectedItems.map(itemToString).includes(itemToString(item));
 
 /**
  * Gets full item element by its `value` prop
  */
-const getSelectedItems = (values, items) =>
+const getSelectedItems = (values: string[], items: MultiSelectItemElement[]) =>
   items.filter((item) => values.includes(item.props.value));
 
 /**
- * @param {Node} selectItem full react element of a select item
- * @param {String} userInput most recent thing a user typed while focused on input
- * @returns {String} the string to use for typeahead for each given `selectItem`
+ * @param selectItem full react element of a select item
+ * @param userInput most recent thing a user typed while focused on input
+ * @returns the string to use for typeahead for each given `selectItem`
  */
-// eslint-disable-next-line no-unused-vars
-const defaultGetTypeAheadString = (userInput = "", selectItem) => {
+const defaultGetTypeAheadString = (
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  userInput = "",
+  selectItem: MultiSelectItemElement,
+) => {
   return selectItem.props.searchValue || selectItem.props.value;
 };
 
+export interface MultiSelectSummaryFormatterArgs {
+  /** Currently selected item React elements */
+  selectedItems: MultiSelectItemElement[];
+  /** downshift helper for token props */
+  getSelectedItemProps: UseMultipleSelectionReturnValue<MultiSelectItemElement>["getSelectedItemProps"];
+  /** Removes a token */
+  removeSelectedItem: (item: MultiSelectItemElement) => void;
+  /** Flag indicating if the component is disabled */
+  disabled: boolean;
+  /** Placeholder text when no items are selected */
+  label: string;
+}
+
 /**
  * Default summary formatter function.
- *
- * Receives an object with:
- *   - selectedItems: Array of currently selected item React elements.
- *   - getSelectedItemProps: Helper function for token props.
- *   - removeSelectedItem: Function to remove a token.
- *   - disabled: Flag indicating if the component is disabled.
- *   - label: Placeholder text when no items are selected.
  *
  * If no items are selected, returns the label.
  * Otherwise, returns a container with FieldToken components.
@@ -61,7 +77,7 @@ const defaultSummaryFormatter = ({
   removeSelectedItem,
   disabled,
   label,
-}) => {
+}: MultiSelectSummaryFormatterArgs): React.ReactNode => {
   if (selectedItems.length === 0) {
     return label;
   }
@@ -75,13 +91,71 @@ const defaultSummaryFormatter = ({
             label={tokenLabel}
             onDismiss={() => removeSelectedItem(item)}
             disabled={disabled}
-            {...getSelectedItemProps({ selectedItem: item, i })}
+            {...getSelectedItemProps({ selectedItem: item })}
           />
         );
       })}
     </div>
   );
 };
+
+export interface MultiSelectProps {
+  /**
+   * unique name attribute for the input (used for `id` and `name`).
+   * The trigger id falls back to a value derived from `label`.
+   */
+  name?: string;
+  /** Label for the select control */
+  label: string;
+  /** MultiSelect.Item children */
+  children?: React.ReactNode;
+  /**
+   * When passed, the MultiSelect becomes fully controlled.
+   * Use `onSelectedItemsChange` to manage this value.
+   */
+  selectedItems?: string[];
+  /**
+   * Change callback for user actions that select or deselect items.
+   * Called with an array of selected item values.
+   */
+  onSelectedItemsChange?: (values: string[]) => void;
+  /**
+   * Disables the input and all user interaction.
+   * You may still pass in `selectedItems` if items need to be selected
+   * when the input is disabled.
+   */
+  disabled?: boolean;
+  /**
+   * Value for the input with the given `name` prop.
+   * This should be the value of the field in the submitted form.
+   */
+  fieldValue?: string;
+  /**
+   * Error message.
+   * When passed, this will cause the trigger to render in error state.
+   */
+  errorText?: string;
+  /** Optional value for `data-testid` attribute */
+  testId?: string;
+  /** Optional label override for the clear all button */
+  clearLabel?: string;
+  /** If true, renders a "Clear all" button on the right side of the trigger */
+  isClearable?: boolean;
+  /**
+   * Optional function to format the summary content shown in the trigger.
+   * Must return a React node.
+   */
+  summaryFormatter?: (args: MultiSelectSummaryFormatterArgs) => React.ReactNode;
+  /**
+   * Function with signature `(userInputValue, selectItemNode) => {}`,
+   * used to customize typeahead filtering behavior.
+   * See "Changing Typeahead Behavior" story for example.
+   */
+  getTypeaheadString?: (
+    userInput: string,
+    selectItem: MultiSelectItemElement,
+  ) => string;
+}
 
 /**
  * Accessible multiple select control for giving users the ability to select
@@ -109,17 +183,14 @@ const MultiSelect = ({
   testId,
   clearLabel = "Clear all",
   isClearable = false,
-  /**
-   * Function to format the summary content.
-   * Receives an object with:
-   *   { selectedItems, getSelectedItemProps, removeSelectedItem, disabled, label }
-   * Must return a React node.
-   */
   summaryFormatter = defaultSummaryFormatter,
   getTypeaheadString = defaultGetTypeAheadString,
-}) => {
+}: MultiSelectProps) => {
   // Convert children to an array for easier processing.
-  const items = useMemo(() => Children.toArray(children), [children]);
+  const items = useMemo(
+    () => Children.toArray(children) as MultiSelectItemElement[],
+    [children],
+  );
 
   // Determine if the component is controlled.
   const isControlled = selectedItemsProp !== undefined;
@@ -131,7 +202,7 @@ const MultiSelect = ({
     removeSelectedItem,
     selectedItems,
     setSelectedItems,
-  } = useMultipleSelection({
+  } = useMultipleSelection<MultiSelectItemElement>({
     initialSelectedItems: getSelectedItems(selectedItemsProp || [], items),
     stateReducer: (state, actionAndChanges) => {
       const { type, changes } = actionAndChanges;
@@ -139,7 +210,7 @@ const MultiSelect = ({
       switch (type) {
         case useMultipleSelection.stateChangeTypes.FunctionRemoveSelectedItem:
         case useMultipleSelection.stateChangeTypes.FunctionAddSelectedItem:
-          onChangeProp(changes.selectedItems.map(itemToString));
+          onChangeProp((changes.selectedItems ?? []).map(itemToString));
           return changes;
         default:
           return changes;
@@ -165,16 +236,14 @@ const MultiSelect = ({
     getItemProps,
     inputValue,
     closeMenu,
-  } = useSelect({
-    disabled,
+  } = useSelect<MultiSelectItemElement>({
     id: name || `nds-multiselect-${label}`,
     items,
-    itemToString: (item) => getTypeaheadString(inputValue || "", item),
+    itemToString: (item): string =>
+      getTypeaheadString(inputValue || "", item as MultiSelectItemElement),
     stateReducer: (state, actionAndChanges) => {
       const { changes: newChanges, type } = actionAndChanges;
       switch (type) {
-        case useSelect.stateChangeTypes.MenuKeyDownEnter:
-        case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
         case useSelect.stateChangeTypes.ItemClick:
           return {
             ...newChanges,
@@ -188,11 +257,10 @@ const MultiSelect = ({
     onStateChange: ({ type, selectedItem: newSelectedItem }) => {
       // Toggle selection when an item is clicked or activated via keyboard.
       switch (type) {
-        case useSelect.stateChangeTypes.MenuKeyDownEnter:
         case useSelect.stateChangeTypes.ItemClick:
         case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
           if (isSelected(selectedItems, newSelectedItem)) {
-            removeSelectedItem(newSelectedItem);
+            removeSelectedItem(newSelectedItem as MultiSelectItemElement);
           } else if (newSelectedItem) {
             addSelectedItem(newSelectedItem);
           }
@@ -277,7 +345,10 @@ const MultiSelect = ({
         id={name}
         value={fieldValue || selectedItems.map(itemToString).join(",")}
       />
-      <div {...anchorProps}>
+      <div
+        {...(anchorProps as React.HTMLAttributes<HTMLDivElement>)}
+        ref={anchorProps.ref as React.Ref<HTMLDivElement>}
+      >
         <DropdownTrigger
           disabled={disabled}
           isOpen={isOpen}
@@ -286,15 +357,14 @@ const MultiSelect = ({
           errorText={errorText}
           labelProps={{
             ...getLabelProps(),
-            style: {
-              ...getLabelProps().style,
-              ...(isClearable ? { display: "block", paddingRight: 80 } : {}),
-            },
+            style: isClearable
+              ? { display: "block", paddingRight: 80 }
+              : undefined,
           }}
           {...getToggleButtonProps()}
         />
       </div>
-      <div {...layerProps}>
+      <div {...layerProps} ref={layerProps.ref as React.Ref<HTMLDivElement>}>
         <div
           className={cc([
             "nds-multiselect-list",
@@ -322,7 +392,7 @@ const MultiSelect = ({
                   ])}
                   {...getItemProps({ item, index })}
                   role="option"
-                  aria-selected={isSelected(selectedItems, item).toString()}
+                  aria-selected={isSelected(selectedItems, item)}
                 >
                   <Row as="span">
                     <Row.Item as="span">{item}</Row.Item>
@@ -340,61 +410,6 @@ const MultiSelect = ({
       </div>
     </div>
   );
-};
-
-MultiSelect.propTypes = {
-  /** unique name attribute for the input (used for `id` and `name`) */
-  name: PropTypes.string.isRequired,
-  /** Label for the select control */
-  label: PropTypes.string.isRequired,
-  /**
-   * When passed, the MultiSelect becomes fully controlled.
-   * Use `onSelectedItemsChange` to manage this value.
-   */
-  selectedItems: PropTypes.arrayOf(PropTypes.string),
-  /**
-   * Change callback for user actions that select or deselect items.
-   * Called with an array of selected item values.
-   */
-  onSelectedItemsChange: PropTypes.func,
-  /**
-   * Error message.
-   * When passed, this will cause the trigger to render in error state.
-   */
-  errorText: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]),
-  /** Optional value for `data-testid` attribute */
-  testId: PropTypes.string,
-  /**
-   * Value for the input with the given `name` prop.
-   * This should be the value of the field in the submitted form.
-   */
-  fieldValue: PropTypes.string,
-  /**
-   * Disables the input and all user interaction.
-   * You may still pass in `selectedItems` if items need to be selected
-   * when the input is disabled.
-   */
-  disabled: PropTypes.bool,
-  /** If true, renders a "Clear all" button on the right side of the trigger */
-  isClearable: PropTypes.bool,
-  /** Optional label override for the clear all button */
-  clearLabel: PropTypes.string,
-  /**
-   * Optional function to format the summary text when kind is "summary".
-   * The function is passed the number of selected items and an array of labels,
-   * and returns a string summary.
-   */
-  summaryFormatter: PropTypes.func,
-  /**
-   * Function with signature `(userInputValue, selectItemNode) => {}`,
-   * used to customize typeahead filtering behavior.
-   * See "Changing Typeahead Behavior" story for example.
-   */
-  getTypeaheadString: PropTypes.func,
 };
 
 MultiSelect.Item = MultiSelectItem;

--- a/src/MultiSelect/index.tsx
+++ b/src/MultiSelect/index.tsx
@@ -244,6 +244,8 @@ const MultiSelect = ({
     stateReducer: (state, actionAndChanges) => {
       const { changes: newChanges, type } = actionAndChanges;
       switch (type) {
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
         case useSelect.stateChangeTypes.ItemClick:
           return {
             ...newChanges,
@@ -259,6 +261,7 @@ const MultiSelect = ({
       switch (type) {
         case useSelect.stateChangeTypes.ItemClick:
         case useSelect.stateChangeTypes.ToggleButtonKeyDownEnter:
+        case useSelect.stateChangeTypes.ToggleButtonKeyDownSpaceButton:
           if (isSelected(selectedItems, newSelectedItem)) {
             removeSelectedItem(newSelectedItem as MultiSelectItemElement);
           } else if (newSelectedItem) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import SplitButton from "./SplitButton";
 import LoadingSkeleton from "./LoadingSkeleton";
 import LoadingShim from "./LoadingShim";
 import MenuButton from "./MenuButton";
+import MultiSelect from "./MultiSelect";
 import Table from "./Table";
 import TableAutocomplete from "./TableAutocomplete";
 import TableDateInput from "./TableDateInput";
@@ -66,7 +67,6 @@ import formatNumber from "./formatters/formatNumber";
  * Untyped Components
  */
 declare const Combobox;
-declare const MultiSelect;
 
 export * from "./types/Icon.types";
 
@@ -118,6 +118,11 @@ export type { InputProps } from "./Input";
 export type { LoadingShimProps } from "./LoadingShim";
 export type { LoadingSkeletonProps } from "./LoadingSkeleton";
 export type { MenuButtonProps } from "./MenuButton";
+export type {
+  MultiSelectProps,
+  MultiSelectSummaryFormatterArgs,
+} from "./MultiSelect";
+export type { MultiSelectItemProps } from "./MultiSelect/MultiSelectItem";
 export type { MenuButtonItemProps } from "./MenuButton/MenuButtonItem";
 export type { PaginationProps } from "./Pagination";
 export type { PopoverProps } from "./Popover";


### PR DESCRIPTION
## Summary

Migrates `MultiSelect` to TypeScript, following the established convention: colocated `Props` interface, PropTypes dropped, component moved from the `declare const` block into the typed import block in `src/index.ts`, and `MultiSelectProps`/`MultiSelectSummaryFormatterArgs`/`MultiSelectItemProps` re-exported.

## Typing decisions (runtime unchanged unless noted)

- **`name` is optional** — propTypes declared it required, but the majority of consumers actually omit it, and the trigger id has a label-derived fallback. `label` stays required (every callsite passes it). We can tighten this later, but I don't think we should wait to do that before we type this component.
- **`summaryFormatter` receives a typed, exported `MultiSelectSummaryFormatterArgs`** — its `selectedItems` are item *elements*, not strings.
- **`DropdownTrigger.labelText` widens `string` → `ReactNode`** — MultiSelect has always passed the token-list JSX through it; the type was just narrower than reality.
- **Dead code removed (all verified runtime-identical):**
  - The default formatter passed `i` to `getSelectedItemProps` — the real option key is `index`, so `i` was silently ignored.
  - The `labelProps` style merge spread `getLabelProps().style`, which doesn't exist — always a spread of `undefined`.
  - `aria-selected` boolean instead of `.toString()` (React stringifies; DOM identical).

## ⚠️ Latent regression surfaced — fixed in the follow-up commit

Two switch cases referenced `useSelect.stateChangeTypes.MenuKeyDownEnter` / `.MenuKeyDownSpaceButton`, which no longer exist in downshift 9 (renamed `ToggleButtonKeyDown*`) — the labels compared against `undefined` and never matched, so **space-bar selection did nothing and Enter selection closed the menu** ever since that upgrade.

The `fix(MultiSelect)` commit restores both using the current enum names, and additionally includes Space in the selection-toggle handler (the pre-rename code only kept the menu open for it) — toggling the highlighted item with Space is the ARIA multiselect listbox interaction. Keyboard regression tests added so the next enum rename fails loudly.
