### PR TITLE
test: add interaction tests for chromatic

### DIFF
--- a/src/AnchoredDialog/index.stories.tsx
+++ b/src/AnchoredDialog/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import AnchoredDialog from "./";
 import Button from "../Button";
 import Checkbox from "../Checkbox";
@@ -37,6 +38,47 @@ export const Interactive = InteractiveTemplate.bind({});
 Interactive.args = {
   renderHeader: () => <div>Custom JSX Header</div>,
   children: <div>Dialog content goes here</div>,
+};
+
+/**
+ * Interaction test that opens the AnchoredDialog on trigger click so
+ * Chromatic can snapshot the anchored placement.
+ */
+export const Opens = {
+  name: "Interaction: Opens on trigger click",
+  render: () => <InteractiveTemplate {...Interactive.args} />,
+  play: async ({ canvas, userEvent }) => {
+    // content is not rendered until the dialog opens
+    expect(
+      canvas.queryByText("Dialog content goes here"),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }));
+    await waitFor(() =>
+      expect(canvas.getByText("Dialog content goes here")).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test verifying the dialog closes via its footer button.
+ */
+export const Closes = {
+  name: "Interaction: Closes via footer button",
+  render: () => <InteractiveTemplate {...Interactive.args} />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }));
+    await waitFor(() =>
+      expect(canvas.getByText("Dialog content goes here")).toBeVisible(),
+    );
+
+    await userEvent.click(canvas.getByRole("button", { name: /^close$/i }));
+    await waitFor(() =>
+      expect(
+        canvas.queryByText("Dialog content goes here"),
+      ).not.toBeInTheDocument(),
+    );
+  },
 };
 
 const ChecklistTemplate = (args) => {

--- a/src/AutocompleteModal/index.stories.js
+++ b/src/AutocompleteModal/index.stories.js
@@ -1,10 +1,72 @@
 /* eslint-disable react/jsx-key */
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import AutocompleteModal from "./";
 import Button from "../Button";
 
 // FIXME: code and story for `footerContent`
 // FIXME: code and story for render prop trigger
+
+/**
+ * Reusable picker used by interaction stories.
+ */
+const AssigneePicker = () => {
+  const [selectedValue, setSelectedValue] = useState("Unassigned");
+  return (
+    <div style={{ margin: "8rem" }}>
+      <AutocompleteModal
+        inputLabel="Assignee"
+        trigger={<span>{selectedValue}</span>}
+        onChange={(val) => setSelectedValue(val)}
+      >
+        <AutocompleteModal.Item value="Unassigned" />
+        <AutocompleteModal.Item value="Chris" />
+        <AutocompleteModal.Item value="Nikhil" />
+        <AutocompleteModal.Item value="James" />
+        <AutocompleteModal.Item value="Phil" />
+      </AutocompleteModal>
+    </div>
+  );
+};
+
+/**
+ * Interaction test that opens the AutocompleteModal so Chromatic can
+ * snapshot the popup. Popup content is queried via `screen`.
+ */
+export const Open = {
+  name: "Interaction: Opens on click",
+  render: () => <AssigneePicker />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByTestId("nds-popover-trigger"));
+    await waitFor(() => expect(screen.getByRole("combobox")).toBeVisible());
+  },
+};
+
+/**
+ * Interaction test for the full flow: open, type to filter, select an
+ * item, and verify the trigger reflects the selection.
+ */
+export const FiltersAndSelects = {
+  name: "Interaction: Filters and selects an item",
+  render: () => <AssigneePicker />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByTestId("nds-popover-trigger"));
+
+    const input = await screen.findByRole("combobox");
+    await userEvent.type(input, "Chris");
+
+    await userEvent.click(
+      await screen.findByRole("option", { name: /chris/i }),
+    );
+
+    // popup closes and the trigger reflects the selection
+    await waitFor(() =>
+      expect(canvas.getByTestId("nds-popover-trigger")).toHaveTextContent(
+        "Chris",
+      ),
+    );
+  },
+};
 
 export const Overview = () => {
   const [selectedValue, setSelectedValue] = useState("Unassigned");

--- a/src/Checkbox/index.stories.js
+++ b/src/Checkbox/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import Checkbox from "./";
 import Alert from "../Alert";
 
@@ -8,6 +9,42 @@ export const Overview = Template.bind({});
 Overview.args = {
   label: "I agree to receive spam",
   name: "spam",
+};
+
+/**
+ * Interaction test verifying that clicking the checkbox toggles its
+ * checked state on and back off.
+ */
+export const Toggles = {
+  name: "Interaction: Toggles on click",
+  render: () => <Checkbox label="I agree to receive spam" name="spam" />,
+  play: async ({ canvas, userEvent }) => {
+    const checkbox = canvas.getByRole("checkbox", {
+      name: /i agree to receive spam/i,
+    });
+    expect(checkbox).not.toBeChecked();
+
+    // check
+    await userEvent.click(checkbox);
+    await waitFor(() => expect(checkbox).toBeChecked());
+
+    // uncheck
+    await userEvent.click(checkbox);
+    await waitFor(() => expect(checkbox).not.toBeChecked());
+  },
+};
+
+/**
+ * Interaction test verifying the indeterminate state renders as a
+ * partially checked checkbox.
+ */
+export const Indeterminate = {
+  name: "Interaction: Renders indeterminate state",
+  render: () => <Checkbox label="Select all" name="select-all" indeterminate />,
+  play: async ({ canvas }) => {
+    const checkbox = canvas.getByRole("checkbox", { name: /select all/i });
+    await waitFor(() => expect(checkbox).toBePartiallyChecked());
+  },
 };
 
 export const FullyControlled = () => {

--- a/src/DateInput/index.stories.js
+++ b/src/DateInput/index.stories.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import DateInput from "./";
 import Popover from "../Popover";
 
@@ -14,6 +15,56 @@ const Template = (args) => <DateInput {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Date of Birth",
+};
+
+/**
+ * Interaction test that opens the flatpickr calendar so Chromatic can
+ * snapshot it. The calendar is appended to the document body, so it is
+ * queried via `screen`.
+ */
+export const OpensCalendar = {
+  name: "Interaction: Opens the calendar",
+  render: () => <DateInput label="Select a date" defaultDate="2021-10-22" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    await waitFor(() =>
+      expect(screen.getByLabelText("October 15, 2021")).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for selecting a day. The `onChange` callback receives
+ * the formatted date, which is surfaced in the story for assertion.
+ */
+export const SelectsDate = {
+  name: "Interaction: Selects a date",
+  render: () => {
+    const Wrapper = () => {
+      const [date, setDate] = useState("");
+      return (
+        <>
+          <DateInput
+            label="Select a date"
+            defaultDate="2021-10-22"
+            onChange={setDate}
+          />
+          <div data-testid="selected-date">Selected: {date}</div>
+        </>
+      );
+    };
+    return <Wrapper />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    const day = await screen.findByLabelText("October 15, 2021");
+    await userEvent.click(day);
+    await waitFor(() =>
+      expect(canvas.getByTestId("selected-date")).toHaveTextContent(
+        "2021-10-15",
+      ),
+    );
+  },
 };
 
 export const WithDisabledDates = Template.bind({});

--- a/src/Dialog/index.stories.js
+++ b/src/Dialog/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Dialog from "./";
 import Button from "../Button";
 import Popover from "../Popover";
@@ -56,6 +57,71 @@ Overview.args = {
 };
 Overview.argTypes = {
   footer: { control: false }, // hide control for `footer` prop
+};
+
+/**
+ * Stateful wrapper used by interaction stories, since `Dialog` is a
+ * portaled component controlled by the `isOpen` prop.
+ */
+const InteractiveDialog = (args) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+      <Dialog {...args} isOpen={isOpen} onUserDismiss={() => setIsOpen(false)}>
+        <div>Dialog content</div>
+      </Dialog>
+    </>
+  );
+};
+
+/**
+ * Interaction test that opens the Dialog so Chromatic can snapshot the
+ * open modal. The Dialog renders in a portal, so its content is queried
+ * from the document via `screen`.
+ */
+export const Opens = {
+  name: "Interaction: Opens on click",
+  render: () => <InteractiveDialog title="Confirm action" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+    expect(screen.getByText("Confirm action")).toBeVisible();
+  },
+};
+
+/**
+ * Interaction test verifying the close (X) button dismisses the Dialog.
+ */
+export const ClosesViaButton = {
+  name: "Interaction: Closes via close button",
+  render: () => <InteractiveDialog title="Confirm action" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+
+    await userEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  },
+};
+
+/**
+ * Interaction test verifying the Escape key dismisses the Dialog.
+ */
+export const ClosesViaEscape = {
+  name: "Interaction: Closes on Escape key",
+  render: () => <InteractiveDialog title="Confirm action" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open dialog/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  },
 };
 
 export const UsingWithState = InteractiveTemplate.bind({});

