### PR TITLE
refactor(tokens): deprecate brand colors

### DIFF
--- a/MIGRATION_NEXT_MAJOR.md
+++ b/MIGRATION_NEXT_MAJOR.md
@@ -1,0 +1,47 @@
+# Migration Guide for Next Major
+
+## Deprecations
+
+### Deprecated `narmi` brand color tokens
+
+All `narmi` brand color tokens — the brand palette (`pine`, `moss`, `cove`, `azul`, `pistachio`, `cactus`, `sand`, `amethyst`, including every numbered ramp such as `pine400`) and the `narmi` grey/black/white aliases — are now **deprecated**.
+
+These tokens are **still emitted** (as `--color-*` CSS custom properties, `--rgb-*` RGB lists, and `ColorNarmi*` JS constants) for backwards compatibility, but they are no longer part of the documented public token API and will be removed in a future major release. Emitted tokens now carry an `@deprecated` annotation in the generated CSS/SCSS/JS.
+
+The associated brand color helper classes (`.bgColor--<brand>` and `.fontColor--<brand>`, e.g. `.bgColor--pine`) are likewise deprecated. They continue to be emitted into the stylesheet but have been removed from the helper class documentation.
+
+**Impact:** If your application references brand color tokens or helper classes directly, they will keep working for now, but you should migrate to the semantic theme tokens, which are designed to be themeable per institution.
+
+**Why this change:** Brand primitives couple consumers to fixed Narmi colors and bypass the theming system. Semantic `--theme-*` tokens (and their `--theme-rgb-*` RGB lists) are the supported, themeable API.
+
+#### Migration Table
+
+| Deprecated                               | Preferred                                           |
+| ---------------------------------------- | --------------------------------------------------- |
+| `var(--color-pine)`                      | `var(--theme-primary)`                              |
+| `var(--color-moss)`                      | `var(--theme-secondary)`                            |
+| `var(--color-cactus)`                    | `var(--theme-tertiary)`                             |
+| `rgb(var(--rgb-pine))`                   | `rgb(var(--theme-rgb-primary))`                     |
+| `rgba(var(--rgb-moss), var(--alpha-10))` | `rgba(var(--theme-rgb-secondary), var(--alpha-10))` |
+| `.bgColor--pine`                         | `.bgColor--theme--primary`                          |
+| `.fontColor--moss`                       | `.fontColor--theme--secondary`                      |
+
+#### Example
+
+**Before:**
+
+```css
+.my-component {
+  background-color: var(--color-pine);
+  color: rgba(var(--rgb-moss), var(--alpha-20));
+}
+```
+
+**After:**
+
+```css
+.my-component {
+  background-color: var(--theme-primary);
+  color: rgba(var(--theme-rgb-secondary), var(--alpha-20));
+}
+```

--- a/MIGRATION_v6.md
+++ b/MIGRATION_v6.md
@@ -319,7 +319,51 @@ No action required for consumers. This change only affects the NDS build process
 
 ---
 
-### Removed webpack builds
+## Deprecations
+
+### Deprecated `narmi` brand color tokens
+
+All `narmi` brand color tokens — the brand palette (`pine`, `moss`, `cove`, `azul`, `pistachio`, `cactus`, `sand`, `amethyst`, including every numbered ramp such as `pine400`) and the `narmi` grey/black/white aliases — are now **deprecated**.
+
+These tokens are **still emitted** (as `--color-*` CSS custom properties, `--rgb-*` RGB lists, and `ColorNarmi*` JS constants) for backwards compatibility, but they are no longer part of the documented public token API and will be removed in a future major release. Emitted tokens now carry an `@deprecated` annotation in the generated CSS/SCSS/JS.
+
+The associated brand color helper classes (`.bgColor--<brand>` and `.fontColor--<brand>`, e.g. `.bgColor--pine`) are likewise deprecated. They continue to be emitted into the stylesheet but have been removed from the helper class documentation.
+
+**Impact:** If your application references brand color tokens or helper classes directly, they will keep working for now, but you should migrate to the semantic theme tokens, which are designed to be themeable per institution.
+
+**Why this change:** Brand primitives couple consumers to fixed Narmi colors and bypass the theming system. Semantic `--theme-*` tokens (and their `--theme-rgb-*` RGB lists) are the supported, themeable API.
+
+#### Migration Table
+
+| Deprecated                               | Preferred                                           |
+| ---------------------------------------- | --------------------------------------------------- |
+| `var(--color-pine)`                      | `var(--theme-primary)`                              |
+| `var(--color-moss)`                      | `var(--theme-secondary)`                            |
+| `var(--color-cactus)`                    | `var(--theme-tertiary)`                             |
+| `rgb(var(--rgb-pine))`                   | `rgb(var(--theme-rgb-primary))`                     |
+| `rgba(var(--rgb-moss), var(--alpha-10))` | `rgba(var(--theme-rgb-secondary), var(--alpha-10))` |
+| `.bgColor--pine`                         | `.bgColor--theme--primary`                          |
+| `.fontColor--moss`                       | `.fontColor--theme--secondary`                      |
+
+#### Example
+
+**Before:**
+
+```css
+.my-component {
+  background-color: var(--color-pine);
+  color: rgba(var(--rgb-moss), var(--alpha-20));
+}
+```
+
+**After:**
+
+```css
+.my-component {
+  background-color: var(--theme-primary);
+  color: rgba(var(--theme-rgb-secondary), var(--alpha-20));
+}
+```
 
 NDS v6 no longer uses webpack for builds. Vite is now the only build tool used by this project.
 

