### PR TITLE
ci: drop obsolete npm auth fallback; automate note-backfill on new maint branches

### DIFF
--- a/.github/workflows/release-backport.yaml
+++ b/.github/workflows/release-backport.yaml
@@ -179,9 +179,11 @@ jobs:
             # "patch" must match the `channel` set for maintenance branches
             # in release.config.js. If that ever changes, update here too.
             NOTE_REF="semantic-release-${LATEST_TAG}"
-            git fetch origin "+refs/notes/${NOTE_REF}:refs/notes/${NOTE_REF}" 2>/dev/null || true
+            if git ls-remote --exit-code origin "refs/notes/${NOTE_REF}" >/dev/null 2>&1; then
+              git fetch origin "+refs/notes/${NOTE_REF}:refs/notes/${NOTE_REF}"
+            fi
             EXISTING=$(git notes --ref="${NOTE_REF}" show "${LATEST_TAG}" 2>/dev/null || echo '{"channels":[null]}')
-            UPDATED=$(echo "${EXISTING}" | jq -c '.channels |= (. + ["patch"] | unique)')
+            UPDATED=$(printf '%s' "${EXISTING}" | jq -c '.channels = ((.channels // []) + ["patch"] | unique)')
             git notes --ref="${NOTE_REF}" add -f -m "${UPDATED}" "${LATEST_TAG}"
 
             git push -u origin "$BRANCH"

--- a/.github/workflows/release-backport.yaml
+++ b/.github/workflows/release-backport.yaml
@@ -2,7 +2,7 @@ name: Release Backport
 
 # Cherry-picks a merged PR from `main` onto a patch-line maintenance branch
 # (e.g. `6.12.x`) and lets the normal `release.yaml` publish a new patch on
-# `@release-6.12.x`.
+# the shared `@patch` npm dist-tag.
 #
 # Design invariants (see release.config.js and the release recipe):
 #   - Direction is main -> older N.N.x, so this is ALWAYS a cherry-pick,
@@ -166,7 +166,26 @@ jobs:
               git commit -m "ci: sync release workflow and config from main [skip ci]"
             fi
 
+            # On the branch's first release, semantic-release calls
+            # `addChannel` on `$LATEST_TAG` because its `channels` git note
+            # doesn't include this branch's channel yet. `addChannel` shells
+            # to `npm dist-tag add`, and npm's OIDC-provisioned token does
+            # NOT authenticate that call -- it 401s. Preempt the whole
+            # roundtrip by declaring `$LATEST_TAG` is already on the "patch"
+            # channel; `get-release-to-add.js` filters it out and
+            # semantic-release goes straight to publish (which OIDC handles
+            # fine, with provenance).
+            #
+            # "patch" must match the `channel` set for maintenance branches
+            # in release.config.js. If that ever changes, update here too.
+            NOTE_REF="semantic-release-${LATEST_TAG}"
+            git fetch origin "+refs/notes/${NOTE_REF}:refs/notes/${NOTE_REF}" 2>/dev/null || true
+            EXISTING=$(git notes --ref="${NOTE_REF}" show "${LATEST_TAG}" 2>/dev/null || echo '{"channels":[null]}')
+            UPDATED=$(echo "${EXISTING}" | jq -c '.channels |= (. + ["patch"] | unique)')
+            git notes --ref="${NOTE_REF}" add -f -m "${UPDATED}" "${LATEST_TAG}"
+
             git push -u origin "$BRANCH"
+            git push origin "refs/notes/${NOTE_REF}"
           fi
 
       - name: Determine picks
@@ -311,7 +330,7 @@ jobs:
           EOF
             echo '```'
             echo ""
-            echo "The push to \`${BRANCH}\` will trigger the release workflow and publish a new patch on \`@release-${BRANCH}\`."
+            echo "The push to \`${BRANCH}\` will trigger the release workflow and publish a new patch on the \`@patch\` npm dist-tag."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report conflict and fail

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,22 +35,8 @@ jobs:
       - name: Build Dist
         run: npm run build
 
