### PR TITLE
ci: write npm auth fallback to project-level .npmrc

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,13 +35,18 @@ jobs:
       - name: Build Dist
         run: npm run build
 
-      # OIDC covers `npm publish` (via the npm CLI's built-in exchange) but not
-      # `npm dist-tag add`. On maintenance branches semantic-release calls
-      # `addChannel` before `publish`, which shells to `npm dist-tag add`.
-      # Write an `_authToken` fallback so that call is authorized; `npm
-      # publish` still prefers its OIDC-issued token and preserves provenance.
+      # OIDC covers `npm publish` (via the npm CLI's built-in exchange) but
+      # not `npm dist-tag add`. On maintenance branches semantic-release
+      # calls `addChannel` before `publish`, which shells to `npm dist-tag
+      # add`. Under OIDC, `@semantic-release/npm` skips writing `_authToken`
+      # to its temp `.npmrc` (see `verify-auth.js:86-88`) yet still passes
+      # that empty file via `--userconfig` on every npm call, which overrides
+      # `~/.npmrc`. Instead we write the fallback to the project-level
+      # `./.npmrc` (repo root), which npm's config hierarchy reads *above*
+      # `--userconfig`, so `npm dist-tag add` finds it. `npm publish` keeps
+      # using OIDC for provenance because the plugin sets `provenance: true`.
       - name: Write npm auth fallback for dist-tag operations
-        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> ./.npmrc
 
       - name: Release
         if: success()


### PR DESCRIPTION
## What

One-line change to `.github/workflows/release.yaml`: write the npm auth fallback to `./.npmrc` (project-level) instead of `~/.npmrc` (user-level).

## Why

Follow-up to #2234. That PR added an `_authToken` fallback so `npm dist-tag add` could authenticate during semantic-release's `addChannel` step, but it wrote to `~/.npmrc`. The 6.21.x rerun still 401'd:

```
npm error 401 Unauthorized - PUT https://registry.npmjs.org/-/package/@narmi%2fdesign_system/dist-tags/patch
```

The failing command was:

```
npm dist-tag add @narmi/design_system@6.21.0 patch \
  --userconfig /tmp/4bba971718953e5aaeddf288a0d5a67d/.npmrc \
  --registry https://registry.npmjs.org/
```

Root cause: `@semantic-release/npm` creates a temp `.npmrc` at module load (`node_modules/@semantic-release/npm/index.js:13`) and passes it via `--userconfig` on every npm subcommand. Under OIDC, `verify-auth.js:86-88` returns early and never writes `_authToken` to that temp file, so it stays empty. The `--userconfig` flag also overrides `~/.npmrc`, so the previous fallback was never read.

## Fix

npm's config hierarchy (per npm docs):

1. CLI flags
2. Env vars (`npm_config_*`)
3. **Project `./.npmrc`** ← land the fallback here
4. User `--userconfig` / `~/.npmrc`
5. Global config
6. Built-in

Project config sits above `--userconfig`, so `npm dist-tag add` — which runs in the repo root as cwd — reads `_authToken` from `./.npmrc` regardless of what temp file the plugin points `--userconfig` at.

## Provenance preserved

`@semantic-release/npm` sets `provenance: true` in `release.config.js`. The npm CLI's provenance path runs its own OIDC exchange when trusted-publisher context is available; the `_authToken` in project config is a fallback, not a preemption. Verification: the next 6.21.x run's log should show `Signed provenance statement` after `Publishing version 6.21.1`.

## No leak of `.npmrc` into the repo

- Literal `${NPM_TOKEN}` is written (shell-escaped in the `echo`), not the token value; npm expands at call time.
- `@semantic-release/git`'s default `assets` is `[CHANGELOG.md, package.json, package-lock.json, npm-shrinkwrap.json]` and `release.config.js` doesn't override it, so `.npmrc` is never committed.

## Follow-up

After merge, cherry-pick onto `6.21.x` (same procedure as #2234) and watch the workflow re-run.