--- a/MIGRATION_v6.md
+++ b/MIGRATION_v6.md
@@ -319,51 +319,7 @@ No action required for consumers. This change only affects the NDS build process
 
 ---
 
-## Deprecations
-
-### Deprecated `narmi` brand color tokens
-
-All `narmi` brand color tokens — the brand palette (`pine`, `moss`, `cove`, `azul`, `pistachio`, `cactus`, `sand`, `amethyst`, including every numbered ramp such as `pine400`) and the `narmi` grey/black/white aliases — are now **deprecated**.
-
-These tokens are **still emitted** (as `--color-*` CSS custom properties, `--rgb-*` RGB lists, and `ColorNarmi*` JS constants) for backwards compatibility, but they are no longer part of the documented public token API and will be removed in a future major release. Emitted tokens now carry an `@deprecated` annotation in the generated CSS/SCSS/JS.
-
-The associated brand color helper classes (`.bgColor--<brand>` and `.fontColor--<brand>`, e.g. `.bgColor--pine`) are likewise deprecated. They continue to be emitted into the stylesheet but have been removed from the helper class documentation.
-
-**Impact:** If your application references brand color tokens or helper classes directly, they will keep working for now, but you should migrate to the semantic theme tokens, which are designed to be themeable per institution.
-
-**Why this change:** Brand primitives couple consumers to fixed Narmi colors and bypass the theming system. Semantic `--theme-*` tokens (and their `--theme-rgb-*` RGB lists) are the supported, themeable API.
-
-#### Migration Table
-
-| Deprecated                               | Preferred                                           |
-| ---------------------------------------- | --------------------------------------------------- |
-| `var(--color-pine)`                      | `var(--theme-primary)`                              |
-| `var(--color-moss)`                      | `var(--theme-secondary)`                            |
-| `var(--color-cactus)`                    | `var(--theme-tertiary)`                             |
-| `rgb(var(--rgb-pine))`                   | `rgb(var(--theme-rgb-primary))`                     |
-| `rgba(var(--rgb-moss), var(--alpha-10))` | `rgba(var(--theme-rgb-secondary), var(--alpha-10))` |
-| `.bgColor--pine`                         | `.bgColor--theme--primary`                          |
-| `.fontColor--moss`                       | `.fontColor--theme--secondary`                      |
-
-#### Example
-
-**Before:**
-
-```css
-.my-component {
-  background-color: var(--color-pine);
-  color: rgba(var(--rgb-moss), var(--alpha-20));
-}
-```
-
-**After:**
-
-```css
-.my-component {
-  background-color: var(--theme-primary);
-  color: rgba(var(--theme-rgb-secondary), var(--alpha-20));
-}
-```
+### Removed webpack builds
 
 NDS v6 no longer uses webpack for builds. Vite is now the only build tool used by this project.
 