-      # OIDC covers `npm publish` (via the npm CLI's built-in exchange) but
-      # not `npm dist-tag add`. On maintenance branches semantic-release
-      # calls `addChannel` before `publish`, which shells to `npm dist-tag
-      # add`. Under OIDC, `@semantic-release/npm` skips writing `_authToken`
-      # to its temp `.npmrc` (see `verify-auth.js:86-88`) yet still passes
-      # that empty file via `--userconfig` on every npm call, which overrides
-      # `~/.npmrc`. Instead we write the fallback to the project-level
-      # `./.npmrc` (repo root), which npm's config hierarchy reads *above*
-      # `--userconfig`, so `npm dist-tag add` finds it. `npm publish` keeps
-      # using OIDC for provenance because the plugin sets `provenance: true`.
-      - name: Write npm auth fallback for dist-tag operations
-        run: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> ./.npmrc
-
       - name: Release
         if: success()
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release --verbose


### PR DESCRIPTION
## Context

Two prior PRs added auth-layer plumbing to work around a 401 that fired when semantic-release ran `npm dist-tag add` on maintenance branches:

- #2234 — added `NPM_TOKEN` fallback + `.npmrc` write step.
- #2235 — moved that write from `~/.npmrc` to `./.npmrc` after the first attempt still 401'd.

Empirical testing on 6.21.x showed the real fix is different: **prevent `addChannel` from firing at all** by ensuring the base tag's semantic-release git note already includes the maintenance branch's channel. When the note lists `"patch"`, `get-release-to-add.js:29-31` filters that version out and semantic-release goes straight to publish (which the npm CLI's built-in OIDC exchange authenticates cleanly, with provenance).

The 6.21.1 release cut successfully via that route: `patch` dist-tag → 6.21.1, `latest` untouched, provenance signed and logged to sigstore.

So the auth-layer plumbing is now inert on every release and can be removed. This PR does that, and automates the note-backfill so future maintenance branches don't have to be hand-nudged.

## Changes

### `.github/workflows/release.yaml`

Delete:
- The `Write npm auth fallback for dist-tag operations` step (whole comment + `run:`).
- `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` from the Release step's `env:`.

Reverts this file to its exact pre-#2234 shape. Only OIDC is used for auth.

The `NPM_TOKEN` secret in the `Publish` GitHub environment stays where it is — just no longer wired into this workflow.

### `.github/workflows/release-backport.yaml`

In the "Ensure maintenance branch exists" step, only on the **branch-creation** path (`$LATEST_TAG` is set, we're about to `git push -u origin $BRANCH`), insert a jq-merge note-backfill:

```bash
NOTE_REF="semantic-release-${LATEST_TAG}"
git fetch origin "+refs/notes/${NOTE_REF}:refs/notes/${NOTE_REF}" 2>/dev/null || true
EXISTING=$(git notes --ref="${NOTE_REF}" show "${LATEST_TAG}" 2>/dev/null || echo '{"channels":[null]}')
UPDATED=$(echo "${EXISTING}" | jq -c '.channels |= (. + ["patch"] | unique)')
git notes --ref="${NOTE_REF}" add -f -m "${UPDATED}" "${LATEST_TAG}"
# ... then push both the branch and the note ref
git push origin "refs/notes/${NOTE_REF}"
```

Effect on the branch's first release run:

- `get-release-to-add.js:30` filters `$LATEST_TAG` out because `channels.includes("patch")` is true.
- No `addChannel` call, no `npm dist-tag add` shell-out, no 401 possible.
- Publish under OIDC as normal.

`jq` is pre-installed on `ubuntu-latest` — no `apt install` needed. Handles the case where the base tag has no prior note (falls back to `{"channels":[null]}`) and preserves any existing channel entries via `+ ["patch"] | unique`.

`"patch"` is hard-coded with a comment: it must match `release.config.js`'s maintenance-branch `channel` value. If the config ever changes, this backfill needs the same edit.

### Stale text swept up

Two references to the old `@release-${BRANCH}` dist-tag scheme are corrected to `@patch`:

- File-header comment (line 5)
- Step-summary text at end of `Push clean backport` (was line 314)

## Follow-up

After merge:
- Cherry-pick the `release.yaml` half of this commit onto `6.21.x` so that branch also stops running the inert echo step. That push will trigger a release run that no-ops (no releasable commits since v6.21.1) — serves as a live smoke-test.
- `6.16.x` and `6.15.x` still hold pre-`channel: "patch"` versions of `release.yaml` and `release.config.js`. They'll need a one-time manual sync (and note-backfill on their highest tag) before their next release. Deferred.

## Not doing here

- Not touching `release.config.js`.
- Not touching `release-backport-on-merge.yaml` (dispatcher only, unaffected).
- Not deleting `NPM_TOKEN` from the `Publish` environment.
- Not retroactively syncing 6.16.x / 6.15.x.