### PR TITLE
fix(Chip): add isLabelSelectable prop

### DIFF
--- a/src/Chip/index.scss
+++ b/src/Chip/index.scss
@@ -67,6 +67,10 @@
 
 .nds-chip-label {
   user-select: none;
+
+  &--selectable {
+    user-select: text;
+  }
 }
 
 .nds-chip-icon {

--- a/src/Chip/index.stories.js
+++ b/src/Chip/index.stories.js
@@ -42,6 +42,19 @@ export const WithBorder = () => (
   </>
 );
 
+export const SelectableLabel = () => (
+  <>
+    <p>
+      By default a Chip&apos;s label is not selectable, since Chips are
+      typically short filter/status tags. When the{" "}
+      <code>isLabelSelectable</code> prop is set to true, the label text can be
+      selected/copied — useful when a Chip surfaces content like an error
+      message.
+    </p>
+    <Chip kind="error" label="Selectable error text" isLabelSelectable={true} />
+  </>
+);
+
 export const CustomIcon = () => (
   <>
     <p>

--- a/src/Chip/index.test.tsx
+++ b/src/Chip/index.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Chip from "./";
+
+describe("Chip", () => {
+  it("renders the label as non-selectable by default", () => {
+    render(<Chip label="Status" />);
+    const label = screen.getByText("Status");
+    expect(label).toHaveClass("nds-chip-label");
+    expect(label).not.toHaveClass("nds-chip-label--selectable");
+  });
+
+  it("makes the label selectable when isLabelSelectable is true", () => {
+    render(<Chip label="Unknown Error" isLabelSelectable />);
+    const label = screen.getByText("Unknown Error");
+    expect(label).toHaveClass("nds-chip-label--selectable");
+  });
+});

--- a/src/Chip/index.tsx
+++ b/src/Chip/index.tsx
@@ -36,6 +36,12 @@ export interface ChipProps {
   hasBorder?: boolean;
   /** Defines if the label is visible */
   isLabelVisible?: boolean;
+  /**
+   * Allows the label text to be selected/copied when `true`. Off by default since Chips are
+   * typically short filter/status tags where accidental text selection is undesirable, but
+   * some Chips (e.g. surfacing an error message) carry content a user may want to copy.
+   */
+  isLabelSelectable?: boolean;
 }
 
 /**
@@ -54,6 +60,7 @@ const Chip = ({
   endIcon,
   hasBorder = false,
   isLabelVisible = true,
+  isLabelSelectable = false,
 }: ChipProps) => {
   const isButton = typeof onClick === "function";
   const isDismissable = !isButton && typeof onDismiss === "function";
@@ -88,7 +95,15 @@ const Chip = ({
         )}
         {isLabelVisible && (
           <Row.Item shrink>
-            <div className="nds-chip-label whiteSpace--truncate">{label}</div>
+            <div
+              className={cc([
+                "nds-chip-label",
+                "whiteSpace--truncate",
+                { "nds-chip-label--selectable": isLabelSelectable },
+              ])}
+            >
+              {label}
+            </div>
           </Row.Item>
         )}
         {count && (


### PR DESCRIPTION
## Summary
Chip labels currently have `user-select: none` unconditionally, which is right for typical filter/status tags but blocks copying text on the rare Chip that surfaces real content — e.g. an error title in a failure card. Adds an opt-in `isLabelSelectable` prop (default `false`, preserving current behavior for all existing consumers) rather than changing the default everywhere.

## Test plan
- [x] `npx vitest run src/Chip/index.test.tsx` passes
- [x] `npx tsc -p tsconfig.check.json` passes
- [x] `npx eslint src/Chip/` passes
- [x] `npx prettier --check src/Chip/` passes
- [x] Added a `SelectableLabel` story for visual verification