--- a/src/Drawer/index.stories.js
+++ b/src/Drawer/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import Drawer from "./";
 import Button from "../Button";
 import Popover from "../Popover";
@@ -90,6 +91,78 @@ const InteractiveTemplate = (args) => {
 };
 
 export const Overview = InteractiveTemplate.bind({});
+
+/**
+ * Interaction test that opens the Drawer so Chromatic can snapshot the
+ * open panel. The Drawer renders in a portal, so its content is queried
+ * from the document via `screen`.
+ */
+export const Opens = {
+  name: "Interaction: Opens on click",
+  render: () => <InteractiveTemplate />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open drawer/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+    expect(screen.getByText("Title #1")).toBeVisible();
+  },
+};
+
+/**
+ * Interaction test verifying the next/previous controls page through the
+ * Drawer's contents.
+ */
+export const NavigatesContent = {
+  name: "Interaction: Navigates content with controls",
+  render: () => <InteractiveTemplate />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open drawer/i }));
+    await waitFor(() => expect(screen.getByText("Title #1")).toBeVisible());
+
+    // advance to the next content
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(screen.getByText("Title #2")).toBeVisible());
+
+    // go back to the previous content
+    await userEvent.click(screen.getByRole("button", { name: "Previous" }));
+    await waitFor(() => expect(screen.getByText("Title #1")).toBeVisible());
+  },
+};
+
+/**
+ * Interaction test verifying the close button dismisses the Drawer.
+ */
+export const ClosesViaButton = {
+  name: "Interaction: Closes via close button",
+  render: () => <InteractiveTemplate />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open drawer/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(
+      () => expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      { timeout: 2000 },
+    );
+  },
+};
+
+/**
+ * Interaction test verifying the Escape key dismisses the Drawer.
+ */
+export const ClosesViaEscape = {
+  name: "Interaction: Closes on Escape key",
+  render: () => <InteractiveTemplate />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: /open drawer/i }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(
+      () => expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      { timeout: 2000 },
+    );
+  },
+};
 
 export const WithNavigation = InteractiveTemplate.bind({});
 

