### PR TITLE
ci: publish maintenance releases under 'patch' dist-tag with NPM_TOKEN fallback

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,17 @@ jobs:
       - name: Build Dist
         run: npm run build
 
+      # OIDC covers `npm publish` (via the npm CLI's built-in exchange) but not
+      # `npm dist-tag add`. On maintenance branches semantic-release calls
+      # `addChannel` before `publish`, which shells to `npm dist-tag add`.
+      # Write an `_authToken` fallback so that call is authorized; `npm
+      # publish` still prefers its OIDC-issued token and preserves provenance.
+      - name: Write npm auth fallback for dist-tag operations
+        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> ~/.npmrc
+
       - name: Release
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release --verbose

--- a/release.config.js
+++ b/release.config.js
@@ -6,14 +6,13 @@
  */
 const config = {
   branches: [
-    // Maintenance branches shaped `N.N.x` (e.g. `6.18.x`). `range` and
-    // `channel` are inferred by semantic-release from the branch name:
-    //   - range   -> `6.18.x` (patch-only, enforced via EINVALIDNEXTVERSION)
-    //   - channel -> `6.18.x` internally; @semantic-release/npm's
-    //                get-channel.js auto-prefixes valid semver-range
-    //                channels, so the npm dist-tag becomes
-    //                `@release-6.18.x`.
-    "+([0-9]).+([0-9]).x",
+    // Maintenance branches shaped `N.N.x` (e.g. `6.21.x`). semantic-release
+    // infers `range` from the branch name (`N.N.x`, patch-only enforced via
+    // `EINVALIDNEXTVERSION`). We pin `channel: "patch"` so every maintenance
+    // line publishes under the shared `patch` npm dist-tag; the latest patch
+    // release across any active line owns the tag. Git tags remain
+    // `v${version}` per `tagFormat` default.
+    { name: "+([0-9]).+([0-9]).x", channel: "patch" },
     "main",
   ],
   plugins: [


### PR DESCRIPTION
## What

Two changes that together unblock semantic-release on maintenance (`N.N.x`) branches, which currently 401 during `addChannel` on their first run.

### `release.config.js`

Pin maintenance branches to `channel: "patch"`:

```diff
-    "+([0-9]).+([0-9]).x",
+    { name: "+([0-9]).+([0-9]).x", channel: "patch" },
```

`@semantic-release/npm`'s `get-channel.js:4` treats `"patch"` as a non-range string and passes it through verbatim, so `publish.js:25` calls `npm publish --tag patch` and `add-channel.js:23` calls `npm dist-tag add <pkg>@<ver> patch`. No more `release-N.N.x` dist-tags. Git tags remain `v${version}` per the `tagFormat` default.

Aligns with our existing dist-tag convention: `latest`, `patch`, `beta`, `hotfix`.

### `.github/workflows/release.yaml`

Write an `_authToken` fallback to `~/.npmrc` before running semantic-release, and expose `secrets.NPM_TOKEN` on the Release step:

```yaml
- name: Write npm auth fallback for dist-tag operations
  run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> ~/.npmrc

- name: Release
  env:
    GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
  run: npx semantic-release --verbose
```

## Why

`@semantic-release/npm@25.0.5`'s OIDC path (`lib/verify-auth.js:86-88`) returns early when OIDC exchange succeeds and **never writes `_authToken` to `.npmrc`**. That's fine for `npm publish` — the npm CLI (>=11.5.1) performs its own OIDC exchange for the publish operation and preserves provenance. But it leaves `npm dist-tag add` unauthenticated, and that's exactly what `addChannel` calls (`lib/add-channel.js:21-23`).

On the first run of any new maintenance branch, semantic-release core (`lib/get-release-to-add.js:27-35`) detects that already-published versions need the maintenance channel's dist-tag applied, and fires `addChannel` **before** it fires `publish`. That's what killed the 6.21.x release with `PUT /-/package/@narmi%2fdesign_system/dist-tags/... 401`.

The `_authToken` fallback covers dist-tag ops without touching the publish path — `npm publish` still prefers its OIDC-issued token and keeps provenance intact.

## Note

The literal `\${NPM_TOKEN}` in the `echo` is deliberately shell-escaped so the string `${NPM_TOKEN}` lands in `.npmrc` and npm expands it from env at call time, rather than baking the token value into the file on disk.

## Related backfill (already on origin)

Missing git tags for versions that were on npm without git tags:
- `v6.15.1`, `v6.15.2` → `origin/6.15.x` HEAD
- `v6.16.11`, `v6.16.12` → `origin/6.16.x` HEAD
- Each has a matching `refs/notes/semantic-release-vX.Y.Z` note declaring `channels: ["patch"]`

`v6.22.3` was resolved out-of-band by a workflow re-run before this PR — no action needed there.

## Follow-up

After merge, cherry-pick onto `6.21.x` and re-trigger its release workflow to publish 6.21.1 to the `patch` dist-tag.