### PR TITLE
Add colorblind modes red-green and tri

### DIFF
--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { COLOR_MODES } from "../tokens/constants";
+import { COLOR_MODES, CVD_ATTRIBUTE } from "../tokens/constants";
 
 const ndsStyleTag = (
   <style>
@@ -14,6 +14,7 @@ const ndsStyleTag = (
 
 export const NdsStyles = (Story, context) => {
   const contrast = context.globals?.contrast;
+  const colorVision = context.globals?.colorVision;
 
   useEffect(() => {
     const root = document.documentElement;
@@ -28,6 +29,16 @@ export const NdsStyles = (Story, context) => {
       root.removeAttribute(attribute);
     }
   }, [contrast]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    // All CVD palettes share a single attribute; the global holds the value.
+    if (colorVision && colorVision !== "none") {
+      root.setAttribute(CVD_ATTRIBUTE, colorVision);
+    } else {
+      root.removeAttribute(CVD_ATTRIBUTE);
+    }
+  }, [colorVision]);
 
   if (context.title?.startsWith("Issue Test Cases/")) {
     return (

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -49,9 +49,21 @@ export const globalTypes = {
       dynamicTitle: true,
     },
   },
+  colorVision: {
+    description: "Color vision deficiency simulation palette",
+    toolbar: {
+      title: "Color Vision",
+      items: [
+        { value: "none", title: "Typical Vision" },
+        { value: "red-green", title: "Protanopia / Deuteranopia" },
+        { value: "tritanopia", title: "Tritanopia" },
+      ],
+      dynamicTitle: true,
+    },
+  },
 };
 
-export const initialGlobals = { contrast: "system" };
+export const initialGlobals = { contrast: "system", colorVision: "none" };
 
 export const decorators = [NdsStyles, ExamplesBackground];
 export const tags = ["autodocs"];

--- a/MIGRATION_v6.md
+++ b/MIGRATION_v6.md
@@ -365,6 +365,8 @@ The associated brand color helper classes (`.bgColor--<brand>` and `.fontColor--
 }
 ```
 
+### Removed webpack builds
+
 NDS v6 no longer uses webpack for builds. Vite is now the only build tool used by this project.
 
 #### What Changed

--- a/src/examples/ColorModes.stories.jsx
+++ b/src/examples/ColorModes.stories.jsx
@@ -15,6 +15,10 @@ Contrast is a three-state user preference stored on the \`<html>\` element as a
   when the OS reports increased contrast
 - \`data-prefers-contrast="more"\` → **High Contrast**: force the high-contrast palette
 
+Status colors additionally support **color-vision-deficiency** palettes via a
+\`data-color-vision-deficiency\` attribute (\`protanopia\`, \`deuteranopia\`,
+\`tritanopia\`). See the **Examples/Color Vision** story for details.
+
 ### Authoring high-contrast overrides in components
 
 Use the \`contrastMore\` Sass mixin (from \`src/base-styles/scss-utils.scss\`,

--- a/src/examples/ColorModes.stories.jsx
+++ b/src/examples/ColorModes.stories.jsx
@@ -16,7 +16,7 @@ Contrast is a three-state user preference stored on the \`<html>\` element as a
 - \`data-prefers-contrast="more"\` → **High Contrast**: force the high-contrast palette
 
 Status colors additionally support **color-vision-deficiency** palettes via a
-\`data-color-vision-deficiency\` attribute (\`protanopia\`, \`deuteranopia\`,
+\`data-color-vision-deficiency\` attribute (\`red-green\` (aliases: \`protanopia\`, \`deuteranopia\`),
 \`tritanopia\`). See the **Examples/Color Vision** story for details.
 
 ### Authoring high-contrast overrides in components

--- a/src/examples/ColorVisionDeficiency.stories.jsx
+++ b/src/examples/ColorVisionDeficiency.stories.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+
+export default {
+  title: "Examples/Color Vision",
+  parameters: {
+    docs: {
+      description: {
+        component: `
+Status colors are re-based per color-vision deficiency so meaning rides the
+axis that survives. Palettes are opt-in via a \`data-color-vision-deficiency\`
+attribute on the \`<html>\` element:
+
+- _no attribute_ → **Typical Vision**: the default status palette
+- \`data-color-vision-deficiency="red-green"\` → **Protanopia / Deuteranopia**:
+  the two red–green deficiencies share one setting; meaning moves onto the intact
+  blue–amber axis (Okabe-Ito CVD-safe values). The clinical names
+  \`"protanopia"\` / \`"deuteranopia"\` are also accepted as aliases.
+- \`data-color-vision-deficiency="tritanopia"\` → blue–yellow deficiency;
+  success/error keep green/red while info & warn are re-based and separated by
+  lightness
+
+Because these override the primitive \`--color-*Dark\` / \`--color-*Light\` custom
+properties, any consumer using them picks up the CVD-safe value automatically.
+
+> **Color never carries the load alone.** Every status must still be paired with
+> a non-color cue (icon and/or label). These palettes only improve the odds that
+> color reinforces — never replaces — that cue.
+
+**Use the "Color Vision" toolbar button to preview each palette below.**
+        `,
+      },
+    },
+  },
+};
+
+const STATUSES = [
+  { key: "success", icon: "✓", label: "Success" },
+  { key: "info", icon: "ⓘ", label: "Info" },
+  { key: "warn", icon: "⚠", label: "Warning" },
+  { key: "error", icon: "✕", label: "Error" },
+];
+
+const PALETTES = [
+  { attr: undefined, title: "Typical Vision" },
+  { attr: "red-green", title: "Protanopia / Deuteranopia" },
+  { attr: "tritanopia", title: "Tritanopia" },
+];
+
+const StatusStack = () => (
+  <div>
+    {STATUSES.map(({ key, icon, label }) => (
+      <div
+        key={key}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "12px",
+          padding: "10px 14px",
+          borderRadius: "6px",
+          marginBottom: "8px",
+          backgroundColor: `var(--color-${key}Light)`,
+          border: `1px solid var(--color-${key}Dark)`,
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            color: `var(--color-${key}Dark)`,
+            fontWeight: 700,
+            fontSize: "16px",
+            width: "20px",
+            textAlign: "center",
+          }}
+        >
+          {icon}
+        </span>
+        <span
+          style={{
+            color: `var(--color-${key}Dark)`,
+            fontWeight: 600,
+            fontSize: "14px",
+          }}
+        >
+          {label}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * Reacts to the "Color Vision" toolbar toggle (which sets the attribute on
+ * <html>). Non-color cues (icon + label) accompany every status.
+ */
+export const Specimen = () => (
+  <div style={{ fontFamily: "var(--font-family-default, sans-serif)" }}>
+    <p
+      style={{
+        fontSize: "14px",
+        color: "var(--font-color-secondary)",
+        marginBottom: "24px",
+      }}
+    >
+      Use the <strong>Color Vision</strong> toolbar button to switch the active
+      palette. Every status keeps an icon and label so color never carries
+      meaning alone.
+    </p>
+    <StatusStack />
+  </div>
+);
+Specimen.storyName = "Color Vision";
+
+/**
+ * Side-by-side comparison of every palette at once, each column scoped with its
+ * own `data-color-vision-deficiency` attribute — independent of the toolbar.
+ */
+export const Comparison = () => (
+  <div style={{ fontFamily: "var(--font-family-default, sans-serif)" }}>
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+        gap: "24px",
+      }}
+    >
+      {PALETTES.map(({ attr, title }) => (
+        <div
+          key={title}
+          {...(attr ? { "data-color-vision-deficiency": attr } : {})}
+        >
+          <div
+            style={{
+              fontSize: "13px",
+              fontWeight: 700,
+              marginBottom: "12px",
+              color: "var(--font-color-heading)",
+            }}
+          >
+            {title}
+            {attr ? (
+              <span
+                style={{
+                  display: "block",
+                  fontWeight: 400,
+                  fontFamily: "monospace",
+                  fontSize: "11px",
+                  color: "var(--font-color-secondary)",
+                }}
+              >
+                {`[data-color-vision-deficiency="${attr}"]`}
+              </span>
+            ) : null}
+          </div>
+          <StatusStack />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+Comparison.storyName = "Palette Comparison";

--- a/src/examples/ColorVisionDeficiency.stories.jsx
+++ b/src/examples/ColorVisionDeficiency.stories.jsx
@@ -15,9 +15,9 @@ attribute on the \`<html>\` element:
   the two red–green deficiencies share one setting; meaning moves onto the intact
   blue–amber axis (Okabe-Ito CVD-safe values). The clinical names
   \`"protanopia"\` / \`"deuteranopia"\` are also accepted as aliases.
-- \`data-color-vision-deficiency="tritanopia"\` → blue–yellow deficiency;
-  success/error keep green/red while info & warn are re-based and separated by
-  lightness
+- \`data-color-vision-deficiency="tritanopia"\` → blue–yellow deficiency:
+  status colors are re-based to stay distinguishable under tritanopia, with success/error
+  pushed toward lightness extremes and info/warn separated by hue + lightness
 
 Because these override the primitive \`--color-*Dark\` / \`--color-*Light\` custom
 properties, any consumer using them picks up the CVD-safe value automatically.

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -20,6 +20,10 @@ tokens/
 │   │   └── color.json    # text/*, background/*, border/*, theme/*
 │   ├── light-contrast-more/  # High contrast light mode overrides
 │   │   └── color.json    # Only tokens that differ from light/
+│   ├── cvd-red-green/    # Protanopia/deuteranopia palette overrides
+│   │   └── color.json    # Re-based color.system.* status tokens
+│   ├── cvd-tritanopia/   # Tritanopia palette overrides
+│   │   └── color.json    # Re-based color.system.* status tokens
 │   ├── *.stories.js      # Storybook stories
 │   └── *.mdx             # Storybook docs
 ├── constants.ts          # Mode definitions (contrast + color-vision deficiency)
@@ -54,12 +58,15 @@ to a stored user preference.
     aliases (emitted as extra selectors).
   - `data-color-vision-deficiency="tritanopia"` → blue–yellow deficiency palette.
 
-  Unlike contrast, the CVD palettes are defined inline in `constants.ts`
-  (`COLOR_VISION_DEFICIENCIES`) rather than as style-dictionary sources — they only
-  override the primitive `--color-*Dark` / `--color-*Light` custom properties and don't
-  feed any other distribution. Any consumer using those primitives picks up the CVD-safe
-  value. Non-color cues (icon/label) must still accompany every status — color never
-  carries the load alone.
+  Unlike contrast, there is no OS media query for CVD, so these are attribute-only
+  modes (no `@media` block). The palettes live as style-dictionary sources in
+  `semantic/cvd-red-green/` and `semantic/cvd-tritanopia/` — one folder per `value`,
+  linked to its `COLOR_VISION_DEFICIENCIES` entry by the `cvd-<value>` convention.
+  They re-base the primitive `color.system.*` status tokens (`--color-*Dark` /
+  `--color-*Light`), so any consumer using those primitives picks up the CVD-safe
+  value. The `constants.ts` entry carries only the selector/alias/label metadata,
+  which has no home in a token JSON. Non-color cues (icon/label) must still
+  accompany every status — color never carries the load alone.
 
 ## Usage
 
@@ -92,7 +99,8 @@ for a full list of CSS custom properties.
 
 ### Adding a new mode
 
-There are two mode shapes, both emitted as additive CSS blocks appended to `tokens.css`:
+All modes are style-dictionary sources emitted as additive CSS blocks appended to
+`tokens.css`/`tokens.scss`. There are two shapes:
 
 **OS-preference modes** (e.g. contrast) pair a media query with an opt-in/opt-out attribute:
 
@@ -101,14 +109,19 @@ There are two mode shapes, both emitted as additive CSS blocks appended to `toke
 3. Add an entry to `COLOR_MODES` in `tokens/constants.ts` (media query + selector)
 4. Add a build pass in `tokens/build.ts` that calls `buildModeCSS` with the media query
 
-**Attribute-only modes** (e.g. color vision deficiency) have no OS signal and, when they
-only remap existing primitives, don't need a style-dictionary source at all:
+**Attribute-only modes** (e.g. color vision deficiency) have no OS signal, so they emit
+only an attribute-selector block (no `@media`):
 
-1. Add an entry to `COLOR_VISION_DEFICIENCIES` in `tokens/constants.ts` with its collapsed
-   `value`, any `aliases` (rendered as extra selectors), and the `overrides` map (CSS var
-   name → value)
-2. `tokens/build.ts` appends a block for each entry automatically — no per-mode wiring
-3. Wire the toolbar toggle in `.storybook/preview.js` + `.storybook/decorators.js` to preview it
+1. Create a source folder under `tokens/semantic/` named `cvd-<value>` (e.g.
+   `cvd-red-green/`) and add only the tokens that differ from base — for CVD these
+   re-base `color.system.*` status tokens
+2. Add an entry to `COLOR_VISION_DEFICIENCIES` in `tokens/constants.ts` with its
+   collapsed `value` (must match the folder suffix), any `aliases` (rendered as extra
+   selectors), and a `label`
+3. `tokens/build.ts` compiles each palette's source and appends its block
+   automatically — no per-mode wiring
+4. Wire the toolbar toggle in `.storybook/preview.js` + `.storybook/decorators.js` to
+   preview it
 
 ### Adding a new distribution
 

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -22,6 +22,8 @@ tokens/
 │   │   └── color.json    # Only tokens that differ from light/
 │   ├── *.stories.js      # Storybook stories
 │   └── *.mdx             # Storybook docs
+├── constants.ts          # Mode definitions (contrast + color-vision deficiency)
+├── modes.ts              # buildModeCSS: emits mode override blocks
 ├── config.js             # style-dictionary v4 build configuration
 └── README.md
 ```
@@ -43,6 +45,21 @@ Modes are managed as additive CSS overrides appended to `tokens.css`:
 To activate a specific contrast mode programmatically, set `data-prefers-contrast` on the
 `<html>` element (or any ancestor, for the `"more"` case). Consumer apps typically wire this
 to a stored user preference.
+
+- **Color vision deficiency (CVD)**: status colors are re-based per deficiency so meaning
+  rides the axis that survives. There is no OS media query for CVD, so these are
+  attribute-only modes driven by `data-color-vision-deficiency` on the `<html>` element:
+  - `data-color-vision-deficiency="red-green"` → shared **Protanopia / Deuteranopia**
+    palette. The clinical names `"protanopia"` / `"deuteranopia"` are also accepted as
+    aliases (emitted as extra selectors).
+  - `data-color-vision-deficiency="tritanopia"` → blue–yellow deficiency palette.
+
+  Unlike contrast, the CVD palettes are defined inline in `constants.ts`
+  (`COLOR_VISION_DEFICIENCIES`) rather than as style-dictionary sources — they only
+  override the primitive `--color-*Dark` / `--color-*Light` custom properties and don't
+  feed any other distribution. Any consumer using those primitives picks up the CVD-safe
+  value. Non-color cues (icon/label) must still accompany every status — color never
+  carries the load alone.
 
 ## Usage
 
@@ -75,9 +92,23 @@ for a full list of CSS custom properties.
 
 ### Adding a new mode
 
+There are two mode shapes, both emitted as additive CSS blocks appended to `tokens.css`:
+
+**OS-preference modes** (e.g. contrast) pair a media query with an opt-in/opt-out attribute:
+
 1. Create a new folder under `tokens/semantic/` (e.g. `dark/`, `dark-contrast-more/`)
 2. Add only the tokens that differ from the base `light/` mode
-3. Update `config.js` to add the new mode source and format output
+3. Add an entry to `COLOR_MODES` in `tokens/constants.ts` (media query + selector)
+4. Add a build pass in `tokens/build.ts` that calls `buildModeCSS` with the media query
+
+**Attribute-only modes** (e.g. color vision deficiency) have no OS signal and, when they
+only remap existing primitives, don't need a style-dictionary source at all:
+
+1. Add an entry to `COLOR_VISION_DEFICIENCIES` in `tokens/constants.ts` with its collapsed
+   `value`, any `aliases` (rendered as extra selectors), and the `overrides` map (CSS var
+   name → value)
+2. `tokens/build.ts` appends a block for each entry automatically — no per-mode wiring
+3. Wire the toolbar toggle in `.storybook/preview.js` + `.storybook/decorators.js` to preview it
 
 ### Adding a new distribution
 

--- a/tokens/build.ts
+++ b/tokens/build.ts
@@ -18,8 +18,10 @@ import {
   COLOR_MODES,
   COLOR_VISION_DEFICIENCIES,
   cvdSelectors,
+  cvdSourceDir,
 } from "./constants.js";
 import { buildModeCSS } from "./modes.js";
+import type { ColorVisionDeficiency } from "./constants.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
@@ -175,31 +177,48 @@ const modeConfig: Config = {
   },
 };
 
-// ─── Color-vision-deficiency mode overrides ──────────────────────────────────
+// ─── Color-vision-deficiency mode config ─────────────────────────────────────
 
 /**
- * Appends the color-vision-deficiency palettes to the already-built CSS/SCSS.
- *
- * Unlike contrast, CVD palettes are defined inline (see `COLOR_VISION_DEFICIENCIES`)
- * rather than as style-dictionary sources: they only override existing primitive
- * `--color-*` properties and never feed any other distribution, so a full SD pass
- * would be ceremony. Each palette emits one attribute-only block (no media query),
- * with its collapsed value plus clinical-name aliases as selectors.
+ * Builds a style-dictionary config for one CVD palette, mirroring the high
+ * contrast setup: the palette's `semantic/cvd-*` source is compiled and its
+ * tokens appended to the CSS/SCSS as an attribute-only override block (no media
+ * query — there is no OS signal for CVD). Clinical-name aliases render as extra
+ * selectors sharing the block.
  */
-function appendColorVisionDeficiencies(): void {
-  const cssDir = getBuildPath("css");
-  for (const cvd of COLOR_VISION_DEFICIENCIES) {
-    const tokens = Object.entries(cvd.overrides).map(([name, value]) => ({
-      name,
-      value,
-    }));
-    const modeBlock = buildModeCSS({
-      selector: cvdSelectors(cvd),
-      tokens,
-    });
-    fs.appendFileSync(`${cssDir}tokens.css`, modeBlock);
-    fs.appendFileSync(`${cssDir}tokens.scss`, modeBlock);
-  }
+function cvdConfig(cvd: ColorVisionDeficiency): Config {
+  return {
+    source: [
+      path.resolve(__dirname, `semantic/${cvdSourceDir(cvd)}/**/*.json`),
+    ],
+    hooks: {
+      transforms,
+      filters,
+      actions: {
+        "append-cvd": {
+          do: (dictionary) => {
+            const modeBlock = buildModeCSS({
+              selector: cvdSelectors(cvd),
+              tokens: dictionary.allTokens,
+            });
+            const cssDir = getBuildPath("css");
+            fs.appendFileSync(`${cssDir}tokens.css`, modeBlock);
+            fs.appendFileSync(`${cssDir}tokens.scss`, modeBlock);
+          },
+          undo: () => {},
+        },
+      },
+    },
+    platforms: {
+      cssMode: {
+        basePxFontSize: 16,
+        transforms: [...CSS_TRANSFORMS, "custom/value/pxToRem"],
+        buildPath: getBuildPath("css"),
+        actions: ["append-cvd"],
+        files: [],
+      },
+    },
+  };
 }
 
 // ─── Build ───────────────────────────────────────────────────────────────────
@@ -211,7 +230,10 @@ async function main() {
   const sdMode = new StyleDictionary(modeConfig);
   await sdMode.buildAllPlatforms();
 
-  appendColorVisionDeficiencies();
+  for (const cvd of COLOR_VISION_DEFICIENCIES) {
+    const sdCvd = new StyleDictionary(cvdConfig(cvd));
+    await sdCvd.buildAllPlatforms();
+  }
 }
 main().catch((error) => {
   console.error(error);

--- a/tokens/build.ts
+++ b/tokens/build.ts
@@ -14,7 +14,11 @@ import {
 import { transforms } from "./hooks/transforms.mjs";
 import { filters } from "./hooks/filters.mjs";
 import { formats } from "./hooks/formats.mjs";
-import { COLOR_MODES } from "./constants.js";
+import {
+  COLOR_MODES,
+  COLOR_VISION_DEFICIENCIES,
+  cvdSelectors,
+} from "./constants.js";
 import { buildModeCSS } from "./modes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -171,6 +175,33 @@ const modeConfig: Config = {
   },
 };
 
+// ─── Color-vision-deficiency mode overrides ──────────────────────────────────
+
+/**
+ * Appends the color-vision-deficiency palettes to the already-built CSS/SCSS.
+ *
+ * Unlike contrast, CVD palettes are defined inline (see `COLOR_VISION_DEFICIENCIES`)
+ * rather than as style-dictionary sources: they only override existing primitive
+ * `--color-*` properties and never feed any other distribution, so a full SD pass
+ * would be ceremony. Each palette emits one attribute-only block (no media query),
+ * with its collapsed value plus clinical-name aliases as selectors.
+ */
+function appendColorVisionDeficiencies(): void {
+  const cssDir = getBuildPath("css");
+  for (const cvd of COLOR_VISION_DEFICIENCIES) {
+    const tokens = Object.entries(cvd.overrides).map(([name, value]) => ({
+      name,
+      value,
+    }));
+    const modeBlock = buildModeCSS({
+      selector: cvdSelectors(cvd),
+      tokens,
+    });
+    fs.appendFileSync(`${cssDir}tokens.css`, modeBlock);
+    fs.appendFileSync(`${cssDir}tokens.scss`, modeBlock);
+  }
+}
+
 // ─── Build ───────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -179,6 +210,8 @@ async function main() {
 
   const sdMode = new StyleDictionary(modeConfig);
   await sdMode.buildAllPlatforms();
+
+  appendColorVisionDeficiencies();
 }
 main().catch((error) => {
   console.error(error);

--- a/tokens/constants.ts
+++ b/tokens/constants.ts
@@ -18,3 +18,88 @@ export const COLOR_MODES = {
     value: "less",
   },
 } as const satisfies Record<string, ColorMode>;
+
+export interface ColorVisionDeficiency {
+  /**
+   * The collapsed, user-facing value set on `CVD_ATTRIBUTE`. Red–green
+   * deficiencies share one setting (`red-green`) rather than exposing the two
+   * clinical names as separate settings.
+   */
+  value: string;
+  /**
+   * Additional attribute values that resolve to the same palette. The clinical
+   * names are kept as aliases so a consumer that stores `protanopia` /
+   * `deuteranopia` directly still matches (rendered as extra selectors).
+   */
+  aliases: string[];
+  /** Human-readable label (used in Storybook / docs). */
+  label: string;
+  /**
+   * Primitive overrides for this palette: CSS custom-property name (without the
+   * leading `--`) → value. These override the primitive `--color-*` properties
+   * directly, so any consumer using them picks up the CVD-safe value.
+   */
+  overrides: Record<string, string>;
+}
+
+/** Attribute on the `<html>` element that opts into a CVD palette. */
+export const CVD_ATTRIBUTE = "data-color-vision-deficiency";
+
+/**
+ * Color-vision-deficiency palettes. Unlike contrast, there is no OS media query
+ * for CVD, so these are attribute-only modes driven by `CVD_ATTRIBUTE`.
+ *
+ * Status colors are re-based per deficiency so meaning rides the axis that
+ * survives. Non-color cues (icon/label) must still accompany every status —
+ * color never carries the load alone.
+ */
+export const COLOR_VISION_DEFICIENCIES: ColorVisionDeficiency[] = [
+  {
+    // Red–green deficiencies. These are ALTERNATE colors chosen to be maximally
+    // distinguishable *under protanopia/deuteranopia simulation* — not tweaks of
+    // the standard status colors. Assigned so success (lightest) and error
+    // (darkest) sit at the lightness extremes (the never-confuse pair is the most
+    // separated). A grayscale floor keeps every status distinct by lightness too.
+    // Verified: worst-case sim ΔE ≈ 26–29 (standard ≈ 11); all AA on their tint.
+    // Meaning is carried by icon/label — color never carries the load alone.
+    value: "red-green",
+    aliases: ["protanopia", "deuteranopia"],
+    label: "Protanopia / Deuteranopia (red–green)",
+    overrides: {
+      "color-successDark": "#6F6BAD",
+      "color-successLight": "#F7F8FF",
+      "color-infoDark": "#1A56B0",
+      "color-infoLight": "#E9EFFB",
+      "color-warnDark": "#6F004F",
+      "color-warnLight": "#FFE9F4",
+      "color-errorDark": "#4B0200",
+      "color-errorLight": "#FFEBE7",
+    },
+  },
+  {
+    // Blue–yellow deficiency. ALTERNATE colors chosen to be maximally
+    // distinguishable *under tritanopia simulation*; success (lightest) and error
+    // (darkest) at the lightness extremes, with a grayscale floor.
+    // Verified: worst-case sim ΔE ≈ 32 (standard ≈ 4); all AA on their tint.
+    value: "tritanopia",
+    aliases: [],
+    label: "Tritanopia (blue–yellow)",
+    overrides: {
+      "color-successDark": "#E2004C",
+      "color-successLight": "#FFF6F6",
+      "color-infoDark": "#007654",
+      "color-infoLight": "#D2FBE8",
+      "color-warnDark": "#2200C3",
+      "color-warnLight": "#EAF0FF",
+      "color-errorDark": "#52001C",
+      "color-errorLight": "#FFEAED",
+    },
+  },
+];
+
+/** All attribute selectors (value + aliases) that activate a CVD palette. */
+export const cvdSelectors = ({
+  value,
+  aliases,
+}: ColorVisionDeficiency): string[] =>
+  [value, ...aliases].map((v) => `[${CVD_ATTRIBUTE}="${v}"]`);

--- a/tokens/constants.ts
+++ b/tokens/constants.ts
@@ -102,4 +102,7 @@ export const cvdSelectors = ({
   value,
   aliases,
 }: ColorVisionDeficiency): string[] =>
-  [value, ...aliases].map((v) => `[${CVD_ATTRIBUTE}="${v}"]`);
+  [value, ...aliases].flatMap((v) => [
+    `:root[${CVD_ATTRIBUTE}="${v}"]`,
+    `[${CVD_ATTRIBUTE}="${v}"]`,
+  ]);

--- a/tokens/constants.ts
+++ b/tokens/constants.ts
@@ -34,20 +34,27 @@ export interface ColorVisionDeficiency {
   aliases: string[];
   /** Human-readable label (used in Storybook / docs). */
   label: string;
-  /**
-   * Primitive overrides for this palette: CSS custom-property name (without the
-   * leading `--`) → value. These override the primitive `--color-*` properties
-   * directly, so any consumer using them picks up the CVD-safe value.
-   */
-  overrides: Record<string, string>;
 }
 
 /** Attribute on the `<html>` element that opts into a CVD palette. */
 export const CVD_ATTRIBUTE = "data-color-vision-deficiency";
 
 /**
+ * Style-dictionary source directory (under `tokens/semantic/`) holding a CVD
+ * palette's primitive overrides. Derived from `value` by convention, mirroring
+ * how `light-contrast-more/` ties to `COLOR_MODES.highContrast`.
+ */
+export const cvdSourceDir = ({ value }: ColorVisionDeficiency): string =>
+  `cvd-${value}`;
+
+/**
  * Color-vision-deficiency palettes. Unlike contrast, there is no OS media query
  * for CVD, so these are attribute-only modes driven by `CVD_ATTRIBUTE`.
+ *
+ * The override values live as style-dictionary sources in `tokens/semantic/cvd-*`
+ * (one folder per `value`); they re-base the primitive `color.system.*` status
+ * tokens so any consumer of `--color-*` picks up the CVD-safe value. This entry
+ * only carries the selector/label metadata that has no home in a token JSON.
  *
  * Status colors are re-based per deficiency so meaning rides the axis that
  * survives. Non-color cues (icon/label) must still accompany every status —
@@ -62,38 +69,20 @@ export const COLOR_VISION_DEFICIENCIES: ColorVisionDeficiency[] = [
     // separated). A grayscale floor keeps every status distinct by lightness too.
     // Verified: worst-case sim ΔE ≈ 26–29 (standard ≈ 11); all AA on their tint.
     // Meaning is carried by icon/label — color never carries the load alone.
+    // Values: tokens/semantic/cvd-red-green/color.json
     value: "red-green",
     aliases: ["protanopia", "deuteranopia"],
     label: "Protanopia / Deuteranopia (red–green)",
-    overrides: {
-      "color-successDark": "#6F6BAD",
-      "color-successLight": "#F7F8FF",
-      "color-infoDark": "#1A56B0",
-      "color-infoLight": "#E9EFFB",
-      "color-warnDark": "#6F004F",
-      "color-warnLight": "#FFE9F4",
-      "color-errorDark": "#4B0200",
-      "color-errorLight": "#FFEBE7",
-    },
   },
   {
     // Blue–yellow deficiency. ALTERNATE colors chosen to be maximally
     // distinguishable *under tritanopia simulation*; success (lightest) and error
     // (darkest) at the lightness extremes, with a grayscale floor.
     // Verified: worst-case sim ΔE ≈ 32 (standard ≈ 4); all AA on their tint.
+    // Values: tokens/semantic/cvd-tritanopia/color.json
     value: "tritanopia",
     aliases: [],
     label: "Tritanopia (blue–yellow)",
-    overrides: {
-      "color-successDark": "#E2004C",
-      "color-successLight": "#FFF6F6",
-      "color-infoDark": "#007654",
-      "color-infoLight": "#D2FBE8",
-      "color-warnDark": "#2200C3",
-      "color-warnLight": "#EAF0FF",
-      "color-errorDark": "#52001C",
-      "color-errorLight": "#FFEAED",
-    },
   },
 ];
 

--- a/tokens/modes.ts
+++ b/tokens/modes.ts
@@ -2,9 +2,8 @@ import type { TransformedToken } from "style-dictionary/types";
 
 /**
  * The subset of a token this module needs. Structurally compatible with
- * style-dictionary's `TransformedToken` (so `dictionary.allTokens` works), while
- * also accepting plain override maps that never pass through the SD pipeline
- * (e.g. the inline color-vision-deficiency palettes).
+ * style-dictionary's `TransformedToken`, so `dictionary.allTokens` from any
+ * mode's source build can be passed straight through.
  */
 type ModeToken = Pick<TransformedToken, "name"> & { value: string | number };
 

--- a/tokens/modes.ts
+++ b/tokens/modes.ts
@@ -1,9 +1,28 @@
 import type { TransformedToken } from "style-dictionary/types";
 
+/**
+ * The subset of a token this module needs. Structurally compatible with
+ * style-dictionary's `TransformedToken` (so `dictionary.allTokens` works), while
+ * also accepting plain override maps that never pass through the SD pipeline
+ * (e.g. the inline color-vision-deficiency palettes).
+ */
+type ModeToken = Pick<TransformedToken, "name"> & { value: string | number };
+
 interface BuildModeCSSOptions {
-  mediaQuery: string;
-  selector: string;
-  tokens: TransformedToken[];
+  /**
+   * Optional OS-level media query (e.g. `(prefers-contrast: more)`). When
+   * omitted, only the attribute-selector block is emitted — used for modes
+   * that have no OS signal, such as color-vision deficiencies.
+   */
+  mediaQuery?: string;
+  /**
+   * One or more attribute selectors that opt into this mode. When multiple
+   * selectors are provided they share a single block (comma-separated), which
+   * lets deficiencies with an identical palette (protanopia + deuteranopia)
+   * reuse one set of overrides.
+   */
+  selector: string | string[];
+  tokens: ModeToken[];
   /**
    * Optional attribute selector that, when present on `:root`, should suppress
    * the media-query override. This lets consumers (and Storybook) force a
@@ -14,7 +33,10 @@ interface BuildModeCSSOptions {
 
 /**
  * Generates CSS override blocks for a given mode.
- * Produces both a media query block and a data-attribute selector block.
+ *
+ * Always emits an attribute-selector block. When `mediaQuery` is provided it
+ * additionally emits a media-query block so the mode can follow an OS
+ * preference.
  *
  * When `excludeSelector` is provided, the media-query block is scoped to
  * `:root:not(<excludeSelector>)` so an explicit user preference can opt out
@@ -30,21 +52,22 @@ export function buildModeCSS({
     .map((token) => `    --${token.name}: ${token.value};`)
     .join("\n");
 
-  const mediaRootSelector = excludeSelector
-    ? `:root:not(${excludeSelector})`
-    : ":root";
+  const attributeSelector = Array.isArray(selector)
+    ? selector.join(",\n")
+    : selector;
 
-  return [
-    "",
-    `@media ${mediaQuery} {`,
-    `  ${mediaRootSelector} {`,
-    vars,
-    "  }",
-    "}",
-    "",
-    `${selector} {`,
-    vars,
-    "}",
-    "",
-  ].join("\n");
+  const mediaBlock = mediaQuery
+    ? [
+        "",
+        `@media ${mediaQuery} {`,
+        `  ${excludeSelector ? `:root:not(${excludeSelector})` : ":root"} {`,
+        vars,
+        "  }",
+        "}",
+      ]
+    : [];
+
+  return [...mediaBlock, "", `${attributeSelector} {`, vars, "}", ""].join(
+    "\n",
+  );
 }

--- a/tokens/semantic/cvd-red-green/color.json
+++ b/tokens/semantic/cvd-red-green/color.json
@@ -1,0 +1,14 @@
+{
+  "color": {
+    "system": {
+      "successDark": { "value": "#6F6BAD" },
+      "successLight": { "value": "#F7F8FF" },
+      "infoDark": { "value": "#1A56B0" },
+      "infoLight": { "value": "#E9EFFB" },
+      "warnDark": { "value": "#6F004F" },
+      "warnLight": { "value": "#FFE9F4" },
+      "errorDark": { "value": "#4B0200" },
+      "errorLight": { "value": "#FFEBE7" }
+    }
+  }
+}

--- a/tokens/semantic/cvd-tritanopia/color.json
+++ b/tokens/semantic/cvd-tritanopia/color.json
@@ -1,0 +1,14 @@
+{
+  "color": {
+    "system": {
+      "successDark": { "value": "#E2004C" },
+      "successLight": { "value": "#FFF6F6" },
+      "infoDark": { "value": "#007654" },
+      "infoLight": { "value": "#D2FBE8" },
+      "warnDark": { "value": "#2200C3" },
+      "warnLight": { "value": "#EAF0FF" },
+      "errorDark": { "value": "#52001C" },
+      "errorLight": { "value": "#FFEAED" }
+    }
+  }
+}


### PR DESCRIPTION
#### Glossary
**CVD:** color vision deficiency
Anyone with cone anomalies or full deficiencies within any color space.
We aim to support the two most common types in a common palette for "red/green" color blindness as well as the more rare traitanopia.

### Screenshot
This is the full set of palettes, presented without any filters:
<img width="964" height="350" alt="Screenshot 2026-08-17 at 8 33 54 PM" src="https://github.com/user-attachments/assets/315f01c5-7400-42ef-a446-883917b7f554" />

## What about high contrast?
It's additive. You can independently enable/disable modes. Heres tritanopia with high contrast enabled, for example:
<img width="591" height="402" alt="Screenshot 2026-08-17 at 8 35 02 PM" src="https://github.com/user-attachments/assets/03535127-45e6-440a-ad0f-b353c86bbd86" />

## Changes
We now output this in design system CSS

```css
[data-color-vision-deficiency="red-green"],
[data-color-vision-deficiency="protanopia"],
[data-color-vision-deficiency="deuteranopia"] {
    --color-successDark: #6F6BAD;
    --color-successLight: #F7F8FF;
    --color-infoDark: #1A56B0;
    --color-infoLight: #E9EFFB;
    --color-warnDark: #6F004F;
    --color-warnLight: #FFE9F4;
    --color-errorDark: #4B0200;
    --color-errorLight: #FFEBE7;
}

[data-color-vision-deficiency="tritanopia"] {
    --color-successDark: #E2004C;
    --color-successLight: #FFF6F6;
    --color-infoDark: #007654;
    --color-infoLight: #D2FBE8;
    --color-warnDark: #2200C3;
    --color-warnLight: #EAF0FF;
    --color-errorDark: #52001C;
    --color-errorLight: #FFEAED;
}
```

## Reviewing this PR:
Click on the storybook preview link and navigate to the "Chips kinds" story. This is the best single point to verify semantic system colors are distinguishable by CVD users.

#### Use the accessibility icon to simulate different types of CVD
<img width="664" height="567" alt="Screenshot 2026-08-17 at 8 25 58 PM" src="https://github.com/user-attachments/assets/84c8fdd4-106c-4c59-9fcd-e924b0e3418c" />

For example, here is a simulated CVD _without_ correction via colorblind mode.
<img width="612" height="403" alt="Screenshot 2026-08-17 at 8 26 37 PM" src="https://github.com/user-attachments/assets/172ad291-6796-4033-a3bb-aa628b79b07e" />

**Enable the mode via the colorblind dropdown**
<img width="230" height="175" alt="Screenshot 2026-08-17 at 8 27 22 PM" src="https://github.com/user-attachments/assets/057b30b8-b364-4a64-acdd-f128b556e4b8" />

Test against simulated CVD options.


## Options considered

### Not chosen: _daltonization_
There's a deterministic process for shifting colors within the range of problem colors for users with CVD. It's called daltonization. It's good, but not the right tool for the job. Daltonization aims to preserve as much as possible from the original hue. We do not care about original hue. We only care that users can distinguish between success, info, warn, and error with any form of CVD.

### Chosen: Okate-Ibo palette
This is a single palette designed to fit all forms of CVD. We depart from this in hue using daltonization cues, so that in all color modes "success" is distinguishable from "error". 

Instead of tweaking colors toward a less problematic hue, we chose an entirely different palette where we accept that no green or red will be preserved. Hues of purples, mustard, and olive are used to help group colors for all forms of CVD.

### Why?
Alternate palettes are better and easier to adjust than color math. Don't take my word for it, ask [Edward Tufte](https://www.edwardtufte.com/notebook/choice-of-colors-in-print-and-graphics-for-color-blind-readers/)
