### PR TITLE
feat(Button): add labelAlign prop

### DIFF
--- a/src/Button/index.scss
+++ b/src/Button/index.scss
@@ -18,6 +18,26 @@
   overflow: hidden;
 }
 
+/**
+* Label centered by default unless otherwise specified.
+* When the `labelAlign` prop is passed, it should override all variant behavior.
+*/
+.nds-button-content {
+  text-align: center;
+
+  &--center {
+    text-align: center !important;
+  }
+
+  &--start {
+    text-align: start !important;
+  }
+
+  &--end {
+    text-align: end !important;
+  }
+}
+
 // The click should always originate from the root button or anchor element
 .nds-button *,
 .nds-button.resetButton * {

--- a/src/Button/index.test.js
+++ b/src/Button/index.test.js
@@ -5,6 +5,8 @@ import Button from "./";
 const LABEL = "Submit";
 
 const getButton = () => screen.getByTestId("nds-button");
+const getButtonContent = () =>
+  getButton().querySelector(".nds-button-content");
 
 describe("Button", () => {
   it("has correct attributes for default props", () => {
@@ -96,4 +98,26 @@ describe("Button", () => {
     const button = getButton();
     expect(button).toHaveAttribute("href", "/safe-path");
   });
+
+  it("uses full-width default alignment without a labelAlign modifier", () => {
+    render(<Button label={LABEL} isFullWidth={true} />);
+    const button = getButton();
+    const buttonContent = getButtonContent();
+
+    expect(button).toHaveClass("nds-button--fullWidth");
+    expect(buttonContent).toHaveClass("nds-button-content");
+    expect(buttonContent).not.toHaveClass("nds-button-content--start");
+    expect(buttonContent).not.toHaveClass("nds-button-content--center");
+    expect(buttonContent).not.toHaveClass("nds-button-content--end");
+  });
+
+  it.each(["start", "center", "end"])(
+    "applies the %s label alignment modifier",
+    (labelAlign) => {
+      render(<Button label={LABEL} isFullWidth={true} labelAlign={labelAlign} />);
+      const buttonContent = getButtonContent();
+
+      expect(buttonContent).toHaveClass(`nds-button-content--${labelAlign}`);
+    },
+  );
 });

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -36,6 +36,8 @@ export interface ButtonProps {
   type?: "submit" | "button" | "reset";
   /** size variant of button */
   size?: "xs" | "s" | "m";
+  /** horizontal alignment of button label content */
+  labelAlign?: "start" | "center" | "end";
   /** Name of Narmi icon to place at the start of the label */
   startIcon?: IconName | null;
   /** Name of Narmi icon to place at the end of the label */
@@ -53,7 +55,7 @@ export interface ButtonProps {
   children?: React.ReactNode | string | undefined;
   /**
    * Will take up full width of its parent container when `true`.
-   * The label will align start with flex grow.
+   * Label alignment is controlled by `labelAlign`.
    */
   isFullWidth?: boolean;
   [x: string]: unknown; // spread props
@@ -74,6 +76,7 @@ const Button = ({
   kind = "primary",
   type,
   size = "m",
+  labelAlign,
   startIcon = null,
   endIcon = null,
   testId,
@@ -129,7 +132,16 @@ const Button = ({
       aria-label={ariaLabel || buttonLabel}
       data-testid={testId || "nds-button"}
     >
-      <div className="nds-button-content">
+      <div
+        className={cc([
+          "nds-button-content",
+          {
+            "nds-button-content--center": labelAlign === "center",
+            "nds-button-content--start": labelAlign === "start",
+            "nds-button-content--end": labelAlign === "end",
+          },
+        ])}
+      >
         {isLoading && (
           <div className="nds-button-spinner">
             <Spinner

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -55,7 +55,8 @@ export interface ButtonProps {
   children?: React.ReactNode | string | undefined;
   /**
    * Will take up full width of its parent container when `true`.
-   * Label alignment is controlled by `labelAlign`.
+   * Full-width buttons align label content to `start` by default; use `labelAlign`
+   * to override that alignment.
    */
   isFullWidth?: boolean;
   [x: string]: unknown; // spread props


### PR DESCRIPTION
Closes NDS-3117

Adds `labelAlign` prop to control label alignment in Button.

By default, it's centered. 
When the button `isFullWidth`, the default is `start`.

If `labelAlign` is defined, it will override any of the above defaults.


centered & full width:
<img width="1053" height="150" alt="Screenshot 2026-08-19 at 7 56 31 PM" src="https://github.com/user-attachments/assets/f80a5b58-8a5b-4ab3-a50d-1f0bbbbfa2a4" />
