### PR TITLE
fix(color-modes): set component-level overrides for high contrast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,6 +2747,18 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",

--- a/src/Chip/index.scss
+++ b/src/Chip/index.scss
@@ -24,6 +24,15 @@
     }
   }
 
+  // color modes
+  @include contrastMore {
+    border: 1px solid var(--border-color-light);
+
+    // using the filter here preserves the original color intent
+    // of each `kind` while darkening each text color enough for contrastMore
+    filter: contrast(1.09);
+  }
+
   // `kind` variants
   &--info {
     background-color: var(--color-infoLight);

--- a/src/Count/index.scss
+++ b/src/Count/index.scss
@@ -10,6 +10,10 @@
   font-size: var(--font-size-s);
   line-height: 1;
 
+  @include contrastMore {
+    border: 1px solid var(--border-color-default);
+  }
+
   &--theme {
     background-color: RGBA(var(--theme-rgb-primary), var(--alpha-10));
     color: var(--theme-primary);
@@ -31,7 +35,7 @@
     color: var(--color-errorDark);
   }
   &--neutral {
-    background-color: var(--font-color-hint);
+    background-color: var(--bgColor-neutralGrey);
     color: var(--font-color-primary);
   }
 }

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -177,6 +177,12 @@
         border-radius: var(--border-radius-m);
         background-color: var(--selected-bg);
         box-shadow: var(--elevation-middle);
+
+        // add a border to the pill in high contrast mode
+        @include contrastMore {
+          border: 1px solid var(--border-color-default);
+          background-color: white;
+        }
       }
     }
   }

--- a/src/Tag/index.scss
+++ b/src/Tag/index.scss
@@ -7,12 +7,18 @@
   font-size: var(--font-size-xs);
   height: 23px;
   max-width: 100%;
+
+  @include contrastMore {
+    border: 1px solid var(--border-color-light);
+  }
+
   .narmi-icon-x {
     cursor: pointer;
     display: inline-block;
     transform: translateY(1px);
   }
 }
+
 .nds-tag--dismissible {
   height: 25px;
   padding-right: var(--space-xs);

--- a/src/Toggle/index.scss
+++ b/src/Toggle/index.scss
@@ -15,6 +15,10 @@
       left 200ms ease,
       width 200ms ease;
 
+    @include contrastMore {
+      border: 1px solid var(--border-color-default);
+    }
+
     &--loading {
       width: 24px;
       border-radius: 50%;


### PR DESCRIPTION
Closes NDS-3136

Adds a few component-level overrides to ensure sufficient contrast in high contrast mode.

<img width="715" height="79" alt="Screenshot 2026-08-05 at 6 19 47 PM" src="https://github.com/user-attachments/assets/d59c1f02-0b62-41be-995e-09eb407b4bb6" />
<img width="540" height="336" alt="Screenshot 2026-08-05 at 6 07 26 PM" src="https://github.com/user-attachments/assets/53ce51db-e4ba-40c5-8080-82de2ae6421c" />
<img width="358" height="183" alt="Screenshot 2026-08-05 at 6 01 33 PM" src="https://github.com/user-attachments/assets/d460962f-4582-4758-8abd-32da300f1b1a" />
<img width="119" height="73" alt="Screenshot 2026-08-05 at 6 00 07 PM" src="https://github.com/user-attachments/assets/ff042d4c-8468-4d28-85f4-42e1de97a9a8" />


### The `contrastMore` sass mixin

The mixin is a convenience function that outputs both the query and data attr paths for the same ruleset of style overrides.

```scss
@mixin contrastMore {
  @media (prefers-contrast: more) {
    :root:not([data-prefers-contrast="less"]) & {
      @content;
    }
  }

  [data-prefers-contrast="more"] & {
    @content;
  }
}
```
