### PR TITLE
feat(Table): allow programmatic column hiding

### DIFF
--- a/src/Table/Cell.tsx
+++ b/src/Table/Cell.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import cc from "classcat";
 import { isBreakpointSatisfied } from "./util/breakpoint";
 import ColVisibilityContext from "./util/colVisibilityContext";
 
@@ -16,15 +17,36 @@ export interface CellProps {
 }
 
 const Cell = ({ children, textAlign = "start", _colIndex = 0 }: CellProps) => {
-  const { currentBreakpoint, colVisibility } = useContext(ColVisibilityContext);
+  const { currentBreakpoint, colVisibility, isAnimated } =
+    useContext(ColVisibilityContext);
   const minBreakpoint = colVisibility[_colIndex];
-  const isVisible = isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
+  // `"none"` is only hidden in animated mode; in legacy mode it falls back to
+  // always-visible (matching the parent Table's `console.error` warning).
+  const isVisible =
+    minBreakpoint === "none"
+      ? !isAnimated
+      : isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
 
-  return isVisible ? (
-    <div className="nds-table-cell" role="cell" style={{ textAlign }}>
+  // Default behavior: hidden columns are removed from the DOM entirely.
+  // In animated mode hidden cells must stay in flow (collapsed) so their
+  // tracks can interpolate and auto-placement stays aligned to the tracks.
+  if (!isVisible && !isAnimated) return null;
+
+  const isCollapsed = !isVisible;
+
+  return (
+    <div
+      className={cc([
+        "nds-table-cell",
+        { "nds-table-cell--collapsed": isCollapsed },
+      ])}
+      role="cell"
+      aria-hidden={isCollapsed || undefined}
+      style={{ textAlign }}
+    >
       {children}
     </div>
-  ) : null;
+  );
 };
 
 export default Cell;

