### PR TITLE
feat(Tabs): allow start and end inline tab content

### DIFF
--- a/src/Tabs/TabsTab.tsx
+++ b/src/Tabs/TabsTab.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useRef } from "react";
-import Row from "../Row";
 import TabsContext from "./context";
 
 export interface TabsTabProps {
@@ -57,14 +56,10 @@ const TabsTab = ({
         onClick={onTabClick}
         data-testid={testId}
       >
-        <Row as="span" gapSize="xs" alignItems="center">
-          {renderStartContent && (
-<Row.Item as="span" shrink>
-  {renderStartContent(isSelected)}
-</Row.Item>
-          )}
-          {hasStatusIndicator && (
-            <Row.Item as="span" shrink>
+        {(renderStartContent || hasStatusIndicator) && (
+          <span className="nds-tabs-startContent">
+            {renderStartContent && renderStartContent(isSelected)}
+            {hasStatusIndicator && (
               <span className="nds-tabs-statusIndicator">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -78,17 +73,15 @@ const TabsTab = ({
                   <circle cx="3" cy="3" r="3" fill="var(--color-successDark)" />
                 </svg>
               </span>
-            </Row.Item>
-          )}
-<Row.Item as="span" shrink>
-  {label}
-</Row.Item>
-          {renderEndContent && (
-            <Row.Item as="span" shrink className="nds-tabs-endContent">
-              {renderEndContent(isSelected)}
-            </Row.Item>
-          )}
-        </Row>
+            )}
+          </span>
+        )}
+        <span className="nds-tabs-label">{label}</span>
+        {renderEndContent && (
+          <span className="nds-tabs-endContent">
+            {renderEndContent(isSelected)}
+          </span>
+        )}
       </button>
     </li>
   );

--- a/src/Tabs/TabsTab.tsx
+++ b/src/Tabs/TabsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import Row from "../Row";
 import TabsContext from "./context";
 
 export interface TabsTabProps {
@@ -10,6 +11,16 @@ export interface TabsTabProps {
   testId?: string;
   /** Optional prop to show an "update" notification dot in the tab */
   hasStatusIndicator?: boolean;
+  /**
+   * Renders arbitrary content (e.g. an icon) at the inline-start of the tab,
+   * before the label. Receives the tab's selected state.
+   */
+  renderStartContent?: (isSelected: boolean) => React.ReactNode;
+  /**
+   * Renders arbitrary content (e.g. a count) at the inline-end of the tab,
+   * after the label. Receives the tab's selected state.
+   */
+  renderEndContent?: (isSelected: boolean) => React.ReactNode;
 }
 
 const TabsTab = ({
@@ -17,6 +28,8 @@ const TabsTab = ({
   tabId,
   testId,
   hasStatusIndicator,
+  renderStartContent,
+  renderEndContent,
 }: TabsTabProps) => {
   const { currentIndex, tabIds, hasPanels, changeTabs, kind } =
     useContext(TabsContext);
@@ -44,22 +57,38 @@ const TabsTab = ({
         onClick={onTabClick}
         data-testid={testId}
       >
-        {hasStatusIndicator && (
-          <span className="nds-tabs-statusIndicator">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="6"
-              height="6"
-              viewBox="0 0 6 6"
-              fill="none"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <circle cx="3" cy="3" r="3" fill="var(--color-successDark)" />
-            </svg>
-          </span>
-        )}
-        <span>{label}</span>
+        <Row as="span" gapSize="xs" alignItems="center">
+          {renderStartContent && (
+            <Row.Item as="span" shrink className="nds-tabs-startContent">
+              {renderStartContent(isSelected)}
+            </Row.Item>
+          )}
+          {hasStatusIndicator && (
+            <Row.Item as="span" shrink>
+              <span className="nds-tabs-statusIndicator">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="6"
+                  height="6"
+                  viewBox="0 0 6 6"
+                  fill="none"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <circle cx="3" cy="3" r="3" fill="var(--color-successDark)" />
+                </svg>
+              </span>
+            </Row.Item>
+          )}
+          <Row.Item as="span" shrink>
+            <span>{label}</span>
+          </Row.Item>
+          {renderEndContent && (
+            <Row.Item as="span" shrink className="nds-tabs-endContent">
+              {renderEndContent(isSelected)}
+            </Row.Item>
+          )}
+        </Row>
       </button>
     </li>
   );

--- a/src/Tabs/TabsTab.tsx
+++ b/src/Tabs/TabsTab.tsx
@@ -80,9 +80,9 @@ const TabsTab = ({
               </span>
             </Row.Item>
           )}
-          <Row.Item as="span" shrink>
-            <span>{label}</span>
-          </Row.Item>
+<Row.Item as="span" shrink>
+  {label}
+</Row.Item>
           {renderEndContent && (
             <Row.Item as="span" shrink className="nds-tabs-endContent">
               {renderEndContent(isSelected)}

--- a/src/Tabs/TabsTab.tsx
+++ b/src/Tabs/TabsTab.tsx
@@ -59,9 +59,9 @@ const TabsTab = ({
       >
         <Row as="span" gapSize="xs" alignItems="center">
           {renderStartContent && (
-            <Row.Item as="span" shrink className="nds-tabs-startContent">
-              {renderStartContent(isSelected)}
-            </Row.Item>
+<Row.Item as="span" shrink>
+  {renderStartContent(isSelected)}
+</Row.Item>
           )}
           {hasStatusIndicator && (
             <Row.Item as="span" shrink>

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -76,7 +76,7 @@
 * Status dot
 */
 .nds-tabs-statusIndicator {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
 }
@@ -109,6 +109,28 @@
     font-size: var(--font-size-default);
     font-family: var(--font-family-default);
     white-space: nowrap;
+
+    display: grid;
+    grid-template-columns: min(0px, min-content) 1fr min(0px, min-content);
+    grid-template-areas: "startContent label endContent";
+    align-items: center;
+    grid-gap: var(--space-xs);
+
+    .nds-tabs-startContent {
+      grid-area: startContent;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .nds-tabs-label {
+      grid-area: label;
+    }
+
+    .nds-tabs-endContent {
+      grid-area: endContent;
+      display: inline-flex;
+      align-items: center;
+    }
 
     &:hover {
       color: var(--theme-primary);
@@ -194,6 +216,7 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      gap: var(--space-xs);
       min-height: 2.5rem; // scale with user font settings
       padding-inline: var(--space-s);
       border-radius: var(--border-radius-m);

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -114,7 +114,13 @@
     grid-template-columns: min(0px, min-content) 1fr min(0px, min-content);
     grid-template-areas: "startContent label endContent";
     align-items: center;
-    grid-gap: var(--space-xs);
+    gap: var(--space-xs);
+
+    // collapse the startContent track (and its gap) when nothing is rendered there
+    &:not(:has(> .nds-tabs-startContent)) {
+      grid-template-columns: 1fr min(0px, min-content);
+      grid-template-areas: "label endContent";
+    }
 
     .nds-tabs-startContent {
       grid-area: startContent;

--- a/src/Tabs/index.scss
+++ b/src/Tabs/index.scss
@@ -79,7 +79,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding-right: var(--space-xxs);
 }
 
 /**

--- a/src/Tabs/index.stories.js
+++ b/src/Tabs/index.stories.js
@@ -3,6 +3,7 @@ import Tabs from "./";
 import TabsList from "./TabsList";
 import TabsPanel from "./TabsPanel";
 import TabsTab from "./TabsTab";
+import Count from "../Count";
 
 const Template = (args) => (
   <Tabs {...args}>
@@ -343,6 +344,88 @@ MultipleSegmentedTabs.parameters = {
     description: {
       story:
         "Renders multiple `segmented` Tabs on the same page to verify that each instance's sliding pill resolves to its own selected tab. Since `anchor-name: --active` is declared at document scope, this story exists to confirm there is no cross-instance interference in practice (try changing the selected tab in each set and observe the pill).",
+    },
+  },
+};
+
+export const WithCustomLabelContent = () => (
+  <div style={{ display: "grid", gap: "1.5rem" }}>
+    <Tabs>
+      <Tabs.List>
+        <Tabs.Tab
+          label="Inbox"
+          tabId="inbox"
+          renderStartContent={() => <span className="narmi-icon-mail" />}
+          renderEndContent={(isSelected) => (
+            <Count value={8} kind={isSelected ? "theme" : "neutral"} />
+          )}
+        />
+        <Tabs.Tab
+          label="Starred"
+          tabId="starred"
+          renderStartContent={() => <span className="narmi-icon-star" />}
+          renderEndContent={(isSelected) => (
+            <Count value={2} kind={isSelected ? "theme" : "neutral"} />
+          )}
+        />
+        <Tabs.Tab
+          label="Sent"
+          tabId="sent"
+          renderStartContent={() => <span className="narmi-icon-send" />}
+        />
+      </Tabs.List>
+      <Tabs.Panel tabId="inbox">
+        <div className="padding--all--s">Inbox</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="starred">
+        <div className="padding--all--s">Starred</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="sent">
+        <div className="padding--all--s">Sent</div>
+      </Tabs.Panel>
+    </Tabs>
+
+    <Tabs kind="segmented">
+      <Tabs.List>
+        <Tabs.Tab
+          label="Inbox"
+          tabId="inbox"
+          renderStartContent={() => <span className="narmi-icon-mail" />}
+          renderEndContent={(isSelected) => (
+            <Count value={8} kind={isSelected ? "theme" : "neutral"} />
+          )}
+        />
+        <Tabs.Tab
+          label="Starred"
+          tabId="starred"
+          renderStartContent={() => <span className="narmi-icon-star" />}
+          renderEndContent={(isSelected) => (
+            <Count value={2} kind={isSelected ? "theme" : "neutral"} />
+          )}
+        />
+        <Tabs.Tab
+          label="Sent"
+          tabId="sent"
+          renderStartContent={() => <span className="narmi-icon-send" />}
+        />
+      </Tabs.List>
+      <Tabs.Panel tabId="inbox">
+        <div className="padding--all--s">Inbox</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="starred">
+        <div className="padding--all--s">Starred</div>
+      </Tabs.Panel>
+      <Tabs.Panel tabId="sent">
+        <div className="padding--all--s">Sent</div>
+      </Tabs.Panel>
+    </Tabs>
+  </div>
+);
+WithCustomLabelContent.parameters = {
+  docs: {
+    description: {
+      story:
+        "Use `renderStartContent` and `renderEndContent` on `Tabs.Tab` to render arbitrary inline-start / inline-end content such as an icon or a `Count`. Each render prop receives the tab's `isSelected` state, so content can respond to selection. Shown here with both the `default` and `segmented` kinds.",
     },
   },
 };


### PR DESCRIPTION
Closes NDS-3240

Allows arbitrary JSX in the inline start and end areas of a tab in `Tabs.Tab`. The render functions provide `isSelected` should you want to do anything conditionally based on state in your custom content.

<img width="527" height="321" alt="Screenshot 2026-08-31 at 4 32 14 PM" src="https://github.com/user-attachments/assets/75f82821-d55c-4556-9cdc-e34545afb8c1" />

