### PR TITLE
feat(Callout,TimelineEvent): add divided event; introduce callout

### DIFF
--- a/src/Callout/index.scss
+++ b/src/Callout/index.scss
@@ -1,0 +1,33 @@
+.nds-callout {
+  display: grid;
+  grid-template-columns: 2px 1fr;
+  grid-template-areas: "line content";
+  grid-gap: var(--space-m);
+  padding-top: var(--space-m);
+
+  &::before {
+    content: "";
+    align-self: stretch;
+    grid-area: line;
+    background-color: var(--theme-primary);
+  }
+}
+
+.nds-callout-content {
+  grid-area: content;
+  background-color: rgba(var(--theme-rgb-primary), var(--alpha-5));
+  border-radius: var(--border-radius-default);
+  padding: var(--space-l);
+}
+
+.nds-callout-list {
+  strong {
+    font-weight: var(--font-weight-semibold);
+  }
+  span {
+    color: var(--font-color-secondary);
+  }
+  & > li + li {
+    padding-top: var(--space-s);
+  }
+}

--- a/src/Callout/index.stories.js
+++ b/src/Callout/index.stories.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { Callout } from ".";
+import TimelineEvent from "../TimelineEvent";
+
+export const Overview = () => (
+  <Callout
+    detailList={[
+      { label: "Amount", description: "$1,250.00" },
+      { label: "Account", description: "Checking 1234" },
+      { label: "Confirmation", description: "A1B2C3D4" },
+    ]}
+  />
+);
+
+export const LabelOnly = () => (
+  <Callout
+    detailList={[
+      { label: "Submitted for review" },
+      { label: "Approved by manager" },
+      { label: "Sent to processor", description: "Batch #42" },
+    ]}
+  />
+);
+
+export const CustomContent = () => (
+  <Callout
+    renderContent={() => (
+      <div className="fontSize--s">
+        <div>
+          <span className="narmi-icon-check-circle margin--right--xs" />
+          <strong>Note from reviewer</strong>
+        </div>
+        <div>Approved with a follow-up scheduled for next week.</div>
+      </div>
+    )}
+  />
+);
+
+export const InATimeline = () => (
+  <TimelineEvent
+    kind="divided"
+    detailList={[
+      { label: "Amount", description: "$1,250.00" },
+      { label: "Account", description: "Checking 1234" },
+      { label: "Confirmation", description: "A1B2C3D4" },
+    ]}
+  >
+    <h4>Payment processed</h4>
+  </TimelineEvent>
+);
+
+export default {
+  title: "Components/Callout",
+  component: Callout,
+};