--- a/src/Table/Cell.tsx
+++ b/src/Table/Cell.tsx
@@ -27,9 +27,11 @@ const Cell = ({ children, textAlign = "start", _colIndex = 0 }: CellProps) => {
       ? !isAnimated
       : isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
 
-  // Default behavior: hidden columns are removed from the DOM entirely.
-  // In animated mode hidden cells must stay in flow (collapsed) so their
-  // tracks can interpolate and auto-placement stays aligned to the tracks.
+  // Legacy (deprecated string colLayout): hidden columns are removed from the
+  // DOM entirely. In animated mode (array colLayout) hidden cells must stay in
+  // flow (collapsed) so their tracks can interpolate and auto-placement stays
+  // aligned to the tracks. This `return null` branch goes away when string
+  // layouts are removed in the next major version.
   if (!isVisible && !isAnimated) return null;
 
   const isCollapsed = !isVisible;

--- a/src/Table/HeaderCell.test.tsx
+++ b/src/Table/HeaderCell.test.tsx
@@ -28,7 +28,11 @@ describe("HeaderCell", () => {
 
     renderHeaderCell({ isAnimated: true, colVisibility: ["none"], onClick });
 
-    const header = screen.getByRole("columnheader", { name: "Actions" });
+    // Collapsed cells stay in the DOM but are `aria-hidden`, which both
+    // excludes them from the default accessibility tree and empties their
+    // accessible name. Query with `hidden: true` (and no name) to reach the
+    // intentionally inaccessible header button.
+    const header = screen.getByRole("columnheader", { hidden: true });
     expect(header).toBeDisabled();
 
     fireEvent.click(header);

--- a/src/Table/HeaderCell.test.tsx
+++ b/src/Table/HeaderCell.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import HeaderCell from "./HeaderCell";
+import ColVisibilityContext from "./util/colVisibilityContext";
+
+const renderHeaderCell = ({
+  isAnimated,
+  colVisibility,
+  onClick,
+}: {
+  isAnimated: boolean;
+  colVisibility: ["*" | "none"];
+  onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
+}) =>
+  render(
+    <ColVisibilityContext.Provider
+      value={{ currentBreakpoint: "l", colVisibility, isAnimated }}
+    >
+      <HeaderCell _colIndex={0} onClick={onClick}>
+        Actions
+      </HeaderCell>
+    </ColVisibilityContext.Provider>,
+  );
+
+describe("HeaderCell", () => {
+  it("disables collapsed header buttons in animated mode", () => {
+    const onClick = vi.fn();
+
+    renderHeaderCell({ isAnimated: true, colVisibility: ["none"], onClick });
+
+    const header = screen.getByRole("columnheader", { name: "Actions" });
+    expect(header).toBeDisabled();
+
+    fireEvent.click(header);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("keeps visible header buttons interactive", () => {
+    const onClick = vi.fn();
+
+    renderHeaderCell({ isAnimated: true, colVisibility: ["*"], onClick });
+
+    const header = screen.getByRole("columnheader", { name: "Actions" });
+    expect(header).not.toBeDisabled();
+
+    fireEvent.click(header);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/Table/HeaderCell.tsx
+++ b/src/Table/HeaderCell.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import cc from "classcat";
 import { isBreakpointSatisfied } from "./util/breakpoint";
 import ColVisibilityContext from "./util/colVisibilityContext";
 
@@ -30,18 +31,33 @@ const HeaderCell = ({
   onClick,
   _colIndex = 0,
 }: HeaderCellProps) => {
-  const { currentBreakpoint, colVisibility } = useContext(ColVisibilityContext);
+  const { currentBreakpoint, colVisibility, isAnimated } =
+    useContext(ColVisibilityContext);
   const minBreakpoint = colVisibility[_colIndex];
-  const isVisible = isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
+  // `"none"` is only hidden in animated mode; in legacy mode it falls back to
+  // always-visible (matching the parent Table's `console.error` warning).
+  const isVisible =
+    minBreakpoint === "none"
+      ? !isAnimated
+      : isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
   const isButton = typeof onClick === "function";
 
-  if (!isVisible) return null;
+  // Default behavior: hidden columns are removed from the DOM entirely.
+  // In animated mode hidden cells must stay in flow (collapsed) so their
+  // tracks can interpolate and auto-placement stays aligned to the tracks.
+  if (!isVisible && !isAnimated) return null;
+
+  const isCollapsed = !isVisible;
 
   return isButton ? (
     <button
       aria-live="polite"
+      aria-hidden={isCollapsed || undefined}
       onClick={onClick}
-      className="nds-table-cell button--reset"
+      className={cc([
+        "nds-table-cell button--reset",
+        { "nds-table-cell--collapsed": isCollapsed },
+      ])}
       role="columnheader"
       style={{ textAlign }}
     >
@@ -50,7 +66,11 @@ const HeaderCell = ({
   ) : (
     <div
       aria-live="polite"
-      className="nds-table-cell"
+      aria-hidden={isCollapsed || undefined}
+      className={cc([
+        "nds-table-cell",
+        { "nds-table-cell--collapsed": isCollapsed },
+      ])}
       role="columnheader"
       style={{ textAlign }}
     >

--- a/src/Table/HeaderCell.tsx
+++ b/src/Table/HeaderCell.tsx
@@ -42,9 +42,11 @@ const HeaderCell = ({
       : isBreakpointSatisfied(minBreakpoint, currentBreakpoint);
   const isButton = typeof onClick === "function";
 
-  // Default behavior: hidden columns are removed from the DOM entirely.
-  // In animated mode hidden cells must stay in flow (collapsed) so their
-  // tracks can interpolate and auto-placement stays aligned to the tracks.
+  // Legacy (deprecated string colLayout): hidden columns are removed from the
+  // DOM entirely. In animated mode (array colLayout) hidden cells must stay in
+  // flow (collapsed) so their tracks can interpolate and auto-placement stays
+  // aligned to the tracks. This `return null` branch goes away when string
+  // layouts are removed in the next major version.
   if (!isVisible && !isAnimated) return null;
 
   const isCollapsed = !isVisible;

--- a/src/Table/HeaderCell.tsx
+++ b/src/Table/HeaderCell.tsx
@@ -55,7 +55,8 @@ const HeaderCell = ({
     <button
       aria-live="polite"
       aria-hidden={isCollapsed || undefined}
-      onClick={onClick}
+      disabled={isCollapsed}
+      onClick={isCollapsed ? undefined : onClick}
       className={cc([
         "nds-table-cell button--reset",
         { "nds-table-cell--collapsed": isCollapsed },

--- a/src/Table/index.scss
+++ b/src/Table/index.scss
@@ -1,8 +1,22 @@
 .nds-table {
   --pinned-column-border: oklch(0% 0 0 / 0.06);
+  --animation-duration: 400ms;
   display: grid;
   grid-auto-rows: auto;
   row-gap: 0;
+}
+
+// Only animated (array-layout) tables transition their column tracks. Legacy
+// string layouts change track counts, which cannot interpolate.
+.nds-table--animated {
+  transition: grid-template-columns var(--animation-duration)
+    cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nds-table--animated {
+    transition: none;
+  }
 }
 
 .nds-table-scroll-container {
@@ -67,6 +81,8 @@
   align-items: center;
   padding: var(--space-xxs) var(--space-xs);
   overflow: hidden;
+  opacity: 1;
+  transition: opacity var(--animation-duration) cubic-bezier(0.4, 0, 0.2, 1);
 
   // default wrapping behavior
   white-space: nowrap;
@@ -95,6 +111,15 @@
     color: var(--font-color-primary);
     text-overflow: unset;
   }
+}
+
+// Collapsed cells in animated mode stay mounted at `minmax(0, 0fr)`.
+// Force `overflow: hidden` so their content is clipped as the track reaches
+// zero — this must win over the `:has([class^="nds-tableField"])` exception
+// above (equal specificity, later source order).
+.nds-table-cell.nds-table-cell--collapsed {
+  overflow: hidden;
+  opacity: 0;
 }
 
 // Pinned start column

--- a/src/Table/index.stories.js
+++ b/src/Table/index.stories.js
@@ -158,6 +158,16 @@ ColumnLayout.parameters = {
   docs: {
     description: {
       story:
+        "> **Deprecated interface.** Passing `colLayout` values as " +
+        "`grid-template-columns` **strings** (shown here) is deprecated and will " +
+        "be removed in the next major version. Provide a per-column **track " +
+        "array** parallel to `colVisibility` instead — e.g. " +
+        '`"repeat(4, 1fr) min-content"` becomes ' +
+        '`["1fr", "1fr", "1fr", "1fr", "min-content"]` (list hidden ' +
+        "columns too; their width is used when shown and collapses to `0fr` when " +
+        "hidden). Only the array form animates and supports `colVisibility: " +
+        '"none"`. See the "Animated columns" and "Programmatically hiding a ' +
+        'column" stories.\n\n' +
         "Grid layouts configured per breakpoint using `colLayout`:\n\n" +
         "- **Small**: `2fr 1fr 1fr max-content`\n" +
         "- **Medium**: `minmax(200px, 1fr) max-content 1fr min-content`\n" +

--- a/src/Table/index.stories.js
+++ b/src/Table/index.stories.js
@@ -570,6 +570,165 @@ ScrollableWithPinnedColumns.parameters = {
   },
 };
 
+export const AnimatedColumns = () => (
+  <Table
+    colVisibility={["*", "*", "m", "m", "*"]}
+    colLayout={{
+      s: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+      m: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+      l: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+    }}
+  >
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell>Name</Table.HeaderCell>
+        <Table.HeaderCell>Email</Table.HeaderCell>
+        <Table.HeaderCell>Role</Table.HeaderCell>
+        <Table.HeaderCell>Department</Table.HeaderCell>
+        <Table.HeaderCell>Actions</Table.HeaderCell>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>John Doe</Table.Cell>
+        <Table.Cell>john@example.com</Table.Cell>
+        <Table.Cell>Admin</Table.Cell>
+        <Table.Cell>Engineering</Table.Cell>
+        <Table.Cell>
+          <button>Edit</button>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Jane Smith</Table.Cell>
+        <Table.Cell>jane@example.com</Table.Cell>
+        <Table.Cell>User</Table.Cell>
+        <Table.Cell>Marketing</Table.Cell>
+        <Table.Cell>
+          <button>Edit</button>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Bob Johnson</Table.Cell>
+        <Table.Cell>bob@example.com</Table.Cell>
+        <Table.Cell>Manager</Table.Cell>
+        <Table.Cell>Sales</Table.Cell>
+        <Table.Cell>
+          <button>Edit</button>
+        </Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
+);
+AnimatedColumns.parameters = {
+  docs: {
+    description: {
+      story:
+        "Provide `colLayout` as a **track array** per breakpoint (parallel to " +
+        "`colVisibility`) to opt into animated column show/hide. `fr` widths are " +
+        "wrapped in `minmax(0, …)` internally so hidden columns can collapse to " +
+        "`minmax(0, 0fr)` and interpolate. Resize the viewport across the `m` " +
+        "breakpoint: the Role and Department columns animate open/closed while " +
+        "the track count stays constant. The trailing `min-content` Actions " +
+        "column stays visible and does not interpolate. Honors " +
+        "`prefers-reduced-motion: reduce`.",
+    },
+  },
+};
+
+/**
+ * Toggle a column's visibility at runtime by flipping its `colVisibility` entry
+ * to/from `"none"`. This only animates when `colLayout` is supplied as track
+ * arrays (see the story description).
+ */
+export const ProgrammaticallyHidingAColumn = () => {
+  const [departmentHidden, setDepartmentHidden] = useState(false);
+
+  // "Department" is column index 3. Toggling it between "none" (hidden) and
+  // "*" (always visible) animates the column open/closed.
+  const colVisibility = ["*", "*", "*", departmentHidden ? "none" : "*", "*"];
+
+  return (
+    <div>
+      <button
+        className="button button--primary"
+        onClick={() => setDepartmentHidden((hidden) => !hidden)}
+        style={{ marginBottom: 16 }}
+      >
+        {departmentHidden ? "Show" : "Hide"} Department column
+      </button>
+      <Table
+        colVisibility={colVisibility}
+        colLayout={{
+          s: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+          m: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+          l: ["1fr", "1fr", "1fr", "1fr", "min-content"],
+        }}
+      >
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Name</Table.HeaderCell>
+            <Table.HeaderCell>Email</Table.HeaderCell>
+            <Table.HeaderCell>Role</Table.HeaderCell>
+            <Table.HeaderCell>Department</Table.HeaderCell>
+            <Table.HeaderCell>Actions</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>John Doe</Table.Cell>
+            <Table.Cell>john@example.com</Table.Cell>
+            <Table.Cell>Admin</Table.Cell>
+            <Table.Cell>Engineering</Table.Cell>
+            <Table.Cell>
+              <button>Edit</button>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Jane Smith</Table.Cell>
+            <Table.Cell>jane@example.com</Table.Cell>
+            <Table.Cell>User</Table.Cell>
+            <Table.Cell>Marketing</Table.Cell>
+            <Table.Cell>
+              <button>Edit</button>
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Bob Johnson</Table.Cell>
+            <Table.Cell>bob@example.com</Table.Cell>
+            <Table.Cell>Manager</Table.Cell>
+            <Table.Cell>Sales</Table.Cell>
+            <Table.Cell>
+              <button>Edit</button>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+};
+ProgrammaticallyHidingAColumn.storyName = "Programmatically hiding a column";
+ProgrammaticallyHidingAColumn.parameters = {
+  layout: "centered",
+  docs: {
+    description: {
+      story:
+        'Set a column\'s `colVisibility` entry to `"none"` to hide it ' +
+        'programmatically (e.g. from React state), and back to `"*"` or a ' +
+        'breakpoint (`"m"`) to reveal it. The column animates open/closed.\n\n' +
+        '**`"none"` requires the array form of `colLayout`.** You must provide ' +
+        "each breakpoint's layout as a track array parallel to `colVisibility` " +
+        '(e.g. `["1fr", "1fr", "1fr", "1fr", "min-content"]`) rather ' +
+        'than a CSS string (`"repeat(4, 1fr) min-content"`). Only the array ' +
+        "form exposes each column's width individually, which is what lets a " +
+        "single track collapse to `minmax(0, 0fr)` while the total track count " +
+        "stays constant so the grid can interpolate.\n\n" +
+        'If `colLayout` is a string at the current breakpoint, `"none"` falls ' +
+        'back to `"*"` (the column stays visible) and a `console.error` is ' +
+        "logged.",
+    },
+  },
+};
+
 export default {
   title: "Components/Table",
   component: Table,

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -11,8 +11,17 @@ import ColVisibilityContext from "./util/colVisibilityContext";
 import { isBreakpointSatisfied } from "./util/breakpoint";
 import { columnTemplateFromBreakpoints } from "./util/grid";
 
-/** Minimum size at which to show a column. "*" means "all" */
-export type ColMinBreakpoint = "*" | "s" | "m" | "l";
+/**
+ * Minimum size at which to show a column.
+ * - `"*"` — always shown
+ * - `"s" | "m" | "l"` — shown at that viewport breakpoint or larger
+ * - `"none"` — programmatically hidden (never shown)
+ *
+ * `"none"` only collapses/animates when the matching breakpoint's `colLayout`
+ * is provided as a track array (see `ColLayoutConfig`). With a string layout it
+ * falls back to `"*"` and logs a `console.error`.
+ */
+export type ColMinBreakpoint = "*" | "s" | "m" | "l" | "none";
 /** Subset of breakpoints that can be returned by `useBreakpoints` hook */
 export type ViewportBreakpoint = "s" | "m" | "l";
 
@@ -21,11 +30,23 @@ export type ViewportBreakpoint = "s" | "m" | "l";
  */
 export type CSSValue = string;
 
-/** For each breakpoint key, a valid `grid-template-columns` value */
+/**
+ * For each breakpoint key, either:
+ * - a `grid-template-columns` CSS string (e.g. `"repeat(2, 1fr) min-content"`), or
+ * - a per-column track array parallel to `colVisibility`
+ *   (e.g. `["1fr", "1fr", "min-content"]`).
+ *
+ * The array form is required to animate columns open/closed and to use
+ * `"none"` in `colVisibility`: individual tracks can only be collapsed to
+ * `minmax(0, 0fr)` (keeping a constant track count) when each column's width is
+ * known individually.
+ */
+export type ColTrackList = CSSValue[];
+export type ColLayoutValue = CSSValue | ColTrackList;
 export type ColLayoutConfig = {
-  s: CSSValue;
-  m: CSSValue;
-  l: CSSValue;
+  s: ColLayoutValue;
+  m: ColLayoutValue;
+  l: ColLayoutValue;
 };
 
 export interface TableProps {
@@ -40,10 +61,18 @@ export interface TableProps {
    */
   colVisibility: ColMinBreakpoint[];
   /**
-   * Specify a function that returns a `grid-template-columns` CSS value for each breakpoint.
-   * These are "mobile-first", so "m" means "the browser is at m or larger".
+   * Column layout per breakpoint. These are "mobile-first", so "m" means "the
+   * browser is at m or larger".
    *
-   * Each function is provided with a `cols` argument.
+   * Each breakpoint value may be either:
+   * - a `grid-template-columns` CSS string — `"repeat(2, 1fr) min-content"`
+   *   (legacy: hidden columns drop their track and unmount), or
+   * - a per-column track array parallel to `colVisibility` —
+   *   `["1fr", "1fr", "min-content"]` (animated: the track count stays constant
+   *   and hidden columns collapse to `minmax(0, 0fr)` so they can transition).
+   *
+   * The array form is what enables animated show/hide and the `"none"`
+   * `colVisibility` keyword.
    */
   colLayout?: ColLayoutConfig;
   rowDensity?: "default" | "compact";
@@ -90,13 +119,50 @@ const Table = ({
         ? "l"
         : largestSatisfiedBreakpoint;
 
-  const visibleCols: number = colVisibility.filter(
-    (minRequired: ColMinBreakpoint) =>
-      isBreakpointSatisfied(
-        minRequired,
-        currentBreakpoint as ViewportBreakpoint,
-      ),
-  ).length;
+  /**
+   * The layout for the current breakpoint decides the rendering mechanism:
+   * - a track **array** → animated mode (constant track count, hidden columns
+   *   collapse to `minmax(0, 0fr)` and transition; `"none"` is honored).
+   * - a **string** → legacy mode (variable track count, hidden columns drop
+   *   their track and unmount; `"none"` falls back to `"*"`).
+   */
+  const layoutForBreakpoint =
+    colLayout[currentBreakpoint as ViewportBreakpoint];
+  let isAnimated = Array.isArray(layoutForBreakpoint);
+
+  // Animated mode requires one track per column so tracks can interpolate.
+  if (isAnimated && layoutForBreakpoint.length !== colVisibility.length) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Table: colLayout["${currentBreakpoint}"] has ${layoutForBreakpoint.length} ` +
+        `tracks but colVisibility has ${colVisibility.length} columns. ` +
+        `Array layouts must be parallel to colVisibility. ` +
+        `Falling back to non-animated layout for this breakpoint.`,
+    );
+    isAnimated = false;
+  }
+
+  const hasNone = colVisibility.some((min) => min === "none");
+  if (!isAnimated && hasNone) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Table: colVisibility uses "none" but colLayout["${currentBreakpoint}"] ` +
+        `is not a track array. "none" requires an array layout ` +
+        `(e.g. ["1fr", "1fr", "min-content"]) to collapse a single track. ` +
+        `Treating "none" as "*" (always visible) for this breakpoint.`,
+    );
+  }
+
+  /**
+   * Effective visibility for a column at the current breakpoint. `"none"` is
+   * only ever hidden in animated mode; in legacy mode it falls back to `"*"`.
+   */
+  const isColumnVisible = (min: ColMinBreakpoint): boolean =>
+    min === "none"
+      ? !isAnimated
+      : isBreakpointSatisfied(min, currentBreakpoint as ViewportBreakpoint);
+
+  const visibleCols: number = colVisibility.filter(isColumnVisible).length;
 
   const defaultLayout = {
     s: `repeat(${visibleCols}, 1fr)`,
@@ -107,19 +173,46 @@ const Table = ({
   const validLayoutsFromProps = Object.fromEntries(
     Object.entries(colLayout).filter(
       ([, cssVal]) =>
+        // Only string layouts feed the legacy template. Array layouts are
+        // handled separately below.
+        typeof cssVal === "string" &&
         // In browser environments, the CSS global has a `supports` method intended
         // for feature detection. It also returns false if the property name
         // or value passed in is invalid, acting as a validator.
-        CSS?.supports("grid-template-columns", cssVal) ?? true,
+        (CSS?.supports("grid-template-columns", cssVal) ?? true),
     ),
   );
 
   const finalLayout = { ...defaultLayout, ...validLayoutsFromProps };
-  const gridTemplateColumns = columnTemplateFromBreakpoints(
-    currentBreakpoint as ViewportBreakpoint,
-    finalLayout,
-    visibleCols,
-  );
+
+  /**
+   * `<flex>` widths are wrapped in `minmax(0, …)` so a track can actually reach
+   * zero even when its cell content has an intrinsic min-size, and so both
+   * endpoints share a type (`<flex>` ↔ `<flex>`) and therefore interpolate.
+   */
+  const toTrack = (w: CSSValue) =>
+    /^\s*\d*\.?\d+fr\s*$/.test(w) ? `minmax(0, ${w.trim()})` : w;
+
+  /**
+   * In animated mode we build the template directly from the array layout so the
+   * track count is always `colVisibility.length` (a prerequisite for grid tracks
+   * to interpolate). Visible columns use their track size; hidden columns
+   * (breakpoint-hidden or `"none"`) collapse to `minmax(0, 0fr)`.
+   */
+  const gridTemplateColumns =
+    isAnimated && Array.isArray(layoutForBreakpoint)
+      ? colVisibility
+          .map((min, i) =>
+            isColumnVisible(min)
+              ? toTrack(layoutForBreakpoint[i])
+              : "minmax(0, 0fr)",
+          )
+          .join(" ")
+      : columnTemplateFromBreakpoints(
+          currentBreakpoint as ViewportBreakpoint,
+          finalLayout,
+          visibleCols,
+        );
 
   const isPinnedStart = pinColumns === "start" || pinColumns === "both";
   const isPinnedEnd = pinColumns === "end" || pinColumns === "both";
@@ -130,6 +223,7 @@ const Table = ({
       value={{
         colVisibility,
         currentBreakpoint: currentBreakpoint as ViewportBreakpoint,
+        isAnimated,
       }}
     >
       <div
@@ -139,6 +233,7 @@ const Table = ({
           `nds-table--${rowDensity}`,
           `nds-table--${kind}`,
           {
+            "nds-table--animated": isAnimated,
             "nds-table--pinned-start": isPinnedStart,
             "nds-table--pinned-end": isPinnedEnd,
           },

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -31,18 +31,27 @@ export type ViewportBreakpoint = "s" | "m" | "l";
 export type CSSValue = string;
 
 /**
- * For each breakpoint key, either:
- * - a `grid-template-columns` CSS string (e.g. `"repeat(2, 1fr) min-content"`), or
- * - a per-column track array parallel to `colVisibility`
- *   (e.g. `["1fr", "1fr", "min-content"]`).
- *
- * The array form is required to animate columns open/closed and to use
- * `"none"` in `colVisibility`: individual tracks can only be collapsed to
- * `minmax(0, 0fr)` (keeping a constant track count) when each column's width is
- * known individually.
+ * A per-column track array parallel to `colVisibility`
+ * (e.g. `["1fr", "1fr", "min-content"]`). The recommended layout form: only
+ * arrays keep a constant track count, so hidden columns can animate and
+ * `colVisibility: "none"` works.
  */
 export type ColTrackList = CSSValue[];
-export type ColLayoutValue = CSSValue | ColTrackList;
+
+/**
+ * A raw `grid-template-columns` CSS string (e.g. `"repeat(2, 1fr) min-content"`).
+ *
+ * @deprecated Use a per-column track array instead (see {@link ColTrackList}).
+ * String layouts can't animate or support `colVisibility: "none"`, and are
+ * removed in the next major version.
+ */
+export type LegacyColLayoutString = CSSValue;
+
+/**
+ * For each breakpoint key, either a {@link ColTrackList} (recommended) or a
+ * {@link LegacyColLayoutString} (deprecated).
+ */
+export type ColLayoutValue = ColTrackList | LegacyColLayoutString;
 export type ColLayoutConfig = {
   s: ColLayoutValue;
   m: ColLayoutValue;
@@ -61,18 +70,15 @@ export interface TableProps {
    */
   colVisibility: ColMinBreakpoint[];
   /**
-   * Column layout per breakpoint. These are "mobile-first", so "m" means "the
-   * browser is at m or larger".
+   * Column layout per breakpoint (mobile-first: "m" means "m or larger").
    *
-   * Each breakpoint value may be either:
-   * - a `grid-template-columns` CSS string — `"repeat(2, 1fr) min-content"`
-   *   (legacy: hidden columns drop their track and unmount), or
-   * - a per-column track array parallel to `colVisibility` —
-   *   `["1fr", "1fr", "min-content"]` (animated: the track count stays constant
-   *   and hidden columns collapse to `minmax(0, 0fr)` so they can transition).
+   * Provide each value as a per-column track array parallel to `colVisibility`,
+   * e.g. `["1fr", "1fr", "min-content"]`. This keeps the track count constant so
+   * hidden columns can animate open/closed and `colVisibility: "none"` works.
    *
-   * The array form is what enables animated show/hide and the `"none"`
-   * `colVisibility` keyword.
+   * @deprecated Passing a `grid-template-columns` string (e.g.
+   * `"repeat(4, 1fr) min-content"`) is deprecated and removed in the next major.
+   * Use an array instead: `["1fr", "1fr", "1fr", "1fr", "min-content"]`.
    */
   colLayout?: ColLayoutConfig;
   rowDensity?: "default" | "compact";
@@ -125,6 +131,11 @@ const Table = ({
    *   collapse to `minmax(0, 0fr)` and transition; `"none"` is honored).
    * - a **string** → legacy mode (variable track count, hidden columns drop
    *   their track and unmount; `"none"` falls back to `"*"`).
+   *
+   * NOTE: `isAnimated` and the legacy (string) branch exist only to keep the
+   * deprecated string `colLayout` form working. Once string layouts are removed
+   * in the next major version, every table is array-based/animated, this flag is
+   * always `true`, and both the flag and the legacy branch can be deleted.
    */
   const layoutForBreakpoint =
     colLayout[currentBreakpoint as ViewportBreakpoint];

--- a/src/Table/util/breakpoint.test.ts
+++ b/src/Table/util/breakpoint.test.ts
@@ -20,4 +20,10 @@ describe("isBreakpointSatisfied", () => {
     expect(isBreakpointSatisfied("s", "l")).toBe(true);
     expect(isBreakpointSatisfied("m", "l")).toBe(true);
   });
+
+  it('should always return false when minRequired is "none"', () => {
+    expect(isBreakpointSatisfied("none", "s")).toBe(false);
+    expect(isBreakpointSatisfied("none", "m")).toBe(false);
+    expect(isBreakpointSatisfied("none", "l")).toBe(false);
+  });
 });

--- a/src/Table/util/breakpoint.ts
+++ b/src/Table/util/breakpoint.ts
@@ -13,6 +13,8 @@ const BREAKPOINT_ORDER = {
  * Determines if a current viewport breakpoint satisfies a minimum required breakpoint.
  * Uses "mobile-first" logic where a larger viewport satisfies smaller breakpoint requirements.
  * For example: `l` viewport satisfies `m` minimum requirement.
+ *
+ * `"*"` is always satisfied; `"none"` is never satisfied.
  */
 export const isBreakpointSatisfied = (
   minRequired: ColMinBreakpoint,
@@ -20,4 +22,6 @@ export const isBreakpointSatisfied = (
 ): boolean =>
   minRequired === "*"
     ? true
-    : BREAKPOINT_ORDER[current] >= BREAKPOINT_ORDER[minRequired];
+    : minRequired === "none"
+      ? false
+      : BREAKPOINT_ORDER[current] >= BREAKPOINT_ORDER[minRequired];

--- a/src/Table/util/colVisibilityContext.ts
+++ b/src/Table/util/colVisibilityContext.ts
@@ -4,6 +4,12 @@ import type { ColMinBreakpoint, ViewportBreakpoint } from "..";
 export interface ColVisibilityContextProps {
   currentBreakpoint: ViewportBreakpoint;
   colVisibility: ColMinBreakpoint[];
+  /**
+   * When true, the current breakpoint uses an array (animated) layout: hidden
+   * cells stay mounted (collapsed) so their tracks can animate to/from
+   * `minmax(0, 0fr)` instead of being removed from the grid.
+   */
+  isAnimated: boolean;
 }
 
 /**
@@ -13,6 +19,7 @@ export interface ColVisibilityContextProps {
 const ColVisibilityContext = createContext<ColVisibilityContextProps>({
   currentBreakpoint: "l",
   colVisibility: ["*"],
+  isAnimated: false,
 });
 
 export default ColVisibilityContext;

--- a/src/Table/util/grid.ts
+++ b/src/Table/util/grid.ts
@@ -6,6 +6,9 @@ import type { ColLayoutConfig, CSSValue, ViewportBreakpoint } from "..";
  *
  * Only string (legacy) layouts are consumed here; array layouts are handled by
  * the animated code path in the `Table` component.
+ *
+ * @deprecated Supports the deprecated string `colLayout` form only. Removed with
+ * string layouts in the next major version.
  */
 export const columnTemplateFromBreakpoints = (
   currentBreakpoint: ViewportBreakpoint,

--- a/src/Table/util/grid.ts
+++ b/src/Table/util/grid.ts
@@ -3,6 +3,9 @@ import type { ColLayoutConfig, CSSValue, ViewportBreakpoint } from "..";
 /**
  * Determine the final `grid-template-columns` value to apply
  * to a rowgroup element.
+ *
+ * Only string (legacy) layouts are consumed here; array layouts are handled by
+ * the animated code path in the `Table` component.
  */
 export const columnTemplateFromBreakpoints = (
   currentBreakpoint: ViewportBreakpoint,
@@ -10,8 +13,9 @@ export const columnTemplateFromBreakpoints = (
   visibleCols: number,
 ): CSSValue => {
   let gridTemplateColumns = `repeat(${visibleCols}, 1fr)`;
-  if (colLayout[currentBreakpoint]) {
-    gridTemplateColumns = colLayout[currentBreakpoint];
+  const layout = colLayout[currentBreakpoint];
+  if (typeof layout === "string" && layout) {
+    gridTemplateColumns = layout;
   }
   return gridTemplateColumns;
 };


### PR DESCRIPTION
Closes NDS-3232

Support programmatic column showing and hiding in `Table` with a nice CSS transition. 

**You must use the new array format for defining column tracks in `colLayout` in order to opt-in to transitions and the "none" visibility feature**

### Changes

- update `colVisibility` interface to include a `"none"` keyword, which force hides the given column
- introduce an opt-in array format for defining column tracks on `Table`. **required for the transition**
- add warnings & docs for array format requirement
- add a collapsed variant to `Table.Cell` styles with the appropriate transitions

https://github.com/user-attachments/assets/8b08d377-cd06-424f-ad12-c9748b6c6c51

