### PR TITLE
Nds 3213/tooltip zindex patch

### DIFF
--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -31,9 +31,7 @@ export const Open = {
   name: "Interaction: Opens on click",
   render: () => <Combobox label="Select your state">{children}</Combobox>,
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(
-      canvas.getByRole("combobox", { name: /select your state/i }),
-    );
+    await userEvent.click(canvas.getByRole("combobox"));
     await waitFor(() =>
       expect(screen.getByRole("option", { name: /alabama/i })).toBeVisible(),
     );

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Combobox, { VALID_ICON_NAMES } from "./";
 import ComboboxItem from "./ComboboxItem";
 import ComboboxHeading from "./ComboboxHeading";
@@ -20,6 +21,21 @@ export const Overview = Template.bind({});
 Overview.args = {
   label: "Select your state",
   children,
+};
+
+/**
+ * Interaction test that opens the Combobox so Chromatic can snapshot
+ * the dropdown's placement.
+ */
+export const Open = {
+  name: "Interaction: Opens on click",
+  render: () => <Combobox label="Select your state">{children}</Combobox>,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/select your state/i));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /alabama/i })).toBeVisible(),
+    );
+  },
 };
 
 export const WithIcon = Template.bind({});

--- a/src/Combobox/index.stories.js
+++ b/src/Combobox/index.stories.js
@@ -31,7 +31,9 @@ export const Open = {
   name: "Interaction: Opens on click",
   render: () => <Combobox label="Select your state">{children}</Combobox>,
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByLabelText(/select your state/i));
+    await userEvent.click(
+      canvas.getByRole("combobox", { name: /select your state/i }),
+    );
     await waitFor(() =>
       expect(screen.getByRole("option", { name: /alabama/i })).toBeVisible(),
     );

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Popover from "./";
 import Button from "../Button";
 
@@ -27,6 +28,30 @@ Overview.args = {
 };
 Overview.argTypes = {
   content: { control: false },
+};
+
+/**
+ * Interaction test that opens the Popover so Chromatic can snapshot
+ * the layer's placement.
+ */
+export const Open = {
+  name: "Interaction: Opens on click",
+  render: () => (
+    <Popover
+      renderTrigger={() => (
+        <Button type="button" kind="secondary">
+          Open Popover
+        </Button>
+      )}
+      content={<div className="padding--all--m">📦 Any content</div>}
+    />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: /open popover/i }),
+    );
+    await waitFor(() => expect(screen.getByText(/any content/i)).toBeVisible());
+  },
 };
 
 export const LegacyTrigger = () => {

--- a/src/Popover/index.stories.js
+++ b/src/Popover/index.stories.js
@@ -47,9 +47,7 @@ export const Open = {
     />
   ),
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(
-      canvas.getByRole("button", { name: /open popover/i }),
-    );
+    await userEvent.click(canvas.getByTestId("nds-popover-trigger"));
     await waitFor(() => expect(screen.getByText(/any content/i)).toBeVisible());
   },
 };

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -44,7 +44,9 @@ export const Open = {
     </Select>
   ),
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByLabelText(/favorite icon/i));
+    await userEvent.click(
+      canvas.getByRole("combobox", { name: /favorite icon/i }),
+    );
     await waitFor(() =>
       expect(screen.getByRole("option", { name: /coffee/i })).toBeVisible(),
     );

--- a/src/Select/index.stories.js
+++ b/src/Select/index.stories.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-key,react/no-unescaped-entities */
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Select from "./";
 import SelectItem from "./SelectItem";
 import SelectAction from "./SelectAction";
@@ -29,6 +30,25 @@ Overview.args = {
   id: "overviewStory",
   label: "Favorite icon",
   children,
+};
+
+/**
+ * Interaction test that opens the Select so Chromatic can snapshot
+ * the dropdown's placement.
+ */
+export const Open = {
+  name: "Interaction: Opens on click",
+  render: () => (
+    <Select id="chromaticOpen" label="Favorite icon">
+      {children}
+    </Select>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/favorite icon/i));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toBeVisible(),
+    );
+  },
 };
 
 export const DefaultSelection = Template.bind({});

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -4,6 +4,9 @@ import Button from "../Button";
 import TextInput from "../TextInput";
 import MenuButton from "../MenuButton";
 import IconButton from "../IconButton";
+import Dialog from "../Dialog";
+import Popover from "../Popover";
+import Drawer from "../Drawer";
 
 const Template = (args) => (
   <div
@@ -43,6 +46,75 @@ WithTextInput.parameters = {
         "Tooltip can be used in a TextInput by passing it as the endContent prop.",
     },
   },
