### PR TITLE
fix(Select): ensure layer el receives select list class

### DIFF
--- a/issue-test-cases/NDS-3176-TwoSelectsInARow.stories.js
+++ b/issue-test-cases/NDS-3176-TwoSelectsInARow.stories.js
@@ -1,0 +1,83 @@
+import React from "react";
+import Select from "src/Select";
+
+const storyDescription =
+  "Reproduction for NDS-3176. Two `Select` inputs sit side-by-side in a " +
+  "row inside a tall, vertically scrollable page. Tall spacers above and " +
+  "below keep the row mid-document so it can be scrolled toward the top or " +
+  "bottom edge of the viewport. Scrolling changes the space available " +
+  "above/below the trigger, which exercises the `position-try` fallbacks " +
+  "wired up by `useDropdownLayer`: `--nds-dropdown-above` flips the layer " +
+  "above the trigger when space below is tight, `flip-inline` shifts it on " +
+  "the cross axis when it would overflow horizontally, and " +
+  "`position-try-order: most-height` clamps the menu to the tallest " +
+  "available slot. Open the first (long) select near the bottom of the " +
+  "viewport to force the flip-above case, and near the top to keep it " +
+  "below.";
+
+// ~30 options so the open menu overflows a typical viewport height and the
+// browser must choose a `position-try` fallback / clamp the menu height.
+const longOptions = Array.from({ length: 30 }, (_, i) => {
+  const label = `Option ${String(i + 1).padStart(2, "0")}`;
+  const value = `option-${i + 1}`;
+  return (
+    <Select.Item key={value} value={value} searchValue={label}>
+      {label}
+    </Select.Item>
+  );
+});
+
+const shortOptions = Array.from({ length: 8 }, (_, i) => {
+  const label = `Choice ${String.fromCharCode(65 + i)}`;
+  const value = `choice-${i + 1}`;
+  return (
+    <Select.Item key={value} value={value} searchValue={label}>
+      {label}
+    </Select.Item>
+  );
+});
+
+/**
+ * Full-height scrollable page. Tall spacers above and below the row of
+ * selects push the row into the middle of a long document so it can be
+ * scrolled to either viewport edge, triggering the `position-try`
+ * fallbacks on the open dropdown layer.
+ */
+const ScrollableLayout = (Story) => (
+  <div
+    style={{
+      minHeight: "100vh",
+      backgroundColor: "var(--bgColor-white, #fff)",
+      padding: "0 16px",
+    }}
+  >
+    <div style={{ height: "90vh" }} />
+    <Story />
+    <div style={{ height: "90vh" }} />
+  </div>
+);
+
+export const TwoSelectsInARow = () => (
+  <>
+    <div className="margin--y--s">
+      <Select label="Select one">{longOptions}</Select>
+    </div>
+    <div className="margin--y--s">
+      <Select label="Select two">{shortOptions}</Select>
+    </div>
+  </>
+);
+TwoSelectsInARow.decorators = [ScrollableLayout];
+
+export default {
+  title: "NDS-3176 Two selects in a row",
+  tags: ["!autodocs", "NDS-3176"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component: storyDescription,
+      },
+    },
+  },
+};

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -408,10 +408,13 @@ function Select({
       </div>
       <Error error={errorText} />
 
-      <div {...layerProps} ref={layerProps.ref as React.Ref<HTMLDivElement>}>
+      <div
+        className="nds-select-list"
+        {...layerProps}
+        ref={layerProps.ref as React.Ref<HTMLDivElement>}
+      >
         <div
           className={cc([
-            "nds-select-list",
             "bgColor--white",
             {
               "nds-select-list--error": !!errorText,


### PR DESCRIPTION
As it turns out, another bug was preventing this from happening, until we recently fixed the bug (6.29.2). We were not applying the `%useDropdownLayer` placeholder to the layer element correctly. This PR fixes it. The hook that returns `layerProps` and the sass placeholder must be applied to the same element.

<img width="372" height="486" alt="Screenshot 2026-09-04 at 5 13 51 PM" src="https://github.com/user-attachments/assets/3f846ad0-0549-43ff-84d6-a97ac6100804" />