--- a/src/Field/Select/index.stories.js
+++ b/src/Field/Select/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import { FieldSelect } from "./index";
 
 export default {
@@ -31,6 +32,48 @@ export const Overview = Template.bind({});
 Overview.args = {
   label: "Country",
   placeholder: "Select a country",
+};
+
+/**
+ * Interaction test that opens the Field.Select so Chromatic can snapshot
+ * the dropdown. Options render in a dropdown layer, queried via `screen`.
+ */
+export const Opens = {
+  name: "Interaction: Opens on click",
+  render: () => <Template label="Country" placeholder="Select a country" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("combobox", { name: /country/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: /united states/i }),
+      ).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for the selection flow: open, pick an option, and
+ * verify the trigger reflects the choice and the menu closes.
+ */
+export const SelectsOption = {
+  name: "Interaction: Selects an option",
+  render: () => <Template label="Country" placeholder="Select a country" />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("combobox", { name: /country/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /canada/i })).toBeVisible(),
+    );
+
+    await userEvent.click(screen.getByRole("option", { name: /canada/i }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: /canada/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      canvas.getByRole("combobox", { name: /country/i }),
+    ).toHaveTextContent("Canada");
+  },
 };
 
 export const WithValue = Template.bind({});

--- a/src/Field/Text/index.stories.js
+++ b/src/Field/Text/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import { FieldText } from "./index";
 import { FIELD_MASKS } from "../masks";
 import iconSelection from "../../icons/selection.json";
@@ -26,6 +27,62 @@ Overview.args = {
   id: "email",
   label: "Email Address",
   value: "",
+};
+
+/**
+ * Interaction test verifying that typing updates the field value.
+ */
+export const TypesValue = {
+  name: "Interaction: Accepts typed input",
+  render: () => {
+    const ControlledField = () => {
+      const [value, setValue] = useState("");
+      return (
+        <FieldText
+          id="full-name"
+          label="Full Name"
+          value={value}
+          onChange={setValue}
+        />
+      );
+    };
+    return <ControlledField />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /full name/i });
+    await userEvent.type(input, "Ada Lovelace");
+    await waitFor(() => expect(input).toHaveValue("Ada Lovelace"));
+  },
+};
+
+/**
+ * Interaction test verifying the clear button empties the field.
+ */
+export const ClearsValue = {
+  name: "Interaction: Clears input on button click",
+  render: () => {
+    const ClearableField = () => {
+      const [value, setValue] = useState("");
+      return (
+        <FieldText
+          id="searchable"
+          label="Searchable Text"
+          value={value}
+          onChange={setValue}
+          showClearButton
+        />
+      );
+    };
+    return <ClearableField />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /searchable text/i });
+    await userEvent.type(input, "hello");
+    await waitFor(() => expect(input).toHaveValue("hello"));
+
+    await userEvent.click(canvas.getByRole("button", { name: /clear input/i }));
+    await waitFor(() => expect(input).toHaveValue(""));
+  },
 };
 
 export const WithPlaceholder = Template.bind({});