--- a/src/Callout/index.test.tsx
+++ b/src/Callout/index.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Callout } from "./";
+
+describe("Callout", () => {
+  it("renders detailList labels and descriptions", () => {
+    render(
+      <Callout
+        detailList={[
+          { label: "Amount", description: "$1,250.00" },
+          { label: "Account", description: "Checking 1234" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("$1,250.00")).toBeInTheDocument();
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.getByText("Checking 1234")).toBeInTheDocument();
+  });
+
+  it("renders a label without a description", () => {
+    const { container } = render(
+      <Callout detailList={[{ label: "Submitted for review" }]} />,
+    );
+    expect(screen.getByText("Submitted for review")).toBeInTheDocument();
+    expect(container.querySelectorAll(".nds-callout-list > li")).toHaveLength(
+      1,
+    );
+  });
+
+  it("applies the expected callout classes", () => {
+    const { container } = render(
+      <Callout detailList={[{ label: "Amount" }]} />,
+    );
+    expect(container.querySelector(".nds-callout")).toBeInTheDocument();
+    expect(container.querySelector(".nds-callout-content")).toBeInTheDocument();
+    expect(container.querySelector(".nds-callout-list")).toBeInTheDocument();
+  });
+
+  it("renders custom content via renderContent and skips the list", () => {
+    const { container } = render(
+      <Callout
+        detailList={[{ label: "Ignored" }]}
+        renderContent={() => <div>Custom content</div>}
+      />,
+    );
+    expect(screen.getByText("Custom content")).toBeInTheDocument();
+    expect(screen.queryByText("Ignored")).not.toBeInTheDocument();
+    expect(
+      container.querySelector(".nds-callout-list"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an empty list when no detailList is provided", () => {
+    const { container } = render(<Callout />);
+    expect(container.querySelector(".nds-callout-list")).toBeInTheDocument();
+    expect(container.querySelectorAll(".nds-callout-list > li")).toHaveLength(
+      0,
+    );
+  });
+});

--- a/src/Callout/index.tsx
+++ b/src/Callout/index.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import SeparatorList from "../SeparatorList";
+
+export type Detail = {
+  label: string;
+  description?: string;
+};
+
+export interface CalloutProps {
+  /**
+   * Take full control of rendering,
+   * allowing arbitrary JSX content
+   */
+  renderContent?: () => React.ReactNode;
+  /**
+   * Details to render in a list.
+   */
+  detailList?: Detail[];
+}
+
+export const Callout = ({ renderContent, detailList = [] }: CalloutProps) => (
+  <div className="nds-callout">
+    <div className="nds-callout-content">
+      {renderContent ? (
+        renderContent()
+      ) : (
+        <ul className="nds-callout-list list--reset fontSize--s">
+          {detailList.map(({ label, description }) => (
+            <li key={label}>
+              <SeparatorList
+                separator="⬝"
+                items={[
+                  <strong key={`label-${label}`}>{label}</strong>,
+                  description ? (
+                    <span key={`description-${label}`}>{description}</span>
+                  ) : null,
+                ]}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  </div>
+);

--- a/src/SeparatorList/index.scss
+++ b/src/SeparatorList/index.scss
@@ -10,7 +10,7 @@
 
   li[data-separator]::after {
     content: attr(data-separator);
-    color: var(--font-color-hint);
+    color: var(--nds-separatorList-separator-color, var(--font-color-hint));
     padding: 0 var(--space-xs);
   }
 }

--- a/src/SeparatorList/index.tsx
+++ b/src/SeparatorList/index.tsx
@@ -4,6 +4,8 @@ import cc from "classcat";
 export interface SeparatorListProps {
   items: React.ReactNode[];
   separator?: string;
+  /** CSS color value applied to the separator character */
+  separatorColor?: string;
   noWrap?: boolean;
   testId?: string;
 }
@@ -13,6 +15,7 @@ export interface SeparatorListProps {
  */
 const SeparatorList: React.FC<SeparatorListProps> = ({
   separator = "|",
+  separatorColor = "var(--font-color-secondary)",
   noWrap = false,
   items = [],
   testId,
@@ -22,6 +25,8 @@ const SeparatorList: React.FC<SeparatorListProps> = ({
       "list--reset nds-typography nds-separatorList",
       { "nds-separatorList--noWrap": noWrap },
     ])}
+    // @ts-expect-error CSSProperties does not include custom CSS properties
+    style={{ "--nds-separatorList-separator-color": separatorColor }}
     data-testid={testId}
   >
     {items

--- a/src/TimelineEvent/index.scss
+++ b/src/TimelineEvent/index.scss
@@ -77,3 +77,14 @@
     stroke-dasharray: 2;
   }
 }
+
+.nds-timeline-event--divided {
+  & + & {
+    border-top: 1px solid var(--border-color-light);
+    padding-top: var(--space-s);
+  }
+
+  svg line {
+    display: none;
+  }
+}

--- a/src/TimelineEvent/index.stories.js
+++ b/src/TimelineEvent/index.stories.js
@@ -38,6 +38,42 @@ export const StackingTimelineEvents = () => (
   </>
 );
 
+export const DividedVariant = () => (
+  <>
+    <TimelineEvent kind="divided">Account opened</TimelineEvent>
+    <TimelineEvent kind="divided">
+      At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+      praesentium voluptatum deleniti atque corrupti quos dolores et quas
+      molestias excepturi sint occaecati cupiditate non provident, similique
+      sunt in culpa qui officia deserunt mollitia animi, id est laborum et
+      dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
+      Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil
+      impedit quo minus id quod maxime placeat facere possimus, omnis voluptas
+      assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut
+      officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates
+      repudiandae sint et molestiae non recusandae.
+    </TimelineEvent>
+    <TimelineEvent kind="divided">Debit card mailed</TimelineEvent>
+    <TimelineEvent kind="divided">
+      Online banking enrollment completed
+    </TimelineEvent>
+  </>
+);
+
+export const EventWithDetailsBlock = () => (
+  <TimelineEvent
+    kind="plain"
+    detailList={[
+      { label: "Amount", description: "$1,250.00" },
+      { label: "Account", description: "Checking 1234" },
+      { label: "Confirmation", description: "A1B2C3D4" },
+    ]}
+  >
+    <h4>Payment processed</h4>
+  </TimelineEvent>
+);
+EventWithDetailsBlock.storyName = "Event with details block";
+
 export const CustomNode = () => (
   <>
     <TimelineEvent kind="pending">

--- a/src/TimelineEvent/index.stories.js
+++ b/src/TimelineEvent/index.stories.js
@@ -62,7 +62,6 @@ export const DividedVariant = () => (
 
 export const EventWithDetailsBlock = () => (
   <TimelineEvent
-    kind="plain"
     detailList={[
       { label: "Amount", description: "$1,250.00" },
       { label: "Account", description: "Checking 1234" },

--- a/src/TimelineEvent/index.test.tsx
+++ b/src/TimelineEvent/index.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import TimelineEvent from "./";
+
+describe("TimelineEvent", () => {
+  it("renders children content", () => {
+    render(<TimelineEvent>Event content</TimelineEvent>);
+    expect(screen.getByText("Event content")).toBeInTheDocument();
+  });
+
+  it("composes a Callout when detailList is provided", () => {
+    const { container } = render(
+      <TimelineEvent
+        detailList={[
+          { label: "Amount", description: "$1,250.00" },
+          { label: "Account", description: "Checking 1234" },
+        ]}
+      >
+        <h4>Payment processed</h4>
+      </TimelineEvent>,
+    );
+    // children still render alongside the composed Callout
+    expect(screen.getByText("Payment processed")).toBeInTheDocument();
+    expect(container.querySelector(".nds-callout")).toBeInTheDocument();
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("$1,250.00")).toBeInTheDocument();
+  });
+
+  it("does NOT render a Callout when detailList is omitted", () => {
+    const { container } = render(<TimelineEvent>Just content</TimelineEvent>);
+    expect(container.querySelector(".nds-callout")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render a Callout when detailList is empty", () => {
+    const { container } = render(
+      <TimelineEvent detailList={[]}>Just content</TimelineEvent>,
+    );
+    expect(container.querySelector(".nds-callout")).not.toBeInTheDocument();
+  });
+
+  it("renders the correct node modifier classes for kind", () => {
+    const { container } = render(
+      <TimelineEvent kind="pending">Pending</TimelineEvent>,
+    );
+    expect(
+      container.querySelector(".nds-timeline-event--pending"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/TimelineEvent/index.test.tsx
+++ b/src/TimelineEvent/index.test.tsx
@@ -39,11 +39,16 @@ describe("TimelineEvent", () => {
   });
 
   it("renders the correct node modifier classes for kind", () => {
-    const { container } = render(
+    const { container, rerender } = render(
       <TimelineEvent kind="pending">Pending</TimelineEvent>,
     );
     expect(
       container.querySelector(".nds-timeline-event--pending"),
+    ).toBeInTheDocument();
+
+    rerender(<TimelineEvent kind="divided">Divided</TimelineEvent>);
+    expect(
+      container.querySelector(".nds-timeline-event--divided"),
     ).toBeInTheDocument();
   });
 });

--- a/src/TimelineEvent/index.tsx
+++ b/src/TimelineEvent/index.tsx
@@ -3,11 +3,13 @@ import PropTypes from "prop-types";
 import { VALID_ICON_NAMES } from "../icons/iconNames";
 import cc from "classcat";
 import ToolTip from "../Tooltip";
+import { Callout } from "../Callout";
+import type { Detail } from "../Callout";
 import type { IconName } from "../types/Icon.types";
 
 export { VALID_ICON_NAMES };
 
-export type TimelineEventKind = "node" | "start" | "pending";
+export type TimelineEventKind = "node" | "start" | "pending" | "divided";
 
 export interface TimelineEventProps {
   /**
@@ -35,6 +37,11 @@ export interface TimelineEventProps {
    */
   children?: React.ReactNode;
   /**
+   * Detail list rendered in a composed `Callout`
+   * below the event content
+   */
+  detailList?: Detail[];
+  /**
    * Hover tooltip content for the icon
    */
   tooltip?: string;
@@ -49,6 +56,7 @@ const TimelineEvent = ({
   initial,
   tooltip,
   children,
+  detailList,
   renderNode,
 }: TimelineEventProps) => {
   const useInitial = !icon && !imgUrl && initial;
@@ -58,6 +66,7 @@ const TimelineEvent = ({
         "nds-timeline-event",
         {
           "nds-timeline-event--pending": kind === "pending",
+          "nds-timeline-event--divided": kind === "divided",
         },
       ])}
     >
@@ -111,7 +120,10 @@ const TimelineEvent = ({
           </svg>
         )}
       </div>
-      <div className="nds-timeline-content">{children}</div>
+      <div className="nds-timeline-content">
+        {children}
+        {detailList?.length ? <Callout detailList={detailList} /> : null}
+      </div>
     </div>
   );
 };
@@ -120,7 +132,7 @@ TimelineEvent.propTypes = {
   /**
    * Timeline node variant.
    */
-  kind: PropTypes.oneOf(["node", "start", "pending"]),
+  kind: PropTypes.oneOf(["node", "start", "pending", "divided"]),
   /**
    * Name of NDS icon to render inside the timeline node
    */
@@ -144,6 +156,16 @@ TimelineEvent.propTypes = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]),
+  /**
+   * Detail list rendered in a composed `Callout`
+   * below the event content
+   */
+  detailList: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      description: PropTypes.string,
+    }),
+  ),
   /**
    * Hover tooltip content for the icon
    */

--- a/src/index.scss
+++ b/src/index.scss
@@ -91,6 +91,7 @@
 @import "SplitButton/";
 @import "Popover/";
 @import "Toggle/";
+@import "Callout/";
 @import "TimelineEvent/";
 @import "Tabs/";
 @import "Table/";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import AnchoredDialog from "./AnchoredDialog";
 import AutocompleteModal from "./AutocompleteModal";
 import Avatar from "./Avatar";
 import Button from "./Button";
+import { Callout } from "./Callout";
 import ContentCard from "./ContentCard";
 import Checkbox from "./Checkbox";
 import Chip from "./Chip";
@@ -88,6 +89,7 @@ export type {
 } from "./AutocompleteModal/AutoComplete";
 export type { AvatarProps } from "./Avatar";
 export type { ButtonProps, ButtonKind } from "./Button";
+export type { CalloutProps, Detail } from "./Callout";
 export type { CheckboxProps } from "./Checkbox";
 export type { ChipProps } from "./Chip";
 export type {
@@ -203,6 +205,7 @@ export {
   AutocompleteModal,
   Avatar,
   Button,
+  Callout,
   Checkbox,
   Chip,
   ContentCard,


### PR DESCRIPTION
Closes NDS-3118

- Add `divided` variant of `TimelineEvent`
- Add `Callout` component that may be composed with a TimelineEvent

<img width="632" height="486" alt="Screenshot 2026-08-27 at 2 22 28 PM" src="https://github.com/user-attachments/assets/770d56d4-4d3e-42b5-8f69-5ec5407dcf2f" />
<img width="636" height="663" alt="Screenshot 2026-08-27 at 2 24 02 PM" src="https://github.com/user-attachments/assets/aa7bb9d5-bd33-412a-bdcb-ffdd73af801c" />
<img width="624" height="437" alt="Screenshot 2026-08-27 at 2 22 42 PM" src="https://github.com/user-attachments/assets/14560fce-0f90-468a-8871-c9262b38ffbc" />
<img width="634" height="363" alt="Screenshot 2026-08-27 at 2 22 37 PM" src="https://github.com/user-attachments/assets/25d0127e-237a-4915-b525-b34dec0ecbc2" />