--- a/src/base-styles/_deprecated-brand-helpers.scss
+++ b/src/base-styles/_deprecated-brand-helpers.scss
@@ -1,0 +1,35 @@
+/**
+ * ⚠️ DEPRECATED brand/base color helper classes.
+ *
+ * These utility classes reference deprecated `narmi` brand color tokens
+ * (e.g. `--color-pine`, `--color-moss`) and are no longer part of the
+ * documented public API. They are emitted here for backwards compatibility
+ * only and will be removed in a future major release.
+ *
+ * Prefer semantic theme helpers instead:
+ *   - `.bgColor--theme--*`
+ *   - `.fontColor--theme--*`
+ *
+ * This file intentionally lives outside `src/helper-classes/` so the helper
+ * class documentation scanner (`scripts/util/getHelperClassNames.mjs`) does
+ * not surface these deprecated classes, while `src/index.scss` still imports
+ * it so the classes continue to be emitted into the published stylesheet.
+ */
+
+/**
+* brand/base background colors (deprecated)
+*/
+@each $color in (moss, pine, cove, azul, pistachio, cactus, sand) {
+  .bgColor--#{$color} {
+    background-color: var(--color-#{$color}) !important;
+  }
+}
+
+/**
+* brand/base text colors (deprecated)
+*/
+@each $color in (moss, pine, cove, azul, pistachio, cactus, sand, "white") {
+  .fontColor--#{$color} {
+    color: var(--color-#{$color}) !important;
+  }
+}

--- a/src/helper-classes/background.scss
+++ b/src/helper-classes/background.scss
@@ -11,12 +11,10 @@
 
 /**
 * brand/base background colors
+* ⚠️ DEPRECATED — brand color helper classes are emitted from
+* `base-styles/deprecated-brand-helpers` for backwards compatibility only.
+* Prefer theme background helpers (`.bgColor--theme--*`).
 */
-@each $color in (moss, pine, cove, azul, pistachio, cactus, sand) {
-  .bgColor--#{$color} {
-    background-color: var(--color-#{$color}) !important;
-  }
-}
 
 /**
 * system background colors

--- a/src/helper-classes/font.scss
+++ b/src/helper-classes/font.scss
@@ -12,12 +12,10 @@
 
 /**
 * brand/base text colors
+* ⚠️ DEPRECATED — brand color helper classes are emitted from
+* `base-styles/deprecated-brand-helpers` for backwards compatibility only.
+* Prefer theme font helpers (`.fontColor--theme--*`).
 */