--- a/src/FieldToken/index.stories.jsx
+++ b/src/FieldToken/index.stories.jsx
@@ -1,10 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import FieldToken from ".";
 
 const Template = (args) => <FieldToken {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   label: "Label",
+};
+
+/**
+ * Interaction test verifying the dismiss button fires `onDismiss`,
+ * removing the token.
+ */
+export const Dismisses = {
+  name: "Interaction: Removes token on dismiss",
+  render: () => {
+    const Wrapper = () => {
+      const [visible, setVisible] = useState(true);
+      return visible ? (
+        <FieldToken label="Chicago" onDismiss={() => setVisible(false)} />
+      ) : (
+        <div>Token removed</div>
+      );
+    };
+    return <Wrapper />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    expect(canvas.getByText("Chicago")).toBeVisible();
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: /remove chicago/i }),
+    );
+    await waitFor(() =>
+      expect(canvas.queryByText("Chicago")).not.toBeInTheDocument(),
+    );
+    expect(canvas.getByText("Token removed")).toBeVisible();
+  },
 };
 
 export default {

--- a/src/MultiSelect/index.stories.js
+++ b/src/MultiSelect/index.stories.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-key,react/no-unescaped-entities */
 import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import MultiSelect from ".";
 import MultiSelectItem from "./MultiSelectItem";
 
@@ -34,6 +35,90 @@ Overview.args = {
   children,
   // Default behavior uses the defaultSummaryFormatter which renders tokens using tokenLabel.
   isClearable: true,
+};
+
+/**
+ * Interaction test that opens the MultiSelect so Chromatic can snapshot
+ * the dropdown's placement.
+ */
+export const Open = {
+  name: "Interaction: Opens on click",
+  render: () => (
+    <MultiSelect name="chromaticOpen" label="Favorite icons">
+      {children}
+    </MultiSelect>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("combobox"));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for the multi-selection flow: select two options
+ * (the menu stays open by design) and verify both are marked selected.
+ */
+export const SelectMultiple = {
+  name: "Interaction: Selects multiple options",
+  render: () => (
+    <MultiSelect name="chromaticSelectMultiple" label="Favorite icons">
+      {children}
+    </MultiSelect>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("combobox"));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toBeVisible(),
+    );
+
+    // select two options; the menu stays open for further selections
+    await userEvent.click(screen.getByRole("option", { name: /coffee/i }));
+    await userEvent.click(screen.getByRole("option", { name: /film/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+    expect(screen.getByRole("option", { name: /film/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  },
+};
+
+/**
+ * Interaction test verifying the "Clear all" button deselects all items.
+ */
+export const ClearsAll = {
+  name: "Interaction: Clears all selections",
+  render: () => (
+    <MultiSelect name="chromaticClearAll" label="Favorite icons" isClearable>
+      {children}
+    </MultiSelect>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("combobox"));
+    await userEvent.click(screen.getByRole("option", { name: /coffee/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+
+    // clear all selections
+    await userEvent.click(canvas.getByRole("button", { name: /clear all/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /coffee/i })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      ),
+    );
+  },
 };
 
 export const OverviewSummary = Template.bind({});

--- a/src/Pagination/index.stories.tsx
+++ b/src/Pagination/index.stories.tsx
@@ -52,34 +52,14 @@ export const SelectsPageNumber = {
   name: "Interaction: Selects a page by number",
   render: () => <Pagination totalPages={10} defaultSelectedPage={3} />,
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByRole("button", { name: "Page 5" }));
+    await userEvent.click(canvas.getByRole("button", { name: "Page 4" }));
     await waitFor(() =>
-      expect(canvas.getByRole("button", { name: "Page 5" })).toHaveAttribute(
+      expect(canvas.getByRole("button", { name: "Page 4" })).toHaveAttribute(
         "aria-current",
         "page",
       ),
     );
     expect(canvas.getByRole("button", { name: "Page 3" })).not.toHaveAttribute(
-      "aria-current",
-      "page",
-    );
-  },
-};
-
-/**
- * Interaction test verifying the previous arrow is disabled on the first
- * page and does not change the selection.
- */
-export const DisablesAtBounds = {
-  name: "Interaction: Disables previous arrow at first page",
-  render: () => <Pagination totalPages={10} defaultSelectedPage={1} />,
-  play: async ({ canvas, userEvent }) => {
-    const prev = canvas.getByRole("button", { name: "Previous page" });
-    expect(prev).toHaveAttribute("aria-disabled", "true");
-
-    // clicking the disabled arrow keeps the selection on page 1
-    await userEvent.click(prev);
-    expect(canvas.getByRole("button", { name: "Page 1" })).toHaveAttribute(
       "aria-current",
       "page",
     );

--- a/src/Pagination/index.stories.tsx
+++ b/src/Pagination/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import Pagination from "./";
 
 const Template = (args) => <Pagination {...args} />;
@@ -7,6 +8,82 @@ export const Overview = Template.bind({});
 Overview.args = {
   totalPages: 40,
   defaultSelectedPage: 3,
+};
+
+/**
+ * Interaction test verifying the next/previous arrows move the selected
+ * page (tracked via `aria-current`).
+ */
+export const NavigatesWithArrows = {
+  name: "Interaction: Navigates with next/previous arrows",
+  render: () => <Pagination totalPages={10} defaultSelectedPage={3} />,
+  play: async ({ canvas, userEvent }) => {
+    expect(canvas.getByRole("button", { name: "Page 3" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    // advance to the next page
+    await userEvent.click(canvas.getByRole("button", { name: "Next page" }));
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Page 4" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      ),
+    );
+
+    // go back to the previous page
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Previous page" }),
+    );
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Page 3" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      ),
+    );
+  },
+};
+
+/**
+ * Interaction test verifying clicking a page number selects that page.
+ */
+export const SelectsPageNumber = {
+  name: "Interaction: Selects a page by number",
+  render: () => <Pagination totalPages={10} defaultSelectedPage={3} />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByRole("button", { name: "Page 5" }));
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: "Page 5" })).toHaveAttribute(
+        "aria-current",
+        "page",
+      ),
+    );
+    expect(canvas.getByRole("button", { name: "Page 3" })).not.toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  },
+};
+
+/**
+ * Interaction test verifying the previous arrow is disabled on the first
+ * page and does not change the selection.
+ */
+export const DisablesAtBounds = {
+  name: "Interaction: Disables previous arrow at first page",
+  render: () => <Pagination totalPages={10} defaultSelectedPage={1} />,
+  play: async ({ canvas, userEvent }) => {
+    const prev = canvas.getByRole("button", { name: "Previous page" });
+    expect(prev).toHaveAttribute("aria-disabled", "true");
+
+    // clicking the disabled arrow keeps the selection on page 1
+    await userEvent.click(prev);
+    expect(canvas.getByRole("button", { name: "Page 1" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  },
 };
 
 export const FullyControlled = () => {

--- a/src/Radio/index.stories.js
+++ b/src/Radio/index.stories.js
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import Radio from "./";
 import Row from "../Row";
 
@@ -15,6 +16,55 @@ Overview.args = {
       <code className="fontColor--azul">JSX</code> labels
     </>
   ),
+};
+
+/**
+ * Interaction test verifying that clicking a radio selects it and that
+ * selecting another radio in the same group moves the selection.
+ */
+export const Selects = {
+  name: "Interaction: Selects on click",
+  render: () => {
+    const RadioGroup = () => {
+      const [selected, setSelected] = useState("");
+      return (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--space-default)",
+          }}
+        >
+          {["daily", "weekly"].map((value) => (
+            <Radio
+              key={value}
+              name="frequency"
+              value={value}
+              onCheck={setSelected}
+              checked={selected === value}
+            >
+              Repeats {value}
+            </Radio>
+          ))}
+        </div>
+      );
+    };
+    return <RadioGroup />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const daily = canvas.getByRole("radio", { name: /repeats daily/i });
+    const weekly = canvas.getByRole("radio", { name: /repeats weekly/i });
+    expect(daily).not.toBeChecked();
+
+    // select the first radio
+    await userEvent.click(daily);
+    await waitFor(() => expect(daily).toBeChecked());
+
+    // selecting the second radio moves the selection
+    await userEvent.click(weekly);
+    await waitFor(() => expect(weekly).toBeChecked());
+    expect(daily).not.toBeChecked();
+  },
 };
 
 export const RadioGroups = () => (

--- a/src/RadioButtons/index.stories.js
+++ b/src/RadioButtons/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import RadioButtons from "./";
 
 const Template = (args) => <RadioButtons {...args} />;
@@ -11,6 +12,60 @@ Overview.args = {
     OptionC: "C",
   },
   name: "options",
+};
+
+/**
+ * Interaction test verifying that selecting an option checks its radio
+ * and moves the selection away from any previously selected option.
+ */
+export const Selects = {
+  name: "Interaction: Selects an option",
+  render: () => (
+    <RadioButtons
+      options={{ OptionA: "A", OptionB: "B", OptionC: "C" }}
+      name="interaction-options"
+    />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const optionB = canvas.getByRole("radio", { name: /optionb/i });
+    expect(optionB).not.toBeChecked();
+
+    await userEvent.click(optionB);
+    await waitFor(() => expect(optionB).toBeChecked());
+
+    // selecting another option moves the selection
+    const optionC = canvas.getByRole("radio", { name: /optionc/i });
+    await userEvent.click(optionC);
+    await waitFor(() => expect(optionC).toBeChecked());
+    expect(optionB).not.toBeChecked();
+  },
+};
+
+/**
+ * Interaction test verifying that an option's details are revealed only
+ * once that option is selected.
+ */
+export const RevealsDetails = {
+  name: "Interaction: Reveals details on selection",
+  render: () => (
+    <RadioButtons
+      options={{
+        OptionA: { value: "A", details: "Details for option A" },
+        OptionB: { value: "B", details: "Details for option B" },
+      }}
+      name="interaction-details"
+      kind="card"
+    />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    // details are hidden until an option is selected
+    expect(canvas.queryByText("Details for option A")).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("radio", { name: /optiona/i }));
+    await waitFor(() =>
+      expect(canvas.getByText("Details for option A")).toBeVisible(),
+    );
+  },
 };
 
 export const Example = () => {

--- a/src/Slider/index.stories.tsx
+++ b/src/Slider/index.stories.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid,react/jsx-key */
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import Slider from "./index";
 
 const Template = (args) => <Slider {...args} />;
@@ -13,6 +14,35 @@ Overview.args = {
   maxValue: 120,
   defaultValue: [20, 50],
   step: 1,
+};
+
+/**
+ * Interaction test verifying the slider thumb responds to keyboard input
+ * and updates the value shown in the `<output>` element.
+ */
+export const KeyboardAdjusts = {
+  name: "Interaction: Adjusts value with keyboard",
+  render: () => (
+    <Slider
+      label="Price Range"
+      lowerName="lower_price"
+      higherName="higher_price"
+      minValue={10}
+      maxValue={120}
+      defaultValue={[20, 50]}
+      step={1}
+    />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const [lowerThumb] = canvas.getAllByRole("slider");
+    const output = canvas.getByText(/between/i);
+    expect(output).toHaveTextContent("Between 20 and 50");
+
+    // move the lower thumb up by one step
+    lowerThumb.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await waitFor(() => expect(output).toHaveTextContent("Between 21 and 50"));
+  },
 };
 
 export const AsControlled = () => {

--- a/src/TableAutocomplete/index.stories.tsx
+++ b/src/TableAutocomplete/index.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { action } from "storybook/actions";
+import { expect, screen, waitFor } from "storybook/test";
 import TableAutocomplete from ".";
 import Button from "../Button";
 
@@ -44,6 +45,57 @@ Basic.args = {
   placeholder: "Type to search...",
   isDisabled: false,
   hasError: false,
+};
+
+/**
+ * Interaction test that opens the TableAutocomplete by typing so Chromatic
+ * can snapshot the dropdown. Options are queried via `screen`.
+ */
+export const Opens = {
+  name: "Interaction: Opens on typing",
+  render: () => (
+    <TableAutocomplete label="Select a fruit" placeholder="Type to search...">
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("combobox", { name: /select a fruit/i });
+    await userEvent.type(input, "A");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Apple" })).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for the full flow: type to filter, select an item, and
+ * verify the input reflects the selection.
+ */
+export const FiltersAndSelects = {
+  name: "Interaction: Filters and selects an item",
+  render: () => (
+    <TableAutocomplete label="Select a fruit" placeholder="Type to search...">
+      {mockItems.map((item) => (
+        <TableAutocomplete.Item key={item} value={item}>
+          {item}
+        </TableAutocomplete.Item>
+      ))}
+    </TableAutocomplete>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("combobox", { name: /select a fruit/i });
+    await userEvent.type(input, "Ban");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Banana" })).toBeVisible(),
+    );
+
+    await userEvent.click(screen.getByRole("option", { name: "Banana" }));
+    await waitFor(() => expect(input).toHaveValue("Banana"));
+  },
 };
 
 export const WithCustomContent = () => {

--- a/src/TableAutocomplete/index.tsx
+++ b/src/TableAutocomplete/index.tsx
@@ -159,7 +159,7 @@ const TableAutocomplete = ({
           isDisabled={isDisabled}
           hasError={hasError}
           {...getInputProps({
-            "aria-labelledby": undefined, // use underlying aria-label
+            "aria-label": label, // downshift emits aria-label + omits aria-labelledby
           })}
         />
       </div>

--- a/src/TableDateInput/index.stories.tsx
+++ b/src/TableDateInput/index.stories.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { expect, screen, waitFor } from "storybook/test";
 import TableDateInput from "./";
 import type { TableDateInputProps } from "./";
 
@@ -8,6 +9,63 @@ export const Overview = Template.bind({});
 Overview.args = {
   label: "Select date",
   placeholder: "MM/DD/YYYY",
+};
+
+/**
+ * Interaction test that opens the flatpickr calendar so Chromatic can
+ * snapshot it. The calendar is appended to the document body, so it is
+ * queried via `screen`.
+ */
+export const OpensCalendar = {
+  name: "Interaction: Opens the calendar",
+  render: () => (
+    <TableDateInput
+      label="Select a date"
+      placeholder="MM/DD/YYYY"
+      defaultDate="2024-01-15"
+    />
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    await waitFor(() =>
+      expect(screen.getByLabelText("January 10, 2024")).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for selecting a day. The `onChange` callback receives
+ * the formatted date, which is surfaced in the story for assertion.
+ */
+export const SelectsDate = {
+  name: "Interaction: Selects a date",
+  render: () => {
+    const Wrapper = () => {
+      const [date, setDate] = useState("");
+      return (
+        <>
+          <TableDateInput
+            label="Select a date"
+            placeholder="MM/DD/YYYY"
+            defaultDate="2024-01-15"
+            onChange={setDate}
+          />
+          <div data-testid="selected-date">Selected: {date}</div>
+        </>
+      );
+    };
+    return <Wrapper />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    const day = await screen.findByLabelText("January 10, 2024");
+    await userEvent.click(day);
+    await waitFor(() =>
+      expect(canvas.getByTestId("selected-date")).toHaveTextContent(
+        "2024-01-10",
+      ),
+    );
+  },
 };
 
 export const WithDefaultDate = () => {

--- a/src/TableDateInput/index.stories.tsx
+++ b/src/TableDateInput/index.stories.tsx
@@ -61,7 +61,7 @@ export const SelectsDate = {
     return <Wrapper />;
   },
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByRole("textbox"));
+    await userEvent.click(canvas.getByRole("textbox", { name: /select a date/i }));
     const day = await screen.findByLabelText("January 10, 2024");
     await userEvent.click(day);
     await waitFor(() =>

--- a/src/TableDateInput/index.stories.tsx
+++ b/src/TableDateInput/index.stories.tsx
@@ -27,8 +27,12 @@ export const OpensCalendar = {
   ),
   play: async ({ canvas, userEvent }) => {
     await userEvent.click(canvas.getByRole("textbox"));
+    // flatpickr fades the calendar in via a CSS opacity animation. Chromatic
+    // freezes animations during the play phase, leaving the calendar at
+    // opacity:0 — which trips `toBeVisible`. Assert the calendar is open
+    // instead, which reflects the interaction without the animation flake.
     await waitFor(() =>
-      expect(screen.getByLabelText("January 10, 2024")).toBeVisible(),
+      expect(document.querySelector(".flatpickr-calendar")).toHaveClass("open"),
     );
   },
 };

--- a/src/TableDateInput/index.stories.tsx
+++ b/src/TableDateInput/index.stories.tsx
@@ -26,7 +26,7 @@ export const OpensCalendar = {
     />
   ),
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    await userEvent.click(canvas.getByRole("textbox"));
     await waitFor(() =>
       expect(screen.getByLabelText("January 10, 2024")).toBeVisible(),
     );
@@ -57,7 +57,7 @@ export const SelectsDate = {
     return <Wrapper />;
   },
   play: async ({ canvas, userEvent }) => {
-    await userEvent.click(canvas.getByLabelText(/select a date/i));
+    await userEvent.click(canvas.getByRole("textbox"));
     const day = await screen.findByLabelText("January 10, 2024");
     await userEvent.click(day);
     await waitFor(() =>

--- a/src/TableDateInput/index.tsx
+++ b/src/TableDateInput/index.tsx
@@ -49,6 +49,7 @@ const TableDateInput = ({
   return (
     <DateInput
       {...otherProps}
+      label={label}
       altInput={true}
       altFormat="m/d/Y"
       renderInput={(

--- a/src/TableInput/index.stories.tsx
+++ b/src/TableInput/index.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import TableInput from "./";
 import Table from "../Table";
 import type { TableInputProps } from "./";
@@ -38,6 +39,60 @@ WithMaxLength.args = {
   placeholder: "Enter text here...",
   isDisabled: false,
   maxLength: 12,
+};
+
+/**
+ * Interaction test verifying that typing updates the cell value.
+ */
+export const TypesValue = {
+  name: "Interaction: Accepts typed input",
+  render: () => {
+    const ControlledInput = () => {
+      const [value, setValue] = useState("");
+      return (
+        <TableInput
+          label="Edit name"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Enter name"
+        />
+      );
+    };
+    return <ControlledInput />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /edit name/i });
+    await userEvent.type(input, "Jane Smith");
+    await waitFor(() => expect(input).toHaveValue("Jane Smith"));
+  },
+};
+
+/**
+ * Interaction test verifying the character counter updates as the user types.
+ */
+export const CharacterCounter = {
+  name: "Interaction: Updates character counter",
+  render: () => {
+    const ControlledInput = () => {
+      const [value, setValue] = useState("");
+      return (
+        <TableInput
+          label="Edit code"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          maxLength={12}
+        />
+      );
+    };
+    return <ControlledInput />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /edit code/i });
+    expect(canvas.getByText("0/12")).toBeInTheDocument();
+
+    await userEvent.type(input, "abc");
+    await waitFor(() => expect(canvas.getByText("3/12")).toBeInTheDocument());
+  },
 };
 
 export const InATable = () => {

--- a/src/TableSelect/index.stories.tsx
+++ b/src/TableSelect/index.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { action } from "storybook/actions";
+import { expect, screen, waitFor } from "storybook/test";
 import TableSelect from ".";
 
 export default {
@@ -39,6 +40,63 @@ Basic.args = {
   label: "Select a fruit",
   isDisabled: false,
   hasError: false,
+};
+
+/**
+ * Interaction test that opens the TableSelect so Chromatic can snapshot
+ * the dropdown. The menu is portalled to the body, so options are queried
+ * via `screen`.
+ */
+export const Opens = {
+  name: "Interaction: Opens on click",
+  render: () => (
+    <TableSelect id="fruit-open" label="Select a fruit" onChange={() => {}}>
+      {mockItems.map((item) => (
+        <TableSelect.Item key={item} value={item}>
+          {item}
+        </TableSelect.Item>
+      ))}
+    </TableSelect>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole("combobox", { name: /select a fruit/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Apple" })).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Interaction test for the selection flow: open, pick an option, and
+ * verify the trigger reflects the choice.
+ */
+export const SelectsOption = {
+  name: "Interaction: Selects an option",
+  render: () => (
+    <TableSelect
+      id="fruit-select-story"
+      label="Select a fruit"
+      onChange={() => {}}
+    >
+      {mockItems.map((item) => (
+        <TableSelect.Item key={item} value={item}>
+          {item}
+        </TableSelect.Item>
+      ))}
+    </TableSelect>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const trigger = canvas.getByRole("combobox", { name: /select a fruit/i });
+    await userEvent.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Banana" })).toBeVisible(),
+    );
+
+    await userEvent.click(screen.getByRole("option", { name: "Banana" }));
+    await waitFor(() => expect(trigger).toHaveTextContent("Banana"));
+  },
 };
 
 export const WithCustomContent = () => {

--- a/src/TextInput/index.stories.js
+++ b/src/TextInput/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import TextInput, { VALID_ICON_NAMES } from "./";
 import Button from "../Button";
 
@@ -7,6 +8,64 @@ const Template = (args) => <TextInput {...args} />;
 export const Overview = Template.bind({});
 Overview.args = {
   label: "TextInput Label",
+};
+
+/**
+ * Interaction test verifying that typing updates the input value.
+ */
+export const TypesValue = {
+  name: "Interaction: Accepts typed input",
+  render: () => <TextInput label="Full name" />,
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /full name/i });
+    await userEvent.type(input, "Ada Lovelace");
+    await waitFor(() => expect(input).toHaveValue("Ada Lovelace"));
+  },
+};
+
+/**
+ * Interaction test verifying that the clear button empties the input.
+ */
+export const ClearsValue = {
+  name: "Interaction: Clears input on button click",
+  render: () => {
+    const ClearableInput = () => {
+      const [value, setValue] = useState("");
+      return (
+        <TextInput
+          label="Search"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          showClearButton
+        />
+      );
+    };
+    return <ClearableInput />;
+  },
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /search/i });
+    await userEvent.type(input, "hello");
+    await waitFor(() => expect(input).toHaveValue("hello"));
+
+    // the clear button only renders once there is a value
+    await userEvent.click(canvas.getByRole("button", { name: /clear/i }));
+    await waitFor(() => expect(input).toHaveValue(""));
+  },
+};
+
+/**
+ * Interaction test verifying the character counter updates as the user types.
+ */
+export const CharacterCounter = {
+  name: "Interaction: Updates character counter",
+  render: () => <TextInput label="Bio" maxLength={20} />,
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /bio/i });
+    expect(canvas.getByText("0/20")).toBeInTheDocument();
+
+    await userEvent.type(input, "hello");
+    await waitFor(() => expect(canvas.getByText("5/20")).toBeInTheDocument());
+  },
 };
 
 export const Example = () => {

--- a/src/Toggle/index.stories.js
+++ b/src/Toggle/index.stories.js
@@ -1,10 +1,34 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import Toggle from "./";
 import Row from "../Row";
 
 const Template = (args) => <Toggle {...args} />;
 
 export const Overview = Template.bind({});
+
+/**
+ * Interaction test verifying that clicking the toggle flips its active
+ * (`aria-checked`) state on and back off.
+ */
+export const Switches = {
+  name: "Interaction: Switches on click",
+  render: () => <Toggle label="Include hidden accounts" />,
+  play: async ({ canvas, userEvent }) => {
+    const toggle = canvas.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    // switch on
+    await userEvent.click(toggle);
+    await waitFor(() => expect(toggle).toHaveAttribute("aria-checked", "true"));
+
+    // switch off
+    await userEvent.click(toggle);
+    await waitFor(() =>
+      expect(toggle).toHaveAttribute("aria-checked", "false"),
+    );
+  },
+};
 
 export const WithLabel = () => (
   <Toggle defaultActive={true} label="Include hidden accounts" />

--- a/src/TokenInput/index.stories.js
+++ b/src/TokenInput/index.stories.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { expect, waitFor } from "storybook/test";
 import TokenInput from "./";
 
 const Template = (args) => <TokenInput {...args} />;
@@ -7,6 +8,63 @@ export const Overview = Template.bind({});
 Overview.args = {
   label: "Which cities would you like to add?",
   tokens: ["New York", "Chicago"],
+};
+
+/**
+ * Stateful wrapper used by interaction stories, since `TokenInput` is a
+ * fully controlled component.
+ */
+const ControlledTokenInput = (props) => {
+  const [inputValue, setInputValue] = useState("");
+  const [tokens, setTokens] = useState([]);
+  return (
+    <TokenInput
+      label="Favorite Foods"
+      fieldName="favorite_foods"
+      fieldValue={tokens.join(",")}
+      inputValue={inputValue}
+      tokens={tokens}
+      onInputChange={(e) => setInputValue(e.target.value)}
+      onTokensChange={setTokens}
+      {...props}
+    />
+  );
+};
+
+/**
+ * Interaction test verifying that typing text and pressing Enter creates
+ * a token.
+ */
+export const CreatesToken = {
+  name: "Interaction: Creates a token on Enter",
+  render: () => <ControlledTokenInput />,
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /favorite foods/i });
+    await userEvent.type(input, "bananas{Enter}");
+    await waitFor(() => expect(canvas.getByText("bananas")).toBeVisible());
+    // input is reset after tokenizing
+    expect(input).toHaveValue("");
+  },
+};
+
+/**
+ * Interaction test verifying that a token can be dismissed.
+ */
+export const RemovesToken = {
+  name: "Interaction: Removes a token on dismiss",
+  render: () => <ControlledTokenInput />,
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole("textbox", { name: /favorite foods/i });
+    await userEvent.type(input, "bananas{Enter}");
+    await waitFor(() => expect(canvas.getByText("bananas")).toBeVisible());
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: /remove bananas/i }),
+    );
+    await waitFor(() =>
+      expect(canvas.queryByText("bananas")).not.toBeInTheDocument(),
+    );
+  },
 };
 
 export const UsingWithState = () => {


### PR DESCRIPTION
We recently had some regressions with components that do not have adequate snapshot coverage.

This PR introduces storybook interaction tests to some core components that require interaction to fully cover states of the component.

### Changes

- fix two actual accessibility bugs I found when introducing these tests (Table inputs)
- cover most relevant components with interaction tests

### In Storybook
When developing and testing interaction tests, they may be played directly in storybook locally or in live documentation.

<img width="1024" height="733" alt="Screenshot 2026-09-10 at 3 34 57 PM" src="https://github.com/user-attachments/assets/8155bf14-8531-4cd8-8f74-230ebca6b595" />


### In Chromatic

The `run_chromatic` action pushes our storybook up to Chromatic to create a new chromatic build. It will run both snapshot and interaction tests, warning us is there's a failure and blocking the PR from merging:

<img width="1048" height="352" alt="Screenshot 2026-09-10 at 5 02 21 PM" src="https://github.com/user-attachments/assets/ccc07e38-2578-4294-b461-074516c38a7e" />

