### PR TITLE
fix(useDropdownLayer,Combobox): cap height via css

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,9 @@
 import React from "react";
 import "./story-styles.css";
 import "../src/index.scss";
+// Injects the required viewport meta tag into the preview iframe, matching
+// what published consumers get via `src/index.ts`.
+import "../src/util/viewport";
 import { NdsStyles, ExamplesBackground } from "./decorators";
 import { docs } from "./theme/narmi";
 

--- a/issue-test-cases/NDS-3164-AndroidComboboxPositioning.stories.js
+++ b/issue-test-cases/NDS-3164-AndroidComboboxPositioning.stories.js
@@ -60,12 +60,11 @@ const BottomAnchoredLayout = (Story) => (
 /**
  * Centers the Combobox vertically so both `spaceBelow` and `spaceAbove`
  * start out ample. When the Android soft keyboard opens, `spaceBelow`
- * (useAnchorPolyfill.ts:50) can go negative and the flip decision
- * swaps mid-interaction — exercising `handleViewportResize` and the
- * max-height calc (useDropdownMaxHeight.ts:51-52). The position calc
- * may not produce a negative value here, so if the menu still
- * disappears the `window.resize` close handler (line 185) is
- * implicated rather than the coordinate mixup.
+ * (useAnchorPolyfill.ts) can go negative and the flip decision swaps
+ * mid-interaction. Max-height is no longer computed in JS — the layer
+ * uses a fixed CSS max-height (%nds-dropdown-layer), so if the menu
+ * still disappears the flip/coordinate math in `calculatePosition` is
+ * implicated rather than a max-height calc.
  */
 const CenterAnchoredLayout = (Story) => (
   <div

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -7,6 +7,14 @@
 
 .nds-combobox-list {
   @extend %nds-dropdown-layer;
+
+  // give touch devices a shorter layer to account
+  // for virtual keyboards that open with the paired input el
+  @media (pointer: coarse) {
+    & {
+      max-height: 24dvh !important;
+    }
+  }
 }
 
 .nds-combobox-item,

--- a/src/Combobox/index.scss
+++ b/src/Combobox/index.scss
@@ -10,9 +10,10 @@
 
   // give touch devices a shorter layer to account
   // for virtual keyboards that open with the paired input el
-  @media (pointer: coarse) {
+  @media (any-pointer: coarse) {
     & {
-      max-height: 24dvh !important;
+      max-height: 24vh !important; // fallback for browsers without dvh (e.g. iOS 14 Safari)
+      max-height: 24dvh !important; // keyboard-aware where supported
     }
   }
 }

--- a/src/Combobox/index.tsx
+++ b/src/Combobox/index.tsx
@@ -267,7 +267,6 @@ function Combobox({
 
   const [displayedItems, setDisplayedItems] = useState(items);
   const inputRef = useRef<HTMLInputElement>(null);
-  const isInternalFocusChange = useRef(false);
 
   const itemToString = (item: ComboboxChild | null | undefined) =>
     item?.props?.searchValue || item?.props?.value || "";
@@ -314,16 +313,8 @@ function Combobox({
     },
 
     onSelectedItemChange: ({ selectedItem }) => {
-      // Blur before value change to prevent mobile scroll-into-view (NDS-2906).
-      // Mobile browsers scroll the viewport when a focused input's value
-      // changes to a long string. Removing focus first eliminates the trigger,
-      // then we restore focus without scrolling.
-      isInternalFocusChange.current = true;
-      inputRef.current?.blur();
       onChange(selectedItem ? (selectedItem.props.value ?? "") : "");
       closeMenu();
-      inputRef.current?.focus({ preventScroll: true });
-      isInternalFocusChange.current = false;
     },
 
     // <https://www.downshift-js.com/use-select#state-reducer>
@@ -477,7 +468,6 @@ function Combobox({
   };
 
   const handleMenuToggle = () => {
-    if (isInternalFocusChange.current) return;
     if (!isOpen) {
       // Reset filtered items every time user refocuses.
       // Subsequent changes in the input will re-filter the list.
@@ -489,7 +479,6 @@ function Combobox({
   };
 
   const handleBlur = () => {
-    if (isInternalFocusChange.current) return;
     onInputChange(selectedItem ? itemToString(selectedItem) : "");
     if (highlightedIndex !== -1) {
       closeMenu();

--- a/src/base-styles/custom-properties.scss
+++ b/src/base-styles/custom-properties.scss
@@ -18,14 +18,10 @@
 * placement and this fallback is handled directly in CSS via
 * `calc(100dvh - anchor(...))` and `calc(anchor(top) - ...)`. `dvh`
 * shrinks when the virtual keyboard opens on Chromium/Android, giving
-* keyboard-aware sizing without JS. On the JS polyfill path,
-* `--js-dropdown-max-height` is set by `calculatePosition` in `useAnchorPolyfill`.
+* keyboard-aware sizing without JS.
 */
 @position-try --nds-dropdown-above {
   position-area: top;
-  max-height: calc(
-    anchor(top) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs))
-  );
   margin-top: 0;
   margin-bottom: var(--nds-layer-gap, var(--space-xxs));
 }
@@ -41,12 +37,6 @@
 */
 @position-try --nds-try-below {
   position-area: bottom;
-  max-height: calc(
-    100dvh - anchor(bottom) - var(--space-l) - var(
-        --nds-layer-gap,
-        var(--space-xxs)
-      )
-  );
   margin-top: var(--nds-layer-gap, var(--space-xxs));
   margin-bottom: 0;
 }

--- a/src/base-styles/scss-utils.scss
+++ b/src/base-styles/scss-utils.scss
@@ -103,9 +103,10 @@ $breakpoints: (
  */
 %nds-dropdown-layer {
   overflow-y: auto;
-  max-height: var(--js-dropdown-max-height);
   border: 1px solid var(--theme-primary);
   border-radius: var(--border-radius-default);
+  max-height: 46vh;
+  max-height: 46dvh;
 
   // Defend against broad consumer selectors like `.parent * { display: flex; }`
   // !important wins regardless of specificity or source order.

--- a/src/hooks/useDropdownLayer/index.ts
+++ b/src/hooks/useDropdownLayer/index.ts
@@ -67,14 +67,8 @@ export interface UseDropdownLayerOptions {
   polyfillScrollBug?: boolean;
 }
 
-/** Maps placement to CSS anchor positioning values.
- *
- * `positionTryOrder` and `primaryMaxHeight` are populated for the vertical
- * placements only. Together they let CSS handle both the flip decision and
- * the max-height clip natively in a keyboard-aware way (`dvh` shrinks with
- * the virtual keyboard on Chromium/Android). Horizontal placements
- * (left/right) don't have a keyboard concern, so they keep the original
- * fallback-order-driven behaviour.
+/**
+ * Maps placement to CSS anchor positioning values.
  */
 const PLACEMENT_CONFIG: Record<
   Placement,
@@ -83,7 +77,6 @@ const PLACEMENT_CONFIG: Record<
     positionTryFallbacks: string;
     margin: string;
     positionTryOrder?: string;
-    primaryMaxHeight?: string;
   }
 > = {
   bottom: {
@@ -91,16 +84,12 @@ const PLACEMENT_CONFIG: Record<
     positionTryFallbacks: "--nds-dropdown-above, flip-inline",
     positionTryOrder: "most-height",
     margin: "marginTop",
-    primaryMaxHeight:
-      "calc(100dvh - anchor(bottom) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs)))",
   },
   top: {
     positionArea: "top",
     positionTryFallbacks: "--nds-try-below, flip-inline",
     positionTryOrder: "most-height",
     margin: "marginBottom",
-    primaryMaxHeight:
-      "calc(anchor(top) - var(--space-l) - var(--nds-layer-gap, var(--space-xxs)))",
   },
   left: {
     positionArea: "left",
@@ -186,7 +175,6 @@ const useDropdownLayer = ({
       ...(config.positionTryOrder && {
         positionTryOrder: config.positionTryOrder,
       }),
-      ...(config.primaryMaxHeight && { maxHeight: config.primaryMaxHeight }),
       marginTop: 0,
       marginBottom: 0,
       marginLeft: 0,

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.test.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.test.ts
@@ -87,33 +87,6 @@ describe("calculatePosition", () => {
       expect(props["--js-dropdown-top"]).toBe("154px");
       expect(props["--js-dropdown-bottom"]).toBeNull();
     });
-
-    it("sets --js-dropdown-max-height using 100dvh for below placement", () => {
-      // Below-placement max-height uses `100dvh` so the layer clips to the
-      // visible area above the virtual keyboard on mobile.
-      const anchor = makeEl({
-        top: 100,
-        bottom: 150,
-        left: 0,
-        right: 200,
-        width: 200,
-        height: 50,
-      });
-      const layer = makeEl({
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 200,
-        width: 200,
-        height: 0,
-      });
-
-      calculatePosition(anchor, layer, false);
-
-      expect(layer.style.getPropertyValue("--js-dropdown-max-height")).toBe(
-        "calc(100dvh - var(--js-dropdown-top, 0px) - var(--space-l))",
-      );
-    });
   });
 
   describe("positioning above anchor (more space above)", () => {
@@ -143,33 +116,6 @@ describe("calculatePosition", () => {
       const props = getProps(layer);
       expect(props["--js-dropdown-bottom"]).toBe("204px");
       expect(props["--js-dropdown-top"]).toBeNull();
-    });
-
-    it("sets --js-dropdown-max-height using 100vh for above placement", () => {
-      // Above-placement max-height uses `100vh` (not dvh) because keyboards
-      // open from the bottom and don't affect the space above the anchor.
-      const anchor = makeEl({
-        top: 568,
-        bottom: 608,
-        left: 0,
-        right: 200,
-        width: 200,
-        height: 40,
-      });
-      const layer = makeEl({
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 200,
-        width: 200,
-        height: 0,
-      });
-
-      calculatePosition(anchor, layer, false);
-
-      expect(layer.style.getPropertyValue("--js-dropdown-max-height")).toBe(
-        "max(0px, calc(100vh - var(--js-dropdown-bottom, 0px) - var(--space-l)))",
-      );
     });
   });
 
@@ -250,8 +196,8 @@ describe("calculatePosition", () => {
   describe("available space floor", () => {
     it("clamps availableSpace to 0 when anchor spans the full viewport", () => {
       // Anchor spans the full viewport — spaceAbove and spaceBelow are both negative.
-      // calculatePosition should still run without errors; max-height is handled
-      // by useDropdownMaxHeight which clamps to 0.
+      // calculatePosition should still run without errors; max-height is no longer
+      // set here — the layer's fixed CSS max-height (%nds-dropdown-layer) handles it.
       const anchor = makeEl({
         top: -50,
         bottom: 820,

--- a/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
+++ b/src/hooks/useDropdownLayer/useAnchorPolyfill.ts
@@ -40,14 +40,6 @@ const resolveSpaceToken = (property: string, fallback: number): number => {
  * compared against `getBoundingClientRect()`). This avoids the visual-vs-
  * layout viewport mixup that caused off-screen placement on Android when
  * the soft keyboard was open at the time `calculatePosition` ran.
- *
- * Also writes `--js-dropdown-max-height` as a direction-aware CSS calc
- * string:
- *   - Below-anchor placement uses `100dvh` so the layer clips inside the
- *     visible area above the virtual keyboard (dvh shrinks with the
- *     keyboard on Chromium/Android).
- *   - Above-anchor placement uses `100vh` because keyboards open from the
- *     bottom and don't affect the space above the anchor.
  */
 export const calculatePosition = (
   anchorEl: HTMLElement,
@@ -79,20 +71,12 @@ export const calculatePosition = (
       `${window.innerHeight - anchorRect.top + anchorGap}px`,
     );
     layerEl.style.removeProperty("--js-dropdown-top");
-    layerEl.style.setProperty(
-      "--js-dropdown-max-height",
-      "max(0px, calc(100vh - var(--js-dropdown-bottom, 0px) - var(--space-l)))",
-    );
   } else {
     layerEl.style.setProperty(
       "--js-dropdown-top",
       `${anchorRect.bottom - layerRect.top + anchorGap}px`,
     );
     layerEl.style.removeProperty("--js-dropdown-bottom");
-    layerEl.style.setProperty(
-      "--js-dropdown-max-height",
-      "calc(100dvh - var(--js-dropdown-top, 0px) - var(--space-l))",
-    );
   }
 
   layerEl.style.setProperty(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 /**
+ * Side effects
+ *
+ * Ensures the required viewport meta tag is present in every consumer.
+ * Internal only — nothing from this module is part of the public API.
+ */
+import "./util/viewport";
+
+/**
  * Typed Components
  */
 import Accordion from "./Accordion";

--- a/src/util/viewport.test.ts
+++ b/src/util/viewport.test.ts
@@ -60,9 +60,9 @@ describe("mergeViewportContent", () => {
     expect(mergeViewportContent(CANONICAL)).toBe(CANONICAL);
   });
 
-  it("normalizes a consumer's managed directive values", () => {
+  it("preserves a consumer's width while normalizing owned directives", () => {
     expect(mergeViewportContent("width=1024, initial-scale=0.5")).toBe(
-      "width=device-width, initial-scale=1, interactive-widget=resizes-content",
+      "width=1024, initial-scale=1, interactive-widget=resizes-content",
     );
   });
 
@@ -76,7 +76,13 @@ describe("mergeViewportContent", () => {
 
   it("preserves unrelated directives in place while upserting", () => {
     expect(mergeViewportContent("width=1024, viewport-fit=cover")).toBe(
-      "width=device-width, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
+      "width=1024, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
+    );
+  });
+
+  it("adds the default width when an existing tag does not set one", () => {
+    expect(mergeViewportContent("viewport-fit=cover")).toBe(
+      "viewport-fit=cover, width=device-width, initial-scale=1, interactive-widget=resizes-content",
     );
   });
 
@@ -105,7 +111,7 @@ describe("ensureViewportMeta", () => {
     const metas = getViewportMetas();
     expect(metas).toHaveLength(1);
     expect(metas[0].getAttribute("content")).toBe(
-      "width=device-width, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
+      "width=1024, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
     );
   });
 

--- a/src/util/viewport.test.ts
+++ b/src/util/viewport.test.ts
@@ -1,0 +1,130 @@
+import {
+  parseViewport,
+  serializeViewport,
+  mergeViewportContent,
+  ensureViewportMeta,
+} from "./viewport";
+
+const CANONICAL =
+  "width=device-width, initial-scale=1, interactive-widget=resizes-content";
+
+function getViewportMetas() {
+  return Array.from(
+    document.head.querySelectorAll('meta[name="viewport"]'),
+  ) as HTMLMetaElement[];
+}
+
+function setViewportMeta(content) {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "viewport");
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+  return meta;
+}
+
+describe("parseViewport / serializeViewport", () => {
+  it("round-trips a standard content string", () => {
+    const map = parseViewport(CANONICAL);
+    expect(map.get("width")).toBe("device-width");
+    expect(map.get("initial-scale")).toBe("1");
+    expect(map.get("interactive-widget")).toBe("resizes-content");
+    expect(serializeViewport(map)).toBe(CANONICAL);
+  });
+
+  it("ignores empty segments and preserves valueless directives", () => {
+    const map = parseViewport("width=device-width, , viewport-fit=cover");
+    expect(Array.from(map.keys())).toEqual(["width", "viewport-fit"]);
+  });
+
+  it("lowercases keys (directive names are case-insensitive)", () => {
+    const map = parseViewport("Width=device-width, Initial-Scale=1");
+    expect(map.get("width")).toBe("device-width");
+    expect(map.get("initial-scale")).toBe("1");
+  });
+});
+
+describe("mergeViewportContent", () => {
+  it("returns the canonical content when nothing exists", () => {
+    expect(mergeViewportContent(null)).toBe(CANONICAL);
+    expect(mergeViewportContent("")).toBe(CANONICAL);
+    expect(mergeViewportContent("   ")).toBe(CANONICAL);
+  });
+
+  it("appends managed directives when missing, preserving order", () => {
+    expect(mergeViewportContent("width=device-width, initial-scale=1")).toBe(
+      CANONICAL,
+    );
+  });
+
+  it("leaves content unchanged when already correct", () => {
+    expect(mergeViewportContent(CANONICAL)).toBe(CANONICAL);
+  });
+
+  it("normalizes a consumer's managed directive values", () => {
+    expect(mergeViewportContent("width=1024, initial-scale=0.5")).toBe(
+      "width=device-width, initial-scale=1, interactive-widget=resizes-content",
+    );
+  });
+
+  it("modifies a differing interactive-widget value", () => {
+    expect(
+      mergeViewportContent(
+        "width=device-width, initial-scale=1, interactive-widget=overlays-content",
+      ),
+    ).toBe(CANONICAL);
+  });
+
+  it("preserves unrelated directives in place while upserting", () => {
+    expect(mergeViewportContent("width=1024, viewport-fit=cover")).toBe(
+      "width=device-width, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
+    );
+  });
+
+  it("matches managed keys case-insensitively (no duplicates)", () => {
+    expect(mergeViewportContent("Width=device-width, Initial-Scale=1")).toBe(
+      CANONICAL,
+    );
+  });
+});
+
+describe("ensureViewportMeta", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+  });
+
+  it("creates a full canonical tag when none exists", () => {
+    ensureViewportMeta(document);
+    const metas = getViewportMetas();
+    expect(metas).toHaveLength(1);
+    expect(metas[0].getAttribute("content")).toBe(CANONICAL);
+  });
+
+  it("upserts managed directives on an existing tag", () => {
+    setViewportMeta("width=1024, viewport-fit=cover");
+    ensureViewportMeta(document);
+    const metas = getViewportMetas();
+    expect(metas).toHaveLength(1);
+    expect(metas[0].getAttribute("content")).toBe(
+      "width=device-width, viewport-fit=cover, initial-scale=1, interactive-widget=resizes-content",
+    );
+  });
+
+  it("is a no-op when the tag is already correct", () => {
+    const meta = setViewportMeta(CANONICAL);
+    ensureViewportMeta(document);
+    expect(getViewportMetas()).toHaveLength(1);
+    expect(meta.getAttribute("content")).toBe(CANONICAL);
+  });
+
+  it("never creates a duplicate across repeated calls", () => {
+    ensureViewportMeta(document);
+    ensureViewportMeta(document);
+    ensureViewportMeta(document);
+    expect(getViewportMetas()).toHaveLength(1);
+  });
+
+  it("does nothing when no document is available (SSR guard)", () => {
+    expect(() => ensureViewportMeta(null)).not.toThrow();
+    expect(getViewportMetas()).toHaveLength(0);
+  });
+});

--- a/src/util/viewport.test.ts
+++ b/src/util/viewport.test.ts
@@ -14,7 +14,7 @@ function getViewportMetas() {
   ) as HTMLMetaElement[];
 }
 
-function setViewportMeta(content) {
+function setViewportMeta(content: string) {
   const meta = document.createElement("meta");
   meta.setAttribute("name", "viewport");
   meta.setAttribute("content", content);

--- a/src/util/viewport.ts
+++ b/src/util/viewport.ts
@@ -1,0 +1,114 @@
+/**
+ * Ensures the document carries the viewport meta tag the design system
+ * depends on. In particular, `interactive-widget=resizes-content` opts mobile
+ * browsers into resizing the viewport (rather than overlaying) when the
+ * on-screen keyboard appears, which our layout/positioning code assumes.
+ *
+ * This module runs as a side effect on import so every consumer of the
+ * package (and Storybook, which imports it from `.storybook/preview.js`)
+ * gets the tag without any setup. It is intentionally NOT part of the public
+ * API — none of these functions are re-exported from `src/index.ts`.
+ *
+ * Behavior: the design system owns the directives listed in
+ * `ENSURE_META_CONTENT` and upserts each one — adds it if missing, corrects it
+ * if the value differs, leaves it if already right. Any other directive a
+ * consumer has set (e.g. `viewport-fit=cover`) is preserved in place.
+ *
+ * Accessibility guardrail: never add `maximum-scale` or `user-scalable=no` to
+ * `ENSURE_META_CONTENT`. Those disable pinch-to-zoom and violate WCAG 1.4.4.
+ */
+
+// The directives the design system manages. Also used verbatim as the content
+// for a brand-new tag. Keep this to zoom-safe directives only (see above).
+const ENSURE_META_CONTENT =
+  "width=device-width, initial-scale=1, interactive-widget=resizes-content";
+
+/**
+ * Parse a viewport `content` string into an ordered map of directives.
+ *
+ * Keys are lowercased because viewport directive names are case-insensitive to
+ * browsers; this prevents `Width` and `width` from being treated as distinct
+ * (which would otherwise produce a duplicate). Later duplicate keys win,
+ * matching browser behavior.
+ */
+export function parseViewport(content: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const part of content.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) {
+      // Valueless directive; preserve it as an empty value.
+      map.set(trimmed.toLowerCase(), "");
+      continue;
+    }
+    const key = trimmed.slice(0, eq).trim().toLowerCase();
+    const value = trimmed.slice(eq + 1).trim();
+    if (key) map.set(key, value);
+  }
+  return map;
+}
+
+/** Serialize an ordered map of directives back into a viewport `content` string. */
+export function serializeViewport(map: Map<string, string>): string {
+  return Array.from(map.entries())
+    .map(([key, value]) => (value === "" ? key : `${key}=${value}`))
+    .join(", ");
+}
+
+/**
+ * Given the current viewport `content` (or null/empty when no tag exists),
+ * return the content string that should be applied.
+ *
+ * Pure. Upserts every directive from `ENSURE_META_CONTENT`: adds it when
+ * missing (appended in order), corrects it when the value differs, keeps it
+ * when already correct. Directives the consumer set that we don't manage are
+ * preserved in their original position (`Map.set` keeps insertion order on
+ * update).
+ */
+export function mergeViewportContent(existing: string | null): string {
+  if (!existing || !existing.trim()) {
+    return ENSURE_META_CONTENT;
+  }
+  const map = parseViewport(existing);
+  for (const [key, value] of parseViewport(ENSURE_META_CONTENT)) {
+    map.set(key, value);
+  }
+  return serializeViewport(map);
+}
+
+/**
+ * Ensure a `<meta name="viewport">` tag exists in the document and carries the
+ * managed directives. SSR-safe (no-op without a document), idempotent, and
+ * HMR-safe (never creates a duplicate tag). Targets the first viewport meta if
+ * more than one is present.
+ */
+export function ensureViewportMeta(
+  doc: Document | null | undefined = typeof document !== "undefined"
+    ? document
+    : null,
+): void {
+  if (!doc) return;
+
+  const existingMeta = doc.head.querySelector<HTMLMetaElement>(
+    'meta[name="viewport"]',
+  );
+
+  if (!existingMeta) {
+    const meta = doc.createElement("meta");
+    meta.setAttribute("name", "viewport");
+    meta.setAttribute("content", mergeViewportContent(null));
+    doc.head.appendChild(meta);
+    return;
+  }
+
+  const current = existingMeta.getAttribute("content");
+  const next = mergeViewportContent(current);
+  if (next !== current) {
+    existingMeta.setAttribute("content", next);
+  }
+}
+
+// Run on import. Guarded so importing this module during SSR or in a
+// non-DOM environment is a harmless no-op.
+ensureViewportMeta();

--- a/src/util/viewport.ts
+++ b/src/util/viewport.ts
@@ -89,8 +89,10 @@ export function ensureViewportMeta(
     : null,
 ): void {
   if (!doc) return;
+  const head = doc.head;
+  if (!head) return;
 
-  const existingMeta = doc.head.querySelector<HTMLMetaElement>(
+  const existingMeta = head.querySelector<HTMLMetaElement>(
     'meta[name="viewport"]',
   );
 
@@ -98,7 +100,7 @@ export function ensureViewportMeta(
     const meta = doc.createElement("meta");
     meta.setAttribute("name", "viewport");
     meta.setAttribute("content", mergeViewportContent(null));
-    doc.head.appendChild(meta);
+    head.appendChild(meta);
     return;
   }
 

--- a/src/util/viewport.ts
+++ b/src/util/viewport.ts
@@ -9,7 +9,9 @@
  * gets the tag without any setup. It is intentionally NOT part of the public
  * API — none of these functions are re-exported from `src/index.ts`.
  *
- * Behavior: the design system owns the directives listed in
+ * Behavior: the design system always ensures a default `width=device-width`
+ * when creating a brand-new tag. On existing tags, it preserves any consumer-
+ * provided `width` value. It still owns the directives listed in
  * `ENSURE_META_CONTENT` and upserts each one — adds it if missing, corrects it
  * if the value differs, leaves it if already right. Any other directive a
  * consumer has set (e.g. `viewport-fit=cover`) is preserved in place.
@@ -20,8 +22,10 @@
 
 // The directives the design system manages. Also used verbatim as the content
 // for a brand-new tag. Keep this to zoom-safe directives only (see above).
-const ENSURE_META_CONTENT =
+const DEFAULT_META_CONTENT =
   "width=device-width, initial-scale=1, interactive-widget=resizes-content";
+
+const ENSURE_META_CONTENT = "initial-scale=1, interactive-widget=resizes-content";
 
 /**
  * Parse a viewport `content` string into an ordered map of directives.
@@ -60,17 +64,22 @@ export function serializeViewport(map: Map<string, string>): string {
  * Given the current viewport `content` (or null/empty when no tag exists),
  * return the content string that should be applied.
  *
- * Pure. Upserts every directive from `ENSURE_META_CONTENT`: adds it when
- * missing (appended in order), corrects it when the value differs, keeps it
- * when already correct. Directives the consumer set that we don't manage are
+ * Pure. Returns `DEFAULT_META_CONTENT` when no tag exists. Otherwise preserves
+ * any consumer-provided `width`, inserts the default width when missing, and
+ * upserts every directive from `ENSURE_META_CONTENT`: adds it when missing
+ * (appended in order), corrects it when the value differs, keeps it when
+ * already correct. Directives the consumer set that we don't manage are
  * preserved in their original position (`Map.set` keeps insertion order on
  * update).
  */
 export function mergeViewportContent(existing: string | null): string {
   if (!existing || !existing.trim()) {
-    return ENSURE_META_CONTENT;
+    return DEFAULT_META_CONTENT;
   }
   const map = parseViewport(existing);
+  if (!map.has("width")) {
+    map.set("width", "device-width");
+  }
   for (const [key, value] of parseViewport(ENSURE_META_CONTENT)) {
     map.set(key, value);
   }


### PR DESCRIPTION
Closes NDS-3176
Closes NDS-3209
Closes IMENG-3822
Closes NDS-3171
Closes NDS-3242

## Changes

### Combobox
- remove the focus/blur "fix" that is no longer necessary on item selection
- set a special max height for touch devices, as the dropdown trigger here is an `input`

### useDropdownLayer
- take away all height management from JS
- set `vh` and `dvh` max heights as viewport-relative constraints instead
- clean up code we no longer need
- **add meta tag side effect:** consumers MUST include interactive-widget in the viewport meta tag. 