-@each $color in (moss, pine, cove, azul, pistachio, cactus, sand, "white") {
-  .fontColor--#{$color} {
-    color: var(--color-#{$color}) !important;
-  }
-}
 
 /**
 * theme colors

--- a/src/index.scss
+++ b/src/index.scss
@@ -46,6 +46,10 @@
 @import "helper-classes/scroll";
 @import "helper-classes/lists";
 
+// ⚠️ DEPRECATED brand color helper classes (emitted for backwards
+// compatibility only; intentionally excluded from helper class docs).
+@import "base-styles/deprecated-brand-helpers";
+
 // Components
 @import "Accordion/";
 @import "Alert/";

--- a/tokens/docs/color.mdx
+++ b/tokens/docs/color.mdx
@@ -6,10 +6,6 @@ import * as ColorStories from "./color.stories.js";
 
 # Color Tokens
 
-## Narmi Base Colors
-
-<Canvas of={ColorStories.Base} name="Base" style={{ height: "auto" }} />
-
 ## Theme Colors
 
 Tokens with the prefix `--theme` are dedicated to theming. These CSS custom
@@ -52,14 +48,14 @@ Colors used for system messages and indicators.
 
 ## Transparency
 
-All [Base Colors](#narmi-base-colors), [System Colors](#system-colors),
+All [System Colors](#system-colors),
 [Theme Colors](#theme-colors), and [Background Colors](#background-colors) are available as partial RGB values
 that can be composed with the following alpha values to lighten or darken a color.
 
 These values are prefixed with `--rgb` instead of `--color`.
 Theme RGB values are prefixed with `--theme-rgb`.
 
-The value `rgb(var(--rgb-pine))` is equivalent to `var(--color-pine)`.
+The value `rgb(var(--theme-rgb-primary))` is equivalent to `var(--theme-primary)`.
 
 ### Alpha Values
 
@@ -68,6 +64,6 @@ The value `rgb(var(--rgb-pine))` is equivalent to `var(--color-pine)`.
 ### Usage
 
 ```
-background-color: rgba(var(--rgb-pine), var(--alpha-10));
-color: rgba(var(--theme-rgb-primary), var(--alpha-20));
+background-color: rgba(var(--theme-rgb-primary), var(--alpha-10));
+color: rgba(var(--theme-rgb-secondary), var(--alpha-20));
 ```

--- a/tokens/docs/color.stories.js
+++ b/tokens/docs/color.stories.js
@@ -6,18 +6,6 @@ export default {
   title: "Design Tokens/Color",
 };
 
-const Template = (args) => <TokenTable {...args} />;
-
-export const Base = Template.bind({});
-Base.args = {
-  previewType: "color",
-  rows: toTokenRows(color, "narmi", "color").filter(({ name }) => {
-    // filter out offset brand colors (e.g. `moss100`) from documentation for now
-    const isOffsetColor = new RegExp(/[0-9]/).test(name);
-    return !isOffsetColor;
-  }),
-};
-
 export const Theme = () => (
   <>
     <h2>Theme Colors</h2>

--- a/tokens/primitives/color.json
+++ b/tokens/primitives/color.json
@@ -13,83 +13,290 @@
       "white": { "value": "#ffffff" }
     },
     "narmi": {
-      "moss100": { "value": "#002921" },
-      "moss200": { "value": "#0F3C32" },
-      "moss300": { "value": "#005242" },
-      "moss400": { "value": "#006553" },
-      "moss500": { "value": "#3E8373" },
-      "moss600": { "value": "#6EA193" },
-      "moss700": { "value": "#9DC0B6" },
-      "moss800": { "value": "#CDDED9" },
-      "moss": { "value": "{color.narmi.moss400}" },
+      "moss100": {
+        "value": "#002921",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss200": {
+        "value": "#0F3C32",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss300": {
+        "value": "#005242",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss400": {
+        "value": "#006553",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss500": {
+        "value": "#3E8373",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss600": {
+        "value": "#6EA193",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss700": {
+        "value": "#9DC0B6",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss800": {
+        "value": "#CDDED9",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "moss": {
+        "value": "{color.narmi.moss400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "pine100": { "value": "#041A14" },
-      "pine200": { "value": "#062821" },
-      "pine300": { "value": "#16362C" },
-      "pine400": { "value": "#1A4338" },
-      "pine500": { "value": "#44655B" },
-      "pine600": { "value": "#708981" },
-      "pine700": { "value": "#708981" },
-      "pine800": { "value": "#CDD6D3" },
-      "pine": { "value": "{color.narmi.pine400}" },
+      "pine100": {
+        "value": "#041A14",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine200": {
+        "value": "#062821",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine300": {
+        "value": "#16362C",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine400": {
+        "value": "#1A4338",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine500": {
+        "value": "#44655B",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine600": {
+        "value": "#708981",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine700": {
+        "value": "#708981",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine800": {
+        "value": "#CDD6D3",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pine": {
+        "value": "{color.narmi.pine400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "cove100": { "value": "#002547" },
-      "cove200": { "value": "#00376A" },
-      "cove300": { "value": "#094895" },
-      "cove400": { "value": "#005CB2" },
-      "cove500": { "value": "#237CC3" },
-      "cove600": { "value": "#66A2D6" },
-      "cove700": { "value": "#A6CFF0" },
-      "cove800": { "value": "#D4EDFF" },
-      "cove": { "value": "{color.narmi.cove400}" },
+      "cove100": {
+        "value": "#002547",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove200": {
+        "value": "#00376A",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove300": {
+        "value": "#094895",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove400": {
+        "value": "#005CB2",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove500": {
+        "value": "#237CC3",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove600": {
+        "value": "#66A2D6",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove700": {
+        "value": "#A6CFF0",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove800": {
+        "value": "#D4EDFF",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cove": {
+        "value": "{color.narmi.cove400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "azul100": { "value": "#001340" },
-      "azul200": { "value": "#00205E" },
-      "azul300": { "value": "#002C82" },
-      "azul400": { "value": "#003EA0" },
-      "azul500": { "value": "#3664B5" },
-      "azul600": { "value": "#6B89C7" },
-      "azul700": { "value": "#9CB1DE" },
-      "azul800": { "value": "#C9D8F2" },
-      "azul": { "value": "{color.narmi.azul400}" },
+      "azul100": {
+        "value": "#001340",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul200": {
+        "value": "#00205E",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul300": {
+        "value": "#002C82",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul400": {
+        "value": "#003EA0",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul500": {
+        "value": "#3664B5",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul600": {
+        "value": "#6B89C7",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul700": {
+        "value": "#9CB1DE",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul800": {
+        "value": "#C9D8F2",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "azul": {
+        "value": "{color.narmi.azul400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "pistachio100": { "value": "#485E3D" },
-      "pistachio200": { "value": "#6B8C5A" },
-      "pistachio300": { "value": "#90BB78" },
-      "pistachio400": { "value": "#B5E995" },
-      "pistachio500": { "value": "#CCF0B4" },
-      "pistachio600": { "value": "#DAF4C8" },
-      "pistachio700": { "value": "#E9F8DE" },
-      "pistachio800": { "value": "#F7FCF3" },
-      "pistachio": { "value": "{color.narmi.pistachio400}" },
+      "pistachio100": {
+        "value": "#485E3D",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio200": {
+        "value": "#6B8C5A",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio300": {
+        "value": "#90BB78",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio400": {
+        "value": "#B5E995",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio500": {
+        "value": "#CCF0B4",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio600": {
+        "value": "#DAF4C8",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio700": {
+        "value": "#E9F8DE",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio800": {
+        "value": "#F7FCF3",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "pistachio": {
+        "value": "{color.narmi.pistachio400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "cactus100": { "value": "#324C23" },
-      "cactus200": { "value": "#4B7137" },
-      "cactus300": { "value": "#63964B" },
-      "cactus400": { "value": "#7FBC5B" },
-      "cactus500": { "value": "#99CA7A" },
-      "cactus600": { "value": "#B3D79A" },
-      "cactus700": { "value": "#CCE4BA" },
-      "cactus800": { "value": "#E5F1DC" },
-      "cactus": { "value": "{color.narmi.cactus400}" },
+      "cactus100": {
+        "value": "#324C23",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus200": {
+        "value": "#4B7137",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus300": {
+        "value": "#63964B",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus400": {
+        "value": "#7FBC5B",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus500": {
+        "value": "#99CA7A",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus600": {
+        "value": "#B3D79A",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus700": {
+        "value": "#CCE4BA",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus800": {
+        "value": "#E5F1DC",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "cactus": {
+        "value": "{color.narmi.cactus400}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "sand100": { "value": "#423329" },
-      "sand200": { "value": "#684D41" },
-      "sand300": { "value": "#947564" },
-      "sand400": { "value": "#C4A08A" },
-      "sand500": { "value": "#DCC1A3" },
-      "sand600": { "value": "#EED6C3" },
-      "sand700": { "value": "#F4E3D6" },
-      "sand800": { "value": "#FCF0E9" },
-      "sand": { "value": "{color.narmi.sand500}" },
+      "sand100": {
+        "value": "#423329",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand200": {
+        "value": "#684D41",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand300": {
+        "value": "#947564",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand400": {
+        "value": "#C4A08A",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand500": {
+        "value": "#DCC1A3",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand600": {
+        "value": "#EED6C3",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand700": {
+        "value": "#F4E3D6",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand800": {
+        "value": "#FCF0E9",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "sand": {
+        "value": "{color.narmi.sand500}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "amethyst": { "value": "#5514B8" },
+      "amethyst": {
+        "value": "#5514B8",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
 
-      "black": { "value": "{color.grey.black}" },
-      "grey": { "value": "{color.grey.mediumGrey}" },
-      "mediumGrey": { "value": "{color.grey.mediumGrey}" },
-      "lightGrey": { "value": "{color.grey.lightGrey}" },
-      "white": { "value": "{color.grey.white}" }
+      "black": {
+        "value": "{color.grey.black}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "grey": {
+        "value": "{color.grey.mediumGrey}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "mediumGrey": {
+        "value": "{color.grey.mediumGrey}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "lightGrey": {
+        "value": "{color.grey.lightGrey}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      },
+      "white": {
+        "value": "{color.grey.white}",
+        "comment": "@deprecated brand color — not part of the public token API; prefer semantic theme tokens (--theme-*)."
+      }
     },
     "system": {
       "successDark": { "value": "#027A48" },


### PR DESCRIPTION
Closes NDS-3208

- Deprecate brand colors
- Remove brand colors from docs
- Begin a v6 migration guide for future removal