### PR TITLE
feat(Select): infer onChange value types generically in Select, MultiSelect, and Combobox

### DIFF
--- a/src/Combobox/index.tsx
+++ b/src/Combobox/index.tsx
@@ -147,7 +147,7 @@ export const defaultRenderEndContent = (isOpen: boolean) => (
   />
 );
 
-export interface ComboboxProps {
+export interface ComboboxProps<Value extends string = string> {
   /** Combobox.Item, Combobox.Action, Combobox.Heading, or Combobox.Category children */
   children: React.ReactNode;
   /** Label for the input */
@@ -156,7 +156,7 @@ export interface ComboboxProps {
    * Called when an item is selected, with the `value` of the selected item.
    * Called with empty string when the user clears the input.
    */
-  onChange?: (value: string) => void;
+  onChange?: (value: Value) => void;
   /**
    * Sets value of the input in a controlled manner.
    * When using the `inputValue` prop, you **must** update it via the
@@ -210,7 +210,10 @@ export interface ComboboxProps {
  * By default options will be filtered down as the user types in the input. This
  * behavior can be disabled via the `disableFiltering` prop.
  */
-const Combobox = ({
+function Combobox<Value extends string = string>(
+  props: ComboboxProps<Value>,
+): React.JSX.Element;
+function Combobox({
   label,
   onChange = noop,
   onInputChange = noop,
@@ -223,7 +226,7 @@ const Combobox = ({
   icon,
   testId,
   renderEndContent = defaultRenderEndContent,
-}: ComboboxProps) => {
+}: ComboboxProps): React.JSX.Element {
   const allChildren = useMemo(
     () =>
       React.Children.toArray(children) as (
@@ -558,7 +561,7 @@ const Combobox = ({
       </div>
     </>
   );
-};
+}
 
 Combobox.Item = ComboboxItem;
 Combobox.Heading = ComboboxHeading;

--- a/src/MultiSelect/index.tsx
+++ b/src/MultiSelect/index.tsx
@@ -99,7 +99,7 @@ const defaultSummaryFormatter = ({
   );
 };
 
-export interface MultiSelectProps {
+export interface MultiSelectProps<Value extends string = string> {
   /**
    * unique name attribute for the input (used for `id` and `name`).
    * The trigger id falls back to a value derived from `label`.
@@ -113,12 +113,12 @@ export interface MultiSelectProps {
    * When passed, the MultiSelect becomes fully controlled.
    * Use `onSelectedItemsChange` to manage this value.
    */
-  selectedItems?: string[];
+  selectedItems?: Value[];
   /**
    * Change callback for user actions that select or deselect items.
    * Called with an array of selected item values.
    */
-  onSelectedItemsChange?: (values: string[]) => void;
+  onSelectedItemsChange?: (values: Value[]) => void;
   /**
    * Disables the input and all user interaction.
    * You may still pass in `selectedItems` if items need to be selected
@@ -170,7 +170,10 @@ export interface MultiSelectProps {
  * - summaryFormatter: an optional function that receives the number of selected items and an array of labels,
  *         and returns a string summary.
  */
-const MultiSelect = ({
+function MultiSelect<Value extends string = string>(
+  props: MultiSelectProps<Value>,
+): React.JSX.Element;
+function MultiSelect({
   name,
   label,
   children,
@@ -185,7 +188,7 @@ const MultiSelect = ({
   isClearable = false,
   summaryFormatter = defaultSummaryFormatter,
   getTypeaheadString = defaultGetTypeAheadString,
-}: MultiSelectProps) => {
+}: MultiSelectProps): React.JSX.Element {
   // Convert children to an array for easier processing.
   const items = useMemo(
     () => Children.toArray(children) as MultiSelectItemElement[],
@@ -413,7 +416,7 @@ const MultiSelect = ({
       </div>
     </div>
   );
-};
+}
 
 MultiSelect.Item = MultiSelectItem;
 export default MultiSelect;

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -147,7 +147,7 @@ interface SelectCategoryConfig {
   isFlat?: boolean;
 }
 
-export interface SelectProps {
+export interface SelectProps<Value extends string = string> {
   /**
    * unique id attribute of the input (used for `htmlFor`).
    * Defaults to a value derived from `label`.
@@ -156,13 +156,13 @@ export interface SelectProps {
   /** Label for the select control */
   label?: string;
   /** Change callback. Called with value string from the selected item */
-  onChange?: (value: string) => void;
+  onChange?: (value: Value) => void;
   /**
    * Sets selected item by value and makes the Select **fully controlled**.
    *
    * When passing a `value`, you must provide an `onChange` handler to update it
    */
-  value?: string;
+  value?: Value;
   /**
    * Function with signature `(userInputValue, selectItemNode) => {}`,
    * used to customize typeahead filtering behavior.
@@ -181,7 +181,7 @@ export interface SelectProps {
    * of one of the `<Select.Item>` children.
    * The Select will remain uncontrolled.
    */
-  defaultValue?: string;
+  defaultValue?: Value;
   /** Open the dropdown on render if `true` */
   defaultOpen?: boolean;
   /**
@@ -204,7 +204,10 @@ export interface SelectProps {
  * `Select` also supports the ability to pass in a `<Select.Action>` that acts as an option that only triggers a side effect.
  * Typeahead is enabled based on the `value` prop of `<Select.Item>` elements passed in.
  */
-const Select = ({
+function Select<Value extends string = string>(
+  props: SelectProps<Value>,
+): React.JSX.Element;
+function Select({
   id,
   label,
   children,
@@ -217,7 +220,7 @@ const Select = ({
   clearSelectionOnAction = false,
   errorText,
   testId,
-}: SelectProps) => {
+}: SelectProps): React.JSX.Element {
   let items: SelectChild[] = []; // List of all item types to pass to downshift state management
   let categories: SelectCategoryConfig[] = []; // Categories extracted from Select.Category children
   const options = useMemo(
@@ -492,7 +495,7 @@ const Select = ({
       </div>
     </div>
   );
-};
+}
 
 Select.Item = SelectItem;
 Select.Action = SelectAction;


### PR DESCRIPTION
An attempt at https://linear.app/narmi/issue/NDS-3150/make-nds-selectonchange-generic. Consumers using string-literal union types for option values currently have to wrap every change handler in a cast to pass typechecks:

```tsx
onChange={(value: string) => handlePricingModelChange(value as PricingModel)}
```

[See examples here](https://github.com/narmi/banking/pull/82421/changes), and [see here](https://github.com/narmi/banking/pull/82441) for what this PR would let us do instead. It's mostly cosmetic, but I do think it's an improvement, and it forces those downstream enums to admit a `""`(which may not be in the enum) is in play.

This PR makes `Select`, `MultiSelect`, and `Combobox` generic over a `Value extends string = string` type parameter, so the value type is inferred directly from the handler (or from `value`/`defaultValue`/`selectedItems`):

```tsx
onChange={handlePricingModelChange}
```

- `Select`: `onChange`, `value`, `defaultValue` are typed as `Value`
- `MultiSelect`: `onSelectedItemsChange`, `selectedItems` are typed as `Value[]`
- `Combobox`: `onChange` is typed as `Value`

Since `Value` defaults to `string`, existing usage (including the exported `SelectProps`/`MultiSelectProps`/`ComboboxProps` types) is unaffected.
