### PR TITLE
fix(useDropdownLayer): make polyfill positioning visual-viewport-aware

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,25 +3,22 @@ on:
   push:
     branches:
       - main
-      - 'maintenance/[0-9]*.[0-9]*.x'
+      - '[0-9]*.[0-9]*.x'
   workflow_dispatch:
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
-    name: Release
+  build:
+    name: Build release artifacts
     runs-on: ubuntu-latest
-    environment: Publish
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
@@ -34,6 +31,43 @@ jobs:
 
       - name: Build Dist
         run: npm run build
+
+      - name: Upload dist
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    environment: Publish
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v4
+        with:
+          node-version-file: ".nvmrc"
+      - name: Install release dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts
+
+      - name: Download dist
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
 
       - name: Release
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.19.11](https://github.com/narmi/design_system/compare/v6.19.10...v6.19.11) (2026-08-24)
+
+### ci
+
+* sync release workflow and config from main [skip ci] ([28b7739](https://github.com/narmi/design_system/commit/28b7739961c34a8b2e5643eff88b741d4e699362))
+
+### fix
+
+* **dropdowns:** use dvh to account for soft keyboards ([98f791d](https://github.com/narmi/design_system/commit/98f791d1552f949041888d873bfee113d4ab95cc))
+
 ## [6.19.10](https://github.com/narmi/design_system/compare/v6.19.9...v6.19.10) (2026-08-04)
 
 ### fix

--- a/issue-test-cases/NDS-3164-AndroidComboboxPositioning.stories.js
+++ b/issue-test-cases/NDS-3164-AndroidComboboxPositioning.stories.js
@@ -1,0 +1,750 @@
+import React, { useEffect, useLayoutEffect, useState } from "react";
+import Combobox from "src/Combobox";
+import { HAS_SCROLL_CONTAINER_BUG } from "src/hooks/useSupportsAnchorPositioning";
+
+const storyDescription =
+  "Regression test for Android soft-keyboard dropdown positioning. " +
+  "Must be tested on a real Android device (e.g. BrowserStack Local). " +
+  "Two anchor positions probe different failure modes. " +
+  "`ComboboxLowInViewport` targets the flip-above coordinate-mixup " +
+  "bug (useAnchorPolyfill.ts:54-58) — expected failure: menu " +
+  "positioned off-screen below the keyboard. " +
+  "`ComboboxMiddleInViewport` targets the reactive flip decision and " +
+  "the `window.resize` close bug (useAnchorPolyfill.ts:185-186) — the " +
+  "menu may still position correctly here but should not disappear " +
+  "on keyboard open. `ComboboxMiddleInViewport_WithMetaTag` re-runs " +
+  "the middle-viewport case with " +
+  "`<meta name=viewport content=...,interactive-widget=resizes-content>` " +
+  "injected at mount. If this variant passes while " +
+  "`ComboboxMiddleInViewport` fails on the same device, the fix is a " +
+  "consumer-side viewport meta change rather than a design-system " +
+  "code change. `LayerPositionMonitor` renders a fixed diagnostic " +
+  "overlay showing anchor + layer rects and visualViewport dimensions " +
+  "live; use it to determine whether CSS anchor-positioning re-fires " +
+  "its fallbacks on visualViewport.resize (layer rect changes) or " +
+  "commits to its initial placement (layer rect stays). " +
+  "`VirtualKeyboardApiProbe` reports whether the VirtualKeyboard API " +
+  "(`navigator.virtualKeyboard`, `env(keyboard-inset-*)`) is available " +
+  "for future progressive-enhancement work. " +
+  "`DvhViewportProbe` measures `100dvh` / `100svh` / `100lvh` / `100vh` " +
+  "before and after the keyboard opens; the critical question is " +
+  "whether `100dvh` shrinks with the keyboard. If yes, keyboard-aware " +
+  "max-height and fallback selection can be handled entirely in CSS " +
+  "via `calc(100dvh - anchor(...))` and `position-try-order: most-height`, " +
+  "no JS required. " +
+  "Use the DetectionProbe story to confirm which code path (native " +
+  "anchor-positioning vs. JS polyfill) is active on the tested device.";
+
+/**
+ * Pins the Combobox near the bottom of the viewport so `spaceBelow`
+ * is smaller than `spaceAbove` and the polyfill takes the "flip above"
+ * branch in useAnchorPolyfill (calculatePosition, lines 54-58). That
+ * branch is where the visual-viewport / layout-viewport coordinate
+ * mixup manifests when the Android soft keyboard opens.
+ */
+const BottomAnchoredLayout = (Story) => (
+  <div
+    style={{
+      minHeight: "100vh",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "flex-end",
+      padding: "12px",
+      backgroundColor: "var(--bgColor-white, #fff)",
+    }}
+  >
+    <Story />
+  </div>
+);
+
+/**
+ * Centers the Combobox vertically so both `spaceBelow` and `spaceAbove`
+ * start out ample. When the Android soft keyboard opens, `spaceBelow`
+ * (useAnchorPolyfill.ts:50) can go negative and the flip decision
+ * swaps mid-interaction — exercising `handleViewportResize` and the
+ * max-height calc (useDropdownMaxHeight.ts:51-52). The position calc
+ * may not produce a negative value here, so if the menu still
+ * disappears the `window.resize` close handler (line 185) is
+ * implicated rather than the coordinate mixup.
+ */
+const CenterAnchoredLayout = (Story) => (
+  <div
+    style={{
+      minHeight: "100vh",
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "center",
+      padding: "12px",
+      backgroundColor: "var(--bgColor-white, #fff)",
+    }}
+  >
+    <Story />
+  </div>
+);
+
+/**
+ * Injects `interactive-widget=resizes-content` into the viewport meta
+ * tag on mount and restores the original value on unmount. In this
+ * mode, Chromium shrinks the layout viewport when the virtual keyboard
+ * opens, which makes `getBoundingClientRect()`, `window.innerHeight`,
+ * and CSS anchor-positioning's `position-try-fallbacks` all react to
+ * the keyboard. Used to test whether the observed native-path bug is
+ * solvable by a consumer-side viewport meta change.
+ */
+const WithInteractiveWidgetResizesContent = (Story) => {
+  useLayoutEffect(() => {
+    let meta = document.querySelector('meta[name="viewport"]');
+    let created = false;
+    let originalContent = null;
+
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.setAttribute("name", "viewport");
+      document.head.appendChild(meta);
+      created = true;
+    } else {
+      originalContent = meta.getAttribute("content");
+    }
+
+    const parts = new Set(
+      (originalContent ?? "width=device-width, initial-scale=1")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    for (const part of Array.from(parts)) {
+      if (part.startsWith("interactive-widget=")) parts.delete(part);
+    }
+    parts.add("interactive-widget=resizes-content");
+    meta.setAttribute("content", Array.from(parts).join(", "));
+
+    return () => {
+      if (created) {
+        meta.remove();
+      } else if (originalContent != null) {
+        meta.setAttribute("content", originalContent);
+      }
+    };
+  }, []);
+
+  return <Story />;
+};
+
+export const ComboboxLowInViewport = () => (
+  <Combobox label="Select an option">
+    <Combobox.Item value="apple" searchValue="apple">
+      Apple
+    </Combobox.Item>
+    <Combobox.Item value="banana" searchValue="banana">
+      Banana
+    </Combobox.Item>
+    <Combobox.Item value="cherry" searchValue="cherry">
+      Cherry
+    </Combobox.Item>
+    <Combobox.Item value="date" searchValue="date">
+      Date
+    </Combobox.Item>
+  </Combobox>
+);
+ComboboxLowInViewport.decorators = [BottomAnchoredLayout];
+
+export const ComboboxMiddleInViewport = () => (
+  <Combobox label="Select an option">
+    <Combobox.Item value="apple" searchValue="apple">
+      Apple
+    </Combobox.Item>
+    <Combobox.Item value="banana" searchValue="banana">
+      Banana
+    </Combobox.Item>
+    <Combobox.Item value="cherry" searchValue="cherry">
+      Cherry
+    </Combobox.Item>
+    <Combobox.Item value="date" searchValue="date">
+      Date
+    </Combobox.Item>
+  </Combobox>
+);
+ComboboxMiddleInViewport.decorators = [CenterAnchoredLayout];
+
+export const ComboboxMiddleInViewport_WithMetaTag = () => (
+  <Combobox label="Select an option">
+    <Combobox.Item value="apple" searchValue="apple">
+      Apple
+    </Combobox.Item>
+    <Combobox.Item value="banana" searchValue="banana">
+      Banana
+    </Combobox.Item>
+    <Combobox.Item value="cherry" searchValue="cherry">
+      Cherry
+    </Combobox.Item>
+    <Combobox.Item value="date" searchValue="date">
+      Date
+    </Combobox.Item>
+  </Combobox>
+);
+// Decorators wrap in reverse array order — WithInteractiveWidgetResizesContent
+// runs last, so it wraps the CenterAnchoredLayout output and ensures the
+// meta tag is applied before the layout renders.
+ComboboxMiddleInViewport_WithMetaTag.decorators = [
+  CenterAnchoredLayout,
+  WithInteractiveWidgetResizesContent,
+];
+
+/**
+ * Renders a fixed diagnostic overlay in the top-left corner that live-
+ * updates on every `visualViewport.resize` event. Displays the current
+ * anchor and layer bounding rects (queried from the DOM via the
+ * `.nds-combobox--active` classname the Combobox toggles when open) and
+ * the visualViewport / innerHeight dimensions. Use this on-device to
+ * determine whether CSS anchor-positioning re-fires its fallbacks when
+ * the keyboard opens (layer rect would change) or commits to its
+ * initial placement (layer rect stays constant while visualViewport
+ * shrinks).
+ */
+const LayerPositionOverlay = () => {
+  const [state, setState] = useState(() => ({
+    resizeEventCount: 0,
+    visualViewportHeight:
+      typeof window !== "undefined"
+        ? (window.visualViewport?.height ?? "n/a")
+        : "n/a",
+    visualViewportOffsetTop:
+      typeof window !== "undefined"
+        ? (window.visualViewport?.offsetTop ?? "n/a")
+        : "n/a",
+    innerHeight: typeof window !== "undefined" ? window.innerHeight : "n/a",
+    anchorRect: null,
+    layerRect: null,
+  }));
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+
+    const readRects = () => {
+      const anchor = document.querySelector(
+        ".nds-combobox--active > div:first-child",
+      );
+      const list = document.querySelector(
+        ".nds-combobox--active .nds-combobox-list",
+      );
+      const layer = list?.parentElement ?? null;
+      const format = (el) => {
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return {
+          top: Math.round(r.top),
+          bottom: Math.round(r.bottom),
+          left: Math.round(r.left),
+          right: Math.round(r.right),
+          width: Math.round(r.width),
+          height: Math.round(r.height),
+        };
+      };
+      return { anchorRect: format(anchor), layerRect: format(layer) };
+    };
+
+    const update = () => {
+      setState((prev) => ({
+        resizeEventCount: prev.resizeEventCount + 1,
+        visualViewportHeight: window.visualViewport.height,
+        visualViewportOffsetTop: window.visualViewport.offsetTop,
+        innerHeight: window.innerHeight,
+        ...readRects(),
+      }));
+    };
+
+    // Also read initial state on next frame so the Combobox has mounted.
+    const raf = requestAnimationFrame(() => {
+      setState((prev) => ({ ...prev, ...readRects() }));
+    });
+
+    window.visualViewport.addEventListener("resize", update);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.visualViewport.removeEventListener("resize", update);
+    };
+  }, []);
+
+  const rows = {
+    resizeEventCount: state.resizeEventCount,
+    "visualViewport.height": state.visualViewportHeight,
+    "visualViewport.offsetTop": state.visualViewportOffsetTop,
+    "window.innerHeight": state.innerHeight,
+    "anchor rect": state.anchorRect
+      ? JSON.stringify(state.anchorRect)
+      : "(not found)",
+    "layer rect": state.layerRect
+      ? JSON.stringify(state.layerRect)
+      : "(not found)",
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        zIndex: 99999,
+        pointerEvents: "none",
+        backgroundColor: "rgba(255, 255, 255, 0.9)",
+        border: "1px solid #999",
+        padding: "6px 8px",
+        fontFamily: "monospace",
+        fontSize: "10px",
+        lineHeight: 1.3,
+        maxWidth: "70vw",
+        wordBreak: "break-all",
+      }}
+    >
+      {Object.entries(rows).map(([k, v]) => (
+        <div key={k}>
+          <strong>{k}:</strong> {String(v)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const LayerPositionMonitor = () => (
+  <>
+    <LayerPositionOverlay />
+    <Combobox label="Select an option">
+      <Combobox.Item value="apple" searchValue="apple">
+        Apple
+      </Combobox.Item>
+      <Combobox.Item value="banana" searchValue="banana">
+        Banana
+      </Combobox.Item>
+      <Combobox.Item value="cherry" searchValue="cherry">
+        Cherry
+      </Combobox.Item>
+      <Combobox.Item value="date" searchValue="date">
+        Date
+      </Combobox.Item>
+    </Combobox>
+  </>
+);
+LayerPositionMonitor.decorators = [CenterAnchoredLayout];
+
+/**
+ * On mount, opts into the VirtualKeyboard API by setting
+ * `navigator.virtualKeyboard.overlaysContent = true` (Chromium only)
+ * and subscribes to the `geometrychange` event. Also injects a style
+ * tag exposing `env(keyboard-inset-*)` values as CSS custom properties
+ * so getComputedStyle can observe them. Restores prior state on
+ * unmount.
+ */
+const WithVirtualKeyboardOverlaysContent = (Story) => {
+  useLayoutEffect(() => {
+    if (typeof navigator === "undefined" || !("virtualKeyboard" in navigator)) {
+      return;
+    }
+    // eslint-disable-next-line compat/compat
+    const vk = navigator.virtualKeyboard;
+    const originalOverlays = vk.overlaysContent;
+    vk.overlaysContent = true;
+
+    const styleEl = document.createElement("style");
+    styleEl.setAttribute("data-nds-3164-vk-probe", "");
+    styleEl.textContent =
+      ":root{" +
+      "--nds-kbd-inset-top:env(keyboard-inset-top,0px);" +
+      "--nds-kbd-inset-bottom:env(keyboard-inset-bottom,0px);" +
+      "--nds-kbd-inset-height:env(keyboard-inset-height,0px);" +
+      "}";
+    document.head.appendChild(styleEl);
+
+    return () => {
+      vk.overlaysContent = originalOverlays;
+      styleEl.remove();
+    };
+  }, []);
+  return <Story />;
+};
+
+const VirtualKeyboardProbeOverlay = () => {
+  const [state, setState] = useState(() => ({
+    geometrychangeEventCount: 0,
+    boundingRect: null,
+    insetTop: "",
+    insetBottom: "",
+    insetHeight: "",
+  }));
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("virtualKeyboard" in navigator)) {
+      return;
+    }
+    // eslint-disable-next-line compat/compat
+    const vk = navigator.virtualKeyboard;
+
+    const readInsets = () => {
+      const root = getComputedStyle(document.documentElement);
+      return {
+        insetTop: root.getPropertyValue("--nds-kbd-inset-top").trim(),
+        insetBottom: root.getPropertyValue("--nds-kbd-inset-bottom").trim(),
+        insetHeight: root.getPropertyValue("--nds-kbd-inset-height").trim(),
+      };
+    };
+
+    const formatRect = (r) => {
+      if (!r) return null;
+      return {
+        top: Math.round(r.top),
+        bottom: Math.round(r.bottom),
+        left: Math.round(r.left),
+        right: Math.round(r.right),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      };
+    };
+
+    const update = () => {
+      setState((prev) => ({
+        geometrychangeEventCount: prev.geometrychangeEventCount + 1,
+        boundingRect: formatRect(vk.boundingRect),
+        ...readInsets(),
+      }));
+    };
+
+    // Initial read on next frame so the injected style tag is applied.
+    const raf = requestAnimationFrame(() => {
+      setState((prev) => ({
+        ...prev,
+        boundingRect: formatRect(vk.boundingRect),
+        ...readInsets(),
+      }));
+    });
+
+    vk.addEventListener("geometrychange", update);
+    return () => {
+      cancelAnimationFrame(raf);
+      vk.removeEventListener("geometrychange", update);
+    };
+  }, []);
+
+  const hasApi =
+    typeof navigator !== "undefined" && "virtualKeyboard" in navigator;
+
+  const rows = {
+    "'virtualKeyboard' in navigator": hasApi,
+    "virtualKeyboard.overlaysContent": hasApi
+      ? // eslint-disable-next-line compat/compat
+        navigator.virtualKeyboard.overlaysContent
+      : "n/a",
+    geometrychangeEventCount: state.geometrychangeEventCount,
+    "virtualKeyboard.boundingRect": state.boundingRect
+      ? JSON.stringify(state.boundingRect)
+      : "(none)",
+    "env(keyboard-inset-top)": state.insetTop || "(empty)",
+    "env(keyboard-inset-bottom)": state.insetBottom || "(empty)",
+    "env(keyboard-inset-height)": state.insetHeight || "(empty)",
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        zIndex: 99999,
+        pointerEvents: "none",
+        backgroundColor: "rgba(255, 255, 255, 0.9)",
+        border: "1px solid #999",
+        padding: "6px 8px",
+        fontFamily: "monospace",
+        fontSize: "10px",
+        lineHeight: 1.3,
+        maxWidth: "70vw",
+        wordBreak: "break-all",
+      }}
+    >
+      {Object.entries(rows).map(([k, v]) => (
+        <div key={k}>
+          <strong>{k}:</strong> {String(v)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const VirtualKeyboardApiProbe = () => (
+  <>
+    <VirtualKeyboardProbeOverlay />
+    <Combobox label="Select an option">
+      <Combobox.Item value="apple" searchValue="apple">
+        Apple
+      </Combobox.Item>
+      <Combobox.Item value="banana" searchValue="banana">
+        Banana
+      </Combobox.Item>
+      <Combobox.Item value="cherry" searchValue="cherry">
+        Cherry
+      </Combobox.Item>
+      <Combobox.Item value="date" searchValue="date">
+        Date
+      </Combobox.Item>
+    </Combobox>
+  </>
+);
+VirtualKeyboardApiProbe.decorators = [
+  CenterAnchoredLayout,
+  WithVirtualKeyboardOverlaysContent,
+];
+
+/**
+ * Measures the pixel height of a hidden element sized to `100dvh`, `100svh`,
+ * `100lvh`, and `100vh` and reports each on every `visualViewport.resize`.
+ * The critical question: does `100dvh` shrink when the soft keyboard opens
+ * on the target device? If yes, keyboard-aware max-height and fallback
+ * selection can be handled entirely in CSS via `calc(100dvh - anchor(...))`
+ * and `position-try-order: most-height`. If no, we cannot use the CSS
+ * route and have to keep JS in the loop.
+ */
+const DvhViewportProbeOverlay = () => {
+  const [state, setState] = useState(() => ({
+    resizeEventCount: 0,
+    dvh: null,
+    svh: null,
+    lvh: null,
+    vh: null,
+    visualViewportHeight:
+      typeof window !== "undefined"
+        ? (window.visualViewport?.height ?? "n/a")
+        : "n/a",
+    innerHeight: typeof window !== "undefined" ? window.innerHeight : "n/a",
+  }));
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+
+    // Create four hidden measurement elements sized to each viewport unit.
+    const container = document.createElement("div");
+    container.style.cssText =
+      "position:absolute;top:0;left:0;width:1px;visibility:hidden;pointer-events:none;";
+    const makeCell = (height) => {
+      const el = document.createElement("div");
+      el.style.cssText = `width:1px;height:${height};`;
+      container.appendChild(el);
+      return el;
+    };
+    const dvhEl = makeCell("100dvh");
+    const svhEl = makeCell("100svh");
+    const lvhEl = makeCell("100lvh");
+    const vhEl = makeCell("100vh");
+    document.body.appendChild(container);
+
+    const measure = () => ({
+      dvh: dvhEl.getBoundingClientRect().height,
+      svh: svhEl.getBoundingClientRect().height,
+      lvh: lvhEl.getBoundingClientRect().height,
+      vh: vhEl.getBoundingClientRect().height,
+    });
+
+    const update = () => {
+      setState((prev) => ({
+        ...prev,
+        resizeEventCount: prev.resizeEventCount + 1,
+        visualViewportHeight: window.visualViewport.height,
+        innerHeight: window.innerHeight,
+        ...measure(),
+      }));
+    };
+
+    // Initial read on next frame.
+    const raf = requestAnimationFrame(() => {
+      setState((prev) => ({
+        ...prev,
+        visualViewportHeight: window.visualViewport.height,
+        innerHeight: window.innerHeight,
+        ...measure(),
+      }));
+    });
+
+    window.visualViewport.addEventListener("resize", update);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.visualViewport.removeEventListener("resize", update);
+      container.remove();
+    };
+  }, []);
+
+  const rows = {
+    resizeEventCount: state.resizeEventCount,
+    "100dvh (px)": state.dvh != null ? state.dvh : "(pending)",
+    "100svh (px)": state.svh != null ? state.svh : "(pending)",
+    "100lvh (px)": state.lvh != null ? state.lvh : "(pending)",
+    "100vh (px)": state.vh != null ? state.vh : "(pending)",
+    "visualViewport.height": state.visualViewportHeight,
+    "window.innerHeight": state.innerHeight,
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        zIndex: 99999,
+        pointerEvents: "none",
+        backgroundColor: "rgba(255, 255, 255, 0.9)",
+        border: "1px solid #999",
+        padding: "6px 8px",
+        fontFamily: "monospace",
+        fontSize: "10px",
+        lineHeight: 1.3,
+        maxWidth: "70vw",
+        wordBreak: "break-all",
+      }}
+    >
+      {Object.entries(rows).map(([k, v]) => (
+        <div key={k}>
+          <strong>{k}:</strong> {String(v)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const DvhViewportProbe = () => {
+  return (
+    <>
+      <DvhViewportProbeOverlay />
+      <input
+        placeholder="Tap here to open the keyboard"
+        style={{
+          padding: "12px",
+          fontSize: "16px",
+          border: "1px solid #999",
+          borderRadius: "4px",
+          width: "100%",
+          boxSizing: "border-box",
+        }}
+      />
+    </>
+  );
+};
+DvhViewportProbe.decorators = [CenterAnchoredLayout];
+
+/**
+ * Static readout of the runtime feature-detection values that determine
+ * which positioning code path Combobox takes on this device. Use this to
+ * confirm whether the JS polyfill (useAnchorPolyfill) is actually active
+ * on the Android device under test, since the ticket's root cause is
+ * gated on that path running.
+ */
+export const DetectionProbe = () => {
+  const [readings] = useState(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    const cssSupports =
+      typeof CSS !== "undefined" && typeof CSS.supports === "function"
+        ? CSS.supports.bind(CSS)
+        : () => false;
+
+    const checks = {
+      "CSS.supports(anchor-name, --a)": cssSupports("anchor-name", "--a"),
+      "CSS.supports(position-anchor, --a)": cssSupports(
+        "position-anchor",
+        "--a",
+      ),
+      "CSS.supports(position-area, bottom center)": cssSupports(
+        "position-area",
+        "bottom center",
+      ),
+      "CSS.supports(position-try-fallbacks, flip-block)": cssSupports(
+        "position-try-fallbacks",
+        "flip-block",
+      ),
+      "CSS.supports(width, anchor-size(width))": cssSupports(
+        "width",
+        "anchor-size(width)",
+      ),
+    };
+
+    const allCssChecksPass = Object.values(checks).every(Boolean);
+    // Combobox opts into polyfillScrollBug: true, so the polyfill path
+    // runs when either (a) native anchor-positioning is unavailable, or
+    // (b) the scroll-container bug is detected.
+    const polyfillPathActive = !allCssChecksPass || HAS_SCROLL_CONTAINER_BUG;
+
+    // Measure 100dvh and 100vh via hidden elements so we can see if dvh
+    // reacts to virtual keyboard on this device (dvh should shrink with
+    // keyboard on Chrome/Android in default keyboard mode).
+    const measureViewportUnit = (heightValue) => {
+      const el = document.createElement("div");
+      el.style.cssText = `position:absolute;top:0;left:0;width:1px;height:${heightValue};visibility:hidden;pointer-events:none;`;
+      document.body.appendChild(el);
+      const measured = el.getBoundingClientRect().height;
+      el.remove();
+      return measured;
+    };
+
+    return {
+      ...checks,
+      HAS_SCROLL_CONTAINER_BUG,
+      "window.visualViewport?.height": window.visualViewport?.height ?? "n/a",
+      "window.innerHeight": window.innerHeight,
+      "100dvh (px)": measureViewportUnit("100dvh"),
+      "100vh (px)": measureViewportUnit("100vh"),
+      "meta[name=viewport] content":
+        document
+          .querySelector('meta[name="viewport"]')
+          ?.getAttribute("content") ?? "(not set)",
+      "'virtualKeyboard' in navigator":
+        typeof navigator !== "undefined" && "virtualKeyboard" in navigator,
+      "navigator.virtualKeyboard.overlaysContent":
+        typeof navigator !== "undefined" && "virtualKeyboard" in navigator
+          ? // eslint-disable-next-line compat/compat
+            navigator.virtualKeyboard.overlaysContent
+          : "n/a",
+      "navigator.userAgent": navigator.userAgent,
+      "Polyfill path active (Combobox)": polyfillPathActive,
+    };
+  });
+
+  if (!readings) return null;
+
+  return (
+    <div style={{ padding: "12px", fontFamily: "monospace", fontSize: "12px" }}>
+      <dl style={{ margin: 0 }}>
+        {Object.entries(readings).map(([key, value]) => (
+          <div
+            key={key}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              marginBottom: "8px",
+              borderBottom: "1px solid var(--color-lightGrey, #ddd)",
+              paddingBottom: "4px",
+            }}
+          >
+            <dt style={{ fontWeight: "bold", wordBreak: "break-all" }}>
+              {key}
+            </dt>
+            <dd style={{ margin: 0, wordBreak: "break-all" }}>
+              {String(value)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+};
+
+export default {
+  title: "NDS-3164 Android Combobox positioning",
+  tags: ["!autodocs", "NDS-3164"],
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: storyDescription,
+      },
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@narmi/design_system",
-  "version": "6.19.10",
+  "version": "6.19.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@narmi/design_system",
-      "version": "6.19.10",
+      "version": "6.19.11",
       "license": "SEE LICENSE IN LICSENSE.md, VENDOR_LICENSE.md",
       "dependencies": {
         "@maskito/core": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@narmi/design_system",
-  "version": "6.19.10",
+  "version": "6.19.11",
   "description": "⚡ A consistent look-and-feel and extensible interface for Narmi experiences 🔥",
   "main": "dist/index.js",
   "style": "dist/style.css",

--- a/release.config.js
+++ b/release.config.js
@@ -6,11 +6,13 @@
  */
 const config = {
   branches: [
-    {
-      name: "maintenance/+([0-9]).+([0-9]).x",
-      channel: "${name.replace(/^maintenance\\//g, '')}",
-      range: "${name.replace(/^maintenance\\//g, '')}",
-    },
+    // Maintenance branches shaped `N.N.x` (e.g. `6.21.x`). semantic-release
+    // infers `range` from the branch name (`N.N.x`, patch-only enforced via
+    // `EINVALIDNEXTVERSION`). We pin `channel: "patch"` so every maintenance
+    // line publishes under the shared `patch` npm dist-tag; the latest patch
+    // release across any active line owns the tag. Git tags remain
+    // `v${version}` per `tagFormat` default.
+    { name: "+([0-9]).+([0-9]).x", channel: "patch" },
     "main",
   ],
   plugins: [

--- a/src/base-styles/custom-properties.scss
+++ b/src/base-styles/custom-properties.scss
@@ -14,11 +14,18 @@
 * When the dropdown overflows below the anchor, the browser tries this
 * ruleset to flip the layer above the anchor.
 *
-* Max-height is handled separately via `--js-dropdown-max-height`, set by
-* the `useDropdownMaxHeight` hook on both the native and polyfill paths.
+* On the native anchor-positioning path, max-height for the primary
+* placement and this fallback is handled directly in CSS via
+* `calc(100dvh - anchor(...))` and `calc(anchor(top) - ...)`. `dvh`
+* shrinks when the virtual keyboard opens on Chromium/Android, giving
+* keyboard-aware sizing without JS. On the polyfill path,
+* `--js-dropdown-max-height` is still set by `useDropdownMaxHeight`.
 */
 @position-try --nds-dropdown-above {
   position-area: top;
+  max-height: calc(
+    anchor(top) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs))
+  );
   margin-top: 0;
   margin-bottom: var(--nds-layer-gap, var(--space-xxs));
 }
@@ -27,9 +34,19 @@
 * Position-try fallbacks for anchor-positioned layers.
 * These allow the browser to flip the layer to the opposite side
 * when there isn't enough space in the preferred direction.
+*
+* `--nds-try-below` includes a `dvh`-based max-height so the flipped
+* layer stays clipped to the visible area above the virtual keyboard
+* on mobile.
 */
 @position-try --nds-try-below {
   position-area: bottom;
+  max-height: calc(
+    100dvh - anchor(bottom) - var(--space-l) - var(
+        --nds-layer-gap,
+        var(--space-xxs)
+      )
+  );
   margin-top: var(--nds-layer-gap, var(--space-xxs));
   margin-bottom: 0;
 }

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -68,20 +68,40 @@ export interface UseDropdownLayerOptions {
   polyfillScrollBug?: boolean;
 }
 
-/** Maps placement to CSS anchor positioning values */
+/** Maps placement to CSS anchor positioning values.
+ *
+ * `positionTryOrder` and `primaryMaxHeight` are populated for the vertical
+ * placements only. Together they let CSS handle both the flip decision and
+ * the max-height clip natively in a keyboard-aware way (`dvh` shrinks with
+ * the virtual keyboard on Chromium/Android). Horizontal placements
+ * (left/right) don't have a keyboard concern, so they keep the original
+ * fallback-order-driven behaviour.
+ */
 const PLACEMENT_CONFIG: Record<
   Placement,
-  { positionArea: string; positionTryFallbacks: string; margin: string }
+  {
+    positionArea: string;
+    positionTryFallbacks: string;
+    margin: string;
+    positionTryOrder?: string;
+    primaryMaxHeight?: string;
+  }
 > = {
   bottom: {
     positionArea: "bottom",
     positionTryFallbacks: "--nds-dropdown-above, flip-inline",
+    positionTryOrder: "most-height",
     margin: "marginTop",
+    primaryMaxHeight:
+      "calc(100dvh - anchor(bottom) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs)))",
   },
   top: {
     positionArea: "top",
     positionTryFallbacks: "--nds-try-below, flip-inline",
+    positionTryOrder: "most-height",
     margin: "marginBottom",
+    primaryMaxHeight:
+      "calc(anchor(top) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs)))",
   },
   left: {
     positionArea: "left",
@@ -102,7 +122,13 @@ const PLACEMENT_CONFIG: Record<
  */
 const useDropdownLayer = ({
   isOpen,
-  setIsOpen,
+  // `setIsOpen` remains part of the public options for API stability but
+  // is no longer read internally. `useAnchorPolyfill` previously used it
+  // to close the menu on `window.resize`; that handler was removed as
+  // part of NDS-3164 because it fired spuriously on Android soft-keyboard
+  // open. Keyboard-aware sizing is now handled in pure CSS via `dvh`
+  // + `position-try-order: most-height` on the native anchor-positioning
+  // path. Blur handling in the consuming component closes the menu.
   matchWidth = true,
   isPortalled = false,
   ariaPopupType = "menu",
@@ -124,11 +150,17 @@ const useDropdownLayer = ({
     layerRef,
     matchWidth,
     isOpen,
-    setIsOpen,
     polyfillScrollBug,
   });
 
-  useDropdownMaxHeight({ anchorRef, layerRef, isOpen });
+  useDropdownMaxHeight({
+    anchorRef,
+    layerRef,
+    isOpen,
+    // Only run on the polyfill path. Native path uses pure CSS
+    // (`calc(100dvh - anchor(bottom) - ...)`) for max-height.
+    enabled: !isAnchorPositionSupported,
+  });
 
   // Memoized props to spread onto the anchor (positioning reference) element
   const anchorProps = useMemo(
@@ -161,6 +193,10 @@ const useDropdownLayer = ({
       positionAnchor: anchorName,
       positionArea,
       positionTryFallbacks,
+      ...(config.positionTryOrder && {
+        positionTryOrder: config.positionTryOrder,
+      }),
+      ...(config.primaryMaxHeight && { maxHeight: config.primaryMaxHeight }),
       marginTop: 0,
       marginBottom: 0,
       marginLeft: 0,

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.test.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.test.ts
@@ -214,6 +214,91 @@ describe("calculatePosition", () => {
     });
   });
 
+  describe("soft keyboard open (visual viewport smaller than layout viewport)", () => {
+    it("emits a layout-viewport `bottom` when flipping above, not a visual-viewport one", () => {
+      // Simulates Android Chrome with the soft keyboard already open when
+      // the dropdown opens (focus moved directly from another input):
+      // layout viewport stays 768px tall, visual viewport shrinks to 400px.
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: VIEWPORT_HEIGHT,
+      });
+      Object.defineProperty(window, "visualViewport", {
+        configurable: true,
+        value: { width: VIEWPORT_WIDTH, height: 400, offsetTop: 0 },
+      });
+
+      // Anchor sits below the visible region's bottom edge (400) in layout
+      // coordinates → no space below, plenty above → flip.
+      const anchor = makeEl({
+        top: 568,
+        bottom: 608,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 40,
+      });
+      const layer = makeEl({
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 0,
+      });
+
+      calculatePosition(anchor, layer, false);
+
+      const props = getProps(layer);
+      // bottom = layoutHeight - anchorRect.top + anchorGap = 768 - 568 + 4.
+      // The old visual-viewport math produced 400 - 568 + 4 = -164px,
+      // pinning the layer below the bottom of the screen.
+      expect(props["--js-dropdown-bottom"]).toBe("204px");
+      expect(props["--js-dropdown-top"]).toBeNull();
+    });
+
+    it("measures available space against the panned visual viewport", () => {
+      // Visual viewport panned down (offsetTop=200) over a 768px layout
+      // viewport; visible region is 200..600 in layout coordinates.
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: VIEWPORT_HEIGHT,
+      });
+      Object.defineProperty(window, "visualViewport", {
+        configurable: true,
+        value: { width: VIEWPORT_WIDTH, height: 400, offsetTop: 200 },
+      });
+
+      // Anchor is above the visible region → no visible space above it,
+      // ample below → must NOT flip even though anchorRect.top is large
+      // relative to a naive 0-based measurement.
+      const anchor = makeEl({
+        top: 250,
+        bottom: 290,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 40,
+      });
+      const layer = makeEl({
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 0,
+      });
+
+      calculatePosition(anchor, layer, false);
+
+      const props = getProps(layer);
+      // spaceAbove = 250 - 200 - 24 = 26; spaceBelow = 600 - 290 - 24 = 286
+      // → place below: top = anchorRect.bottom - layerRect.top + gap
+      expect(props["--js-dropdown-top"]).toBe("294px");
+      expect(props["--js-dropdown-bottom"]).toBeNull();
+    });
+  });
+
   describe("available space floor", () => {
     it("clamps availableSpace to 0 when anchor spans the full viewport", () => {
       // Anchor spans the full viewport — spaceAbove and spaceBelow are both negative.

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect } from "react";
 import useSupportsAnchorPositioning from "../useSupportsAnchorPositioning";
 import { HAS_SCROLL_CONTAINER_BUG } from "../useSupportsAnchorPositioning";
 import { resolveSpaceToken } from "./useDropdownMaxHeight";
+import { getAvailableSpace, getVisibleBounds } from "./viewport";
 
 interface UseAnchorPolyfillParams {
   /** Reference to the element that the dropdown should be anchored to */
@@ -23,6 +24,14 @@ interface UseAnchorPolyfillParams {
 /**
  * Calculates and applies CSS custom properties for dropdown positioning.
  * Exported for unit testing.
+ *
+ * Available space is measured against the *visual* viewport (which the
+ * soft keyboard and pinch-zoom shrink), while the emitted `top`/`bottom`
+ * insets are layout-viewport values, since that is what `position: fixed`
+ * resolves against. See `./viewport.ts` for the distinction. This keeps
+ * the layer inside the user-visible area when the keyboard is already open
+ * at the time the dropdown opens — e.g. focus moving directly from one
+ * combobox to another.
  */
 export const calculatePosition = (
   anchorEl: HTMLElement,
@@ -37,7 +46,7 @@ export const calculatePosition = (
   const anchorGap = resolveSpaceToken("--space-xxs", 4);
   const edgeClearance = resolveSpaceToken("--space-l", 20);
 
-  const vvHeight = window.visualViewport?.height ?? window.innerHeight;
+  const { layoutHeight } = getVisibleBounds();
 
   // Reset to a known baseline before measuring layer position.
   layerEl.style.setProperty("--js-dropdown-top", "0px");
@@ -45,14 +54,21 @@ export const calculatePosition = (
   layerEl.style.setProperty("--js-dropdown-left", "0px");
 
   const layerRect = layerEl.getBoundingClientRect();
-  const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
-  const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
+  const { spaceAbove, spaceBelow } = getAvailableSpace(
+    anchorRect,
+    anchorGap,
+    edgeClearance,
+  );
   const shouldFlip = spaceAbove > spaceBelow;
 
   if (shouldFlip) {
+    // `bottom` on a fixed-position element is measured from the bottom of
+    // the layout viewport — NOT the visual viewport. Using the (possibly
+    // keyboard-shrunken) visual viewport height here pushed the layer
+    // below the screen by the keyboard-height delta.
     layerEl.style.setProperty(
       "--js-dropdown-bottom",
-      `${vvHeight - anchorRect.top + anchorGap}px`,
+      `${layoutHeight - anchorRect.top + anchorGap}px`,
     );
     layerEl.style.removeProperty("--js-dropdown-top");
   } else {
@@ -75,18 +91,27 @@ export const calculatePosition = (
 
 /**
  * Computes an IntersectionObserver rootMargin flush with the element's bounding
- * rect. Uses visualViewport dimensions to account for virtual keyboard adjustments.
+ * rect.
+ *
+ * Must use *layout*-viewport dimensions: with a null root, the IO root is the
+ * layout viewport, and `getBoundingClientRect()` is layout-viewport based too.
+ * Using the visual viewport here meant that with the soft keyboard open, an
+ * anchor sitting below `visualViewport.height` in layout coordinates could
+ * never reach full intersection, leaving the layer stuck `visibility: hidden`
+ * or flickering through hide/re-arm cycles.
  */
 export const computeRootMargin = (rect: DOMRect): string => {
-  // Use visual viewport dimensions — getBoundingClientRect() returns coords
-  // relative to the visual viewport, so the IO root margin must match.
   const vw =
     (typeof window !== "undefined" &&
-      (window.visualViewport?.width ?? window.innerWidth)) ||
+      ((typeof document !== "undefined" &&
+        document.documentElement?.clientWidth) ||
+        window.innerWidth)) ||
     0;
   const vh =
     (typeof window !== "undefined" &&
-      (window.visualViewport?.height ?? window.innerHeight)) ||
+      ((typeof document !== "undefined" &&
+        document.documentElement?.clientHeight) ||
+        window.innerHeight)) ||
     0;
   const top = Math.floor(rect.top);
   const left = Math.floor(rect.left);
@@ -164,8 +189,32 @@ const useAnchorPolyfill = ({
     layerEl.style.visibility = "";
     armObserver();
 
+    // Reposition when the visual viewport resizes — on mobile this fires
+    // when the soft keyboard opens/closes (or on pinch-zoom). The keyboard
+    // often finishes opening *after* the initial calculate (the tap that
+    // opens the dropdown is the same tap that summons the keyboard), so
+    // without this the layer keeps a placement chosen for the pre-keyboard
+    // viewport. Unlike the `window.resize` close handler removed in
+    // NDS-3164, this only recalculates — a spurious fire is harmless.
+    // rAF-throttled: some devices emit a burst of resize events while the
+    // keyboard animates.
+    let rafId = 0;
+    const handleViewportResize = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        if (disposed) return;
+        calculatePosition(...calculateArgs);
+        layerEl.style.visibility = "";
+        armObserver();
+      });
+    };
+    const vv = window.visualViewport;
+    vv?.addEventListener?.("resize", handleViewportResize);
+
     return () => {
       disposed = true;
+      cancelAnimationFrame(rafId);
+      vv?.removeEventListener?.("resize", handleViewportResize);
       currentObserver?.disconnect();
     };
   }, [effectiveSupport, anchorRef, layerRef, matchWidth, isOpen]);

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
@@ -12,8 +12,6 @@ interface UseAnchorPolyfillParams {
   matchWidth?: boolean;
   /** Whether the dropdown is currently open */
   isOpen: boolean;
-  /** Function to close the dropdown */
-  setIsOpen: (isOpen: boolean) => void;
   /**
    * When true, forces the polyfill path if the browser has the Safari
    * scroll-container bug (anchor-size/position-try-fallbacks fail inside
@@ -106,7 +104,6 @@ const useAnchorPolyfill = ({
   layerRef,
   matchWidth = false,
   isOpen,
-  setIsOpen,
   polyfillScrollBug = false,
 }: UseAnchorPolyfillParams) => {
   const isAnchorPositionSupported = useSupportsAnchorPositioning();
@@ -167,34 +164,11 @@ const useAnchorPolyfill = ({
     layerEl.style.visibility = "";
     armObserver();
 
-    // Allow the keyboard animation to settle before recalculating.
-    // This solves for animated virtual keyboards.
-    const handleViewportResize = () => {
-      layerEl.style.visibility = "hidden";
-      requestAnimationFrame(() => {
-        if (disposed) return;
-        calculatePosition(...calculateArgs);
-        layerEl.style.visibility = "";
-        armObserver();
-      });
-    };
-
-    window.visualViewport?.addEventListener("resize", handleViewportResize);
-
-    // close on resize or orientation change
-    const handleWindowResize = () => setIsOpen(false);
-    window.addEventListener("resize", handleWindowResize);
-
     return () => {
       disposed = true;
       currentObserver?.disconnect();
-      window.visualViewport?.removeEventListener(
-        "resize",
-        handleViewportResize,
-      );
-      window.removeEventListener("resize", handleWindowResize);
     };
-  }, [effectiveSupport, anchorRef, layerRef, matchWidth, isOpen, setIsOpen]);
+  }, [effectiveSupport, anchorRef, layerRef, matchWidth, isOpen]);
 
   return {
     isAnchorPositionSupported: effectiveSupport,

--- a/src/hooks/useDropdownLayer/useDropdownMaxHeight.ts
+++ b/src/hooks/useDropdownLayer/useDropdownMaxHeight.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from "react";
+import { getAvailableSpace } from "./viewport";
 
 interface UseDropdownMaxHeightParams {
   anchorRef: React.RefObject<HTMLElement>;
@@ -51,20 +52,35 @@ const useDropdownMaxHeight = ({
     const layerEl = layerRef.current;
     if (!anchorEl || !layerEl) return;
 
-    const anchorRect = anchorEl.getBoundingClientRect();
-    if (anchorRect.width === 0) return;
+    // Clamp to the space on the larger side of the anchor, measured against
+    // the *visual* viewport (shrunken by the soft keyboard) via the same
+    // helper `calculatePosition` uses for its flip decision — so the clamp
+    // always matches the side the layer is actually placed on.
+    const applyMaxHeight = () => {
+      const anchorRect = anchorEl.getBoundingClientRect();
+      if (anchorRect.width === 0) return;
 
-    const anchorGap = resolveSpaceToken("--space-xxs", 4);
-    const edgeClearance = resolveSpaceToken("--space-l", 20);
-    const vvHeight = window.visualViewport?.height ?? window.innerHeight;
+      const anchorGap = resolveSpaceToken("--space-xxs", 4);
+      const edgeClearance = resolveSpaceToken("--space-l", 20);
+      const { spaceAbove, spaceBelow } = getAvailableSpace(
+        anchorRect,
+        anchorGap,
+        edgeClearance,
+      );
+      const maxHeight = Math.max(spaceAbove, spaceBelow, 0);
 
-    const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
-    const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
-    const maxHeight = Math.max(spaceAbove, spaceBelow, 0);
+      layerEl.style.setProperty("--js-dropdown-max-height", `${maxHeight}px`);
+    };
 
-    layerEl.style.setProperty("--js-dropdown-max-height", `${maxHeight}px`);
+    applyMaxHeight();
+
+    // Re-clamp when the soft keyboard opens/closes (visual viewport resize);
+    // the keyboard often finishes opening after the initial measurement.
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    vv?.addEventListener?.("resize", applyMaxHeight);
 
     return () => {
+      vv?.removeEventListener?.("resize", applyMaxHeight);
       layerEl.style.removeProperty("--js-dropdown-max-height");
     };
   }, [isOpen, enabled, anchorRef, layerRef]);

--- a/src/hooks/useDropdownLayer/useDropdownMaxHeight.ts
+++ b/src/hooks/useDropdownLayer/useDropdownMaxHeight.ts
@@ -4,6 +4,14 @@ interface UseDropdownMaxHeightParams {
   anchorRef: React.RefObject<HTMLElement>;
   layerRef: React.RefObject<HTMLElement>;
   isOpen: boolean;
+  /**
+   * When false, the hook is a no-op. `useDropdownLayer` passes false when
+   * the native anchor-positioning path is active; in that case max-height
+   * is handled by CSS (`calc(100dvh - anchor(bottom) - ...)` on the layer
+   * and equivalent inside `@position-try --nds-dropdown-above`) and this
+   * hook has nothing to contribute.
+   */
+  enabled: boolean;
 }
 
 /**
@@ -26,49 +34,40 @@ export const resolveSpaceToken = (
  * Measures available space above and below the anchor element and writes
  * `--js-dropdown-max-height` to the layer element as a pixel value.
  *
- * Re-runs on `visualViewport` resize to handle virtual keyboard changes.
+ * Runs only when the polyfill path is active (`enabled === true`). On the
+ * native anchor-positioning path, max-height is handled by pure CSS
+ * (`calc(100dvh - anchor(bottom) - ...)`) so this hook is skipped.
  */
 const useDropdownMaxHeight = ({
   anchorRef,
   layerRef,
   isOpen,
+  enabled,
 }: UseDropdownMaxHeightParams): void => {
   useLayoutEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !enabled) return;
 
     const anchorEl = anchorRef.current;
     const layerEl = layerRef.current;
     if (!anchorEl || !layerEl) return;
 
-    const calculate = () => {
-      const anchorRect = anchorEl.getBoundingClientRect();
-      if (anchorRect.width === 0) return;
+    const anchorRect = anchorEl.getBoundingClientRect();
+    if (anchorRect.width === 0) return;
 
-      const anchorGap = resolveSpaceToken("--space-xxs", 4);
-      const edgeClearance = resolveSpaceToken("--space-l", 20);
-      const vvHeight = window.visualViewport?.height ?? window.innerHeight;
+    const anchorGap = resolveSpaceToken("--space-xxs", 4);
+    const edgeClearance = resolveSpaceToken("--space-l", 20);
+    const vvHeight = window.visualViewport?.height ?? window.innerHeight;
 
-      const spaceBelow =
-        vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
-      const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
-      const maxHeight = Math.max(spaceAbove, spaceBelow, 0);
+    const spaceBelow = vvHeight - anchorRect.bottom - anchorGap - edgeClearance;
+    const spaceAbove = anchorRect.top - anchorGap - edgeClearance;
+    const maxHeight = Math.max(spaceAbove, spaceBelow, 0);
 
-      layerEl.style.setProperty("--js-dropdown-max-height", `${maxHeight}px`);
-    };
-
-    calculate();
-
-    const handleViewportResize = () => calculate();
-    window.visualViewport?.addEventListener("resize", handleViewportResize);
+    layerEl.style.setProperty("--js-dropdown-max-height", `${maxHeight}px`);
 
     return () => {
-      window.visualViewport?.removeEventListener(
-        "resize",
-        handleViewportResize,
-      );
       layerEl.style.removeProperty("--js-dropdown-max-height");
     };
-  }, [isOpen, anchorRef, layerRef]);
+  }, [isOpen, enabled, anchorRef, layerRef]);
 };
 
 export default useDropdownMaxHeight;

--- a/src/hooks/useDropdownLayer/viewport.test.ts
+++ b/src/hooks/useDropdownLayer/viewport.test.ts
@@ -1,0 +1,105 @@
+import { getVisibleBounds, getAvailableSpace } from "./viewport";
+
+const setViewport = ({
+  innerHeight,
+  visualViewport,
+}: {
+  innerHeight: number;
+  visualViewport: { height: number; offsetTop: number } | null;
+}) => {
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: innerHeight,
+  });
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: visualViewport,
+  });
+};
+
+describe("getVisibleBounds", () => {
+  it("coincides with the layout viewport when there is no keyboard or zoom", () => {
+    setViewport({
+      innerHeight: 768,
+      visualViewport: { height: 768, offsetTop: 0 },
+    });
+
+    expect(getVisibleBounds()).toEqual({
+      top: 0,
+      bottom: 768,
+      layoutHeight: 768,
+    });
+  });
+
+  it("shrinks the visible bottom when the soft keyboard is open", () => {
+    setViewport({
+      innerHeight: 768,
+      visualViewport: { height: 400, offsetTop: 0 },
+    });
+
+    expect(getVisibleBounds()).toEqual({
+      top: 0,
+      bottom: 400,
+      layoutHeight: 768,
+    });
+  });
+
+  it("offsets the visible region when the visual viewport is panned", () => {
+    setViewport({
+      innerHeight: 768,
+      visualViewport: { height: 400, offsetTop: 200 },
+    });
+
+    expect(getVisibleBounds()).toEqual({
+      top: 200,
+      bottom: 600,
+      layoutHeight: 768,
+    });
+  });
+
+  it("falls back to the layout viewport when visualViewport is unavailable", () => {
+    setViewport({ innerHeight: 600, visualViewport: null });
+
+    expect(getVisibleBounds()).toEqual({
+      top: 0,
+      bottom: 600,
+      layoutHeight: 600,
+    });
+  });
+});
+
+describe("getAvailableSpace", () => {
+  it("measures space against the visible region, not the layout viewport", () => {
+    setViewport({
+      innerHeight: 768,
+      visualViewport: { height: 400, offsetTop: 0 },
+    });
+
+    const { spaceAbove, spaceBelow } = getAvailableSpace(
+      { top: 300, bottom: 340 },
+      4,
+      20,
+    );
+
+    // spaceAbove = 300 - 0 - 4 - 20; spaceBelow = 400 - 340 - 4 - 20
+    expect(spaceAbove).toBe(276);
+    expect(spaceBelow).toBe(36);
+  });
+
+  it("accounts for visual viewport pan on both sides", () => {
+    setViewport({
+      innerHeight: 768,
+      visualViewport: { height: 400, offsetTop: 200 },
+    });
+
+    const { spaceAbove, spaceBelow } = getAvailableSpace(
+      { top: 300, bottom: 340 },
+      4,
+      20,
+    );
+
+    // visible region is 200..600
+    expect(spaceAbove).toBe(76);
+    expect(spaceBelow).toBe(236);
+  });
+});

--- a/src/hooks/useDropdownLayer/viewport.ts
+++ b/src/hooks/useDropdownLayer/viewport.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared viewport measurement for the dropdown positioning polyfill.
+ *
+ * Two coordinate spaces are in play on mobile:
+ *
+ * - The **layout viewport**: the coordinate space of
+ *   `getBoundingClientRect()` and of `top`/`bottom` insets on
+ *   `position: fixed` elements. It does NOT shrink when the soft keyboard
+ *   opens (under the default `interactive-widget=resizes-visual` behavior
+ *   on Chromium/Android).
+ * - The **visual viewport**: the portion of the layout viewport actually
+ *   visible to the user. The soft keyboard and pinch-zoom shrink it, and
+ *   it can be panned; `visualViewport.offsetTop` is its offset within the
+ *   layout viewport.
+ *
+ * All positioning math must MEASURE available space against the visual
+ * viewport (what the user can see) but WRITE styles in layout-viewport
+ * coordinates (what `position: fixed` insets mean). Mixing the two — e.g.
+ * subtracting a layout-coordinate rect from `visualViewport.height` —
+ * misplaces the layer by the keyboard-height delta.
+ */
+
+export interface VisibleBounds {
+  /** Top edge of the visible region, in layout-viewport coordinates */
+  top: number;
+  /** Bottom edge of the visible region, in layout-viewport coordinates */
+  bottom: number;
+  /** Height of the layout viewport itself; the base that `bottom` insets
+   * on fixed-position elements resolve against. */
+  layoutHeight: number;
+}
+
+/**
+ * Bounds of the visible portion of the layout viewport, in layout-viewport
+ * coordinates. With no keyboard or pinch-zoom, `top` is 0 and `bottom`
+ * equals `layoutHeight`.
+ */
+export const getVisibleBounds = (): VisibleBounds => {
+  if (typeof window === "undefined") {
+    return { top: 0, bottom: 0, layoutHeight: 0 };
+  }
+  const layoutHeight =
+    (typeof document !== "undefined" &&
+      document.documentElement?.clientHeight) ||
+    window.innerHeight;
+  const vv = window.visualViewport;
+  const top = vv?.offsetTop ?? 0;
+  const height = vv?.height ?? layoutHeight;
+  return { top, bottom: top + height, layoutHeight };
+};
+
+/**
+ * Visible space above and below an anchor rect, after gap/clearance.
+ * Used by both the flip decision (`calculatePosition`) and the max-height
+ * clamp (`useDropdownMaxHeight`) so the two can never disagree.
+ */
+export const getAvailableSpace = (
+  anchorRect: Pick<DOMRect, "top" | "bottom">,
+  anchorGap: number,
+  edgeClearance: number,
+): { spaceAbove: number; spaceBelow: number } => {
+  const bounds = getVisibleBounds();
+  return {
+    spaceAbove: anchorRect.top - bounds.top - anchorGap - edgeClearance,
+    spaceBelow: bounds.bottom - anchorRect.bottom - anchorGap - edgeClearance,
+  };
+};


### PR DESCRIPTION
## Problem

On Android Chrome, when the soft keyboard is already open at the moment a dropdown opens (e.g. focus moving directly from one Combobox to the next in AO's eligibility flow), the dropdown layer renders far below the input — off-screen, past the keyboard. Repro: two stacked Comboboxes on a real device; select in the first (keyboard persists), tap the second.

See https://github.com/narmi/design_system/compare/v6.19.11...fix/dropdown-visual-viewport-positioning for a clean diff from current 6.19.11. This should be rebased onto `main` before we actually merge, and then we can backport and all that.

## Root cause

The JS positioning polyfill mixes coordinate spaces:

- `calculatePosition` measured space and computed the flipped `bottom` inset from `visualViewport.height`, which the keyboard **shrinks** — but anchor rects (`getBoundingClientRect`) and `position: fixed` insets are **layout-viewport** based, which the keyboard does **not** shrink under the default `interactive-widget=resizes-visual`. With the keyboard open, the flipped `--js-dropdown-bottom` came out too small (even negative), pinning the layer below the screen by the keyboard-height delta.
- `computeRootMargin` had the same mixup: the IntersectionObserver root is the layout viewport, so with the keyboard open an anchor below `visualViewport.height` in layout coords could never reach full intersection — leaving the layer stuck `visibility: hidden` or flickering through hide/re-arm cycles.
- Nothing recalculated after open, so a keyboard that finishes animating *after* initial placement (the same tap opens both) was never accounted for.

## Fix

- New `viewport.ts` helper: **measure** available space against the visual viewport (keyboard- and pan-aware via `visualViewport.offsetTop`), **emit** layout-viewport insets. Shared by the flip decision and the max-height clamp so they can't drift.
- `computeRootMargin` uses layout-viewport dimensions, matching the IO root and rect coordinates.
- Recalculate position + max-height on `visualViewport` `resize` (rAF-throttled). Unlike the `window.resize` **close** handler removed in NDS-3164, this only repositions — spurious fires are harmless.

Net effect on the stacked-combobox repro: the second dropdown now sees it has no visible space below and flips **above** the input, visible over the keyboard.

## Notes for review

- Branched off `v6.19.11` intentionally, targeting the release line the `releases/v2026.8` banking branch pins. The same mixup exists in a different form on `main` (post-6.22.6 `calculatePosition` is layout-only and keyboard-blind; its `100dvh` clamp comment assumes dvh shrinks with the keyboard, which is only true under `interactive-widget=resizes-content`) — forward-porting should be its own PR.
- This fixes the **polyfill** path. On browsers with native CSS anchor positioning the native path may run instead; when validating on-device, confirm which path is active (layer has `--js-dropdown-*` inline props = polyfill; `position-area` = native). If the native path is active on Android Chrome, the off-screen symptom coming from this code implies `HAS_SCROLL_CONTAINER_BUG` is forcing the polyfill there — worth capturing whichever is observed.
- Related: NDS-2906 (blur/refocus keeps the keyboard up after selection, which is what arms this bug when moving between inputs) — separate fix on `fix/combobox-touch-keyboard-dismiss`.

## Testing

- New unit tests: keyboard-open flip emits layout-viewport `bottom` (regression for the off-screen placement), panned-viewport space measurement, `viewport.ts` bounds math.
- `vitest run src/hooks/useDropdownLayer src/Select src/Combobox src/MultiSelect` — all green; eslint + tsc clean.
- Needs on-device validation on a real Android phone (stacked comboboxes, keyboard open, both fresh-tap and moving-between-inputs sequences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)