+};
+
+/**
+ * Tooltip rendered as `endContent` of a `TextInput` inside a `Dialog`.
+ */
+export const InADialog = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+      <Dialog
+        title="Tooltip in a Dialog"
+        isOpen={isOpen}
+        onUserDismiss={() => setIsOpen(false)}
+      >
+        <TextInput
+          label="Account Number"
+          endContent={
+            <Tooltip text="If you don't have an account number, enter your customer ID">
+              <span className="narmi-icon-info"></span>
+            </Tooltip>
+          }
+        />
+      </Dialog>
+    </>
+  );
+};
+
+/**
+ * Tooltip rendered as `endContent` of a `TextInput` inside a `Popover`.
+ */
+export const InAPopover = () => (
+  <Popover
+    renderTrigger={() => <Button>Open Popover</Button>}
+    content={
+      <div className="padding--all--m" style={{ width: "300px" }}>
+        <TextInput
+          label="Account Number"
+          endContent={
+            <Tooltip text="If you don't have an account number, enter your customer ID">
+              <span className="narmi-icon-info"></span>
+            </Tooltip>
+          }
+        />
+      </div>
+    }
+  />
+);
+
+/**
+ * Tooltip rendered as `endContent` of a `TextInput` inside a `Drawer`.
+ */
+export const InADrawer = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Drawer</Button>
+      <Drawer isOpen={isOpen} onUserDismiss={() => setIsOpen(false)}>
+        <TextInput
+          label="Account Number"
+          endContent={
+            <Tooltip text="If you don't have an account number, enter your customer ID">
+              <span className="narmi-icon-info"></span>
+            </Tooltip>
+          }
+        />
+      </Drawer>
+    </>
+  );
 };
 
 export const WithTooltipAsMenuButtonTrigger = () => {

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Tooltip from "./";
 import Button from "../Button";
 import TextInput from "../TextInput";
@@ -26,6 +27,25 @@ export const Overview = Template.bind({});
 Overview.args = {
   text: "I am a tooltip, which is a tool for tips",
   children: <Button>Button with a tooltip</Button>,
+};
+
+/**
+ * Interaction test that hovers the trigger so Chromatic can snapshot
+ * the tooltip's placement.
+ */
+export const Open = {
+  name: "Interaction: Opens on hover",
+  render: () => (
+    <Tooltip text="I am a tooltip, which is a tool for tips">
+      <Button>Hover me</Button>
+    </Tooltip>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.hover(canvas.getByRole("button", { name: /hover me/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/tool for tips/i)).toBeVisible(),
+    );
+  },
 };
 
 export const WithTextInput = () => (

--- a/src/Tooltip/index.stories.js
+++ b/src/Tooltip/index.stories.js
@@ -42,8 +42,9 @@ export const Open = {
   ),
   play: async ({ canvas, userEvent }) => {
     await userEvent.hover(canvas.getByRole("button", { name: /hover me/i }));
-    await waitFor(() =>
-      expect(screen.getByText(/tool for tips/i)).toBeVisible(),
+    await waitFor(
+      () => expect(screen.getByText(/tool for tips/i)).toBeVisible(),
+      { timeout: 2000 },
     );
   },
 };

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -204,9 +204,8 @@ const useDropdownLayer = ({
         ? anchorPositionStyles
         : polyFillLayerStyles),
 
-      // Always include display and z-index.
+      // Always include display
       display: isOpen ? "block" : "none",
-      zIndex: isPortalled ? 9 : 4,
     };
 
     return {


### PR DESCRIPTION
Fixes NDS-3213
Fixes NDS-3096

## Changes

- add interaction tests to core consumers of `useDropdownLayer` to check positioning via automatic chromatic snapshots
- remove z-index responsibility from `useDropdownLayer`

## Why
Many of our positioned elements use a dedicated layer to portal to (`.outlet`), which is at a z-index of 100. Some of the consumers of `useDropdownLayer` are portalled, but to `document.body` instead of `.outlet`.

This means that the .outlet forms a separate stacking context. The `Tooltip` had a 999 z-index to allow it to portal to the document body so the CSS native anchoring path could resolve the anchor correctly. However, **the hook was adding its own zindex as an inline style**, nullifying the original z-index value managed by the component.

The additional tests will help us move forward with these dropdown changes with more confidence as chromatic will force us to look at the placement of dropdown layers with our eyes now.

### Interaction tests
You can run them as a suite of unit tests, manually via storybook, and/or automatically on chromatic snapshots.

<img width="730" height="431" alt="Screenshot 2026-08-24 at 1 59 40 PM" src="https://github.com/user-attachments/assets/deab8a31-e332-405f-ae87-ced40dbf70b3" />
