### PR TITLE
chore(lint): add cyclomatic complexity rule for TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,9 @@ module.exports = {
       parser: "@typescript-eslint/parser",
       plugins: ["@typescript-eslint"],
       extends: ["plugin:@typescript-eslint/recommended"],
+      rules: {
+        complexity: ["error", 31],
+      },
     },
     {
       files: ["*.test.*", "*.spec.*"],


### PR DESCRIPTION
## Summary
- Adds ESLint's `complexity` rule to the `*.ts`/`*.tsx` override in `.eslintrc.js`
- Threshold is set to **31**, the current maximum, so this passes without any source changes. Lowering it to 30 produces exactly one error.
- Closes https://linear.app/narmi/issue/NDS-3258/implement-a-cyclomatic-complexity-linter-over-nds.

## Current distribution (341 functions across 126 files)

| Complexity | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 15 | 17 | 31 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| Functions | 173 | 68 | 34 | 21 | 13 | 10 | 7 | 3 | 1 | 3 | 4 | 2 | 2 | 1 | 1 |

## Top offenders

| Complexity | Function |
|---|---|
| 31 | `src/Drawer/index.tsx:71` Drawer |
| 17 | `src/CollapsibleCard/index.tsx:53` |
| 15 | `src/Input/index.tsx:48` |
| 15 | `src/Select/index.tsx:210` Select |
| 13 | `src/Chip/index.tsx:53` |
| 13 | `src/Table/index.tsx:112` |
| 12 | `src/Button/index.tsx:74` |
| 12 | `src/DropdownTrigger/index.tsx:49` |
| 12 | `src/Tabs/TabsTab.tsx:25` |
| 12 | `src/TextInput/index.tsx:133` |
| 11 | `src/NavigationItem/index.tsx:74` |
| 11 | `src/TimelineEvent/index.tsx:52` |
| 11 | `src/hooks/useDropdownLayer/index.ts:147` |
| 10 | `src/formatters/formatNumber.ts:25` |

Refactoring Drawer alone would allow the threshold to drop to 17. The intent is to ratchet the number down as those are addressed.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run lint` with the rule at 30 fails on exactly one function (Drawer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)