### PR TITLE
refactor(Drawer): reduce cyclomatic complexity, lower lint threshold to 17

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       plugins: ["@typescript-eslint"],
       extends: ["plugin:@typescript-eslint/recommended"],
       rules: {
-        complexity: ["error", 31],
+        complexity: ["error", 17],
       },
     },
     {

--- a/src/Drawer/index.test.tsx
+++ b/src/Drawer/index.test.tsx
@@ -1,0 +1,251 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import Drawer, { type DrawerProps } from "./";
+
+let isDesktop = true;
+vi.mock("../hooks/useBreakpoints", () => ({
+  default: () => ({
+    s: isDesktop,
+    m: isDesktop,
+    l: false,
+    xl: false,
+    largestSatisfiedBreakpoint: "m",
+  }),
+}));
+vi.mock("../hooks/useLockBodyScroll", () => ({ default: vi.fn() }));
+
+const renderDrawer = (props: Partial<DrawerProps> = {}) => {
+  const result = render(
+    <Drawer isOpen testId="drawer" {...props}>
+      {props.children ?? <p>Drawer content</p>}
+    </Drawer>,
+  );
+  act(() => {}); // flush the mount transition effect
+  return result;
+};
+
+const POSITIONS = ["right", "left", "top", "bottom"] as const;
+
+describe("Drawer", () => {
+  beforeEach(() => {
+    isDesktop = true;
+  });
+
+  afterEach(() => {
+    document.getElementById("outlet")?.remove();
+  });
+
+  describe("rendering", () => {
+    it("renders content into a single body-level outlet", () => {
+      renderDrawer();
+      const outlet = document.getElementById("outlet");
+      expect(outlet?.parentElement).toBe(document.body);
+      expect(outlet).toContainElement(screen.getByRole("dialog"));
+      expect(screen.getByText("Drawer content")).toBeInTheDocument();
+    });
+
+    it("renders nothing when closed", () => {
+      renderDrawer({ isOpen: false });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("stays mounted for the close transition, then unmounts", () => {
+      vi.useFakeTimers();
+      const { rerender } = renderDrawer();
+      rerender(
+        <Drawer isOpen={false} testId="drawer">
+          <p>Drawer content</p>
+        </Drawer>,
+      );
+      expect(screen.getByRole("dialog")).not.toHaveClass("drawer--open--right");
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    it("passes visibility to function children", () => {
+      renderDrawer({
+        children: ({ isVisible }) => <p>visible: {String(isVisible)}</p>,
+      });
+      expect(screen.getByText("visible: true")).toBeInTheDocument();
+    });
+
+    it("renders footer when provided", () => {
+      renderDrawer({ footer: <span>Footer</span>, paddingSize: "s" });
+      const footer = screen.getByText("Footer").parentElement;
+      expect(footer).toHaveClass("drawer-footer", "padding--x--s");
+    });
+
+    it("applies paddingSize to content", () => {
+      renderDrawer({ paddingSize: "none" });
+      expect(screen.getByText("Drawer content").parentElement).toHaveClass(
+        "padding--all--none",
+      );
+    });
+
+    it("wraps content in a live region only when controls are shown", () => {
+      renderDrawer();
+      expect(screen.getByRole("region")).toContainElement(
+        screen.getByRole("dialog"),
+      );
+      document.getElementById("outlet")?.remove();
+      renderDrawer({ showControls: false });
+      expect(screen.queryByRole("region")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("depth", () => {
+    it("sets width for vertical drawers and height for horizontal ones", () => {
+      renderDrawer({ depth: "400px", position: "left" });
+      expect(screen.getByRole("dialog")).toHaveStyle({ width: "400px" });
+      document.getElementById("outlet")?.remove();
+      renderDrawer({ depth: "400px", position: "top" });
+      expect(screen.getByRole("dialog")).toHaveStyle({ height: "400px" });
+    });
+
+    it("forces full width for vertical drawers on mobile", () => {
+      isDesktop = false;
+      renderDrawer({ depth: "400px", position: "right" });
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveStyle({ width: "100%" });
+      expect(dialog).toHaveClass("drawer--vertical--mobile");
+    });
+  });
+
+  describe("dismissal", () => {
+    it.each(POSITIONS)(
+      "dismisses via Escape, backdrop, and nav shim (%s)",
+      (position) => {
+        const onUserDismiss = vi.fn();
+        renderDrawer({ position, onUserDismiss });
+
+        fireEvent.keyDown(window, { key: "a" });
+        expect(onUserDismiss).not.toHaveBeenCalled();
+
+        fireEvent.keyDown(window, { key: "Escape" });
+        fireEvent.click(document.querySelector(".backdrop")!);
+        fireEvent.click(document.querySelector(".navigation")!);
+        expect(onUserDismiss).toHaveBeenCalledTimes(3);
+
+        // clicks on nav children (not the shim itself) do not dismiss
+        fireEvent.click(
+          document.querySelector(`.navigation-container--${position}`)!,
+        );
+        expect(onUserDismiss).toHaveBeenCalledTimes(3);
+      },
+    );
+
+    it("does not listen for Escape when closed", () => {
+      const onUserDismiss = vi.fn();
+      renderDrawer({ isOpen: false, onUserDismiss });
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(onUserDismiss).not.toHaveBeenCalled();
+    });
+
+    it("dismisses via the close button", () => {
+      const onUserDismiss = vi.fn();
+      renderDrawer({ onUserDismiss });
+      fireEvent.click(screen.getByRole("button", { name: "Close" }));
+      expect(onUserDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the close button when showClose is false", () => {
+      renderDrawer({ showClose: false });
+      expect(
+        screen.queryByRole("button", { name: "Close" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("desktop navigation", () => {
+    it.each(POSITIONS)("wires next and previous buttons (%s)", (position) => {
+      const onNext = vi.fn();
+      const onPrev = vi.fn();
+      renderDrawer({ position, onNext, onPrev });
+
+      fireEvent.click(screen.getByRole("button", { name: "Next" }));
+      fireEvent.click(screen.getByRole("button", { name: "Previous" }));
+      expect(onNext).toHaveBeenCalledTimes(1);
+      expect(onPrev).toHaveBeenCalledTimes(1);
+    });
+
+    it("orders buttons Prev/Next on vertical drawers and Next/Prev on horizontal ones", () => {
+      renderDrawer({ position: "right" });
+      let buttons = screen
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("aria-label"));
+      expect(buttons).toEqual(["Close", "Previous", "Next"]);
+
+      document.getElementById("outlet")?.remove();
+      renderDrawer({ position: "top" });
+      buttons = screen
+        .getAllByRole("button")
+        .map((b) => b.getAttribute("aria-label"));
+      expect(buttons).toEqual(["Close", "Next", "Previous"]);
+    });
+
+    it("marks a navigation button disabled when its callback is omitted", () => {
+      renderDrawer({ onNext: vi.fn() });
+      expect(screen.getByRole("button", { name: "Next" })).not.toHaveClass(
+        "navigation-button--disabled",
+      );
+      expect(screen.getByRole("button", { name: "Previous" })).toHaveClass(
+        "navigation-button--disabled",
+      );
+    });
+
+    it("hides navigation buttons when showControls is false", () => {
+      renderDrawer({ showControls: false });
+      expect(
+        screen.queryByRole("button", { name: "Next" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Previous" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+  });
+
+  describe("mobile navigation", () => {
+    beforeEach(() => {
+      isDesktop = false;
+    });
+
+    it("renders in-content controls instead of the side navigation", () => {
+      const onUserDismiss = vi.fn();
+      const onNext = vi.fn();
+      const onPrev = vi.fn();
+      renderDrawer({ onUserDismiss, onNext, onPrev });
+
+      expect(document.querySelector(".navigation")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Next" }));
+      fireEvent.click(screen.getByRole("button", { name: "Previous" }));
+      fireEvent.click(
+        document.querySelector(".mobile-navigation-button--close")!,
+      );
+      expect(onNext).toHaveBeenCalledTimes(1);
+      expect(onPrev).toHaveBeenCalledTimes(1);
+      expect(onUserDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides mobile next/prev when showControls is false", () => {
+      renderDrawer({ showControls: false });
+      expect(
+        screen.queryByRole("button", { name: "Next" }),
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".mobile-navigation-button--close"),
+      ).not.toBeNull();
+    });
+
+    it("keeps the side navigation for horizontal drawers", () => {
+      renderDrawer({ position: "bottom" });
+      expect(document.querySelector(".navigation")).not.toBeNull();
+      expect(
+        document.querySelector(".mobile-navigation-button--close"),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -126,6 +126,19 @@ const Drawer = ({
     }
   };
 
+  // Navigation buttons on vertical drawers are the opposite compared to
+  // horizontal ones due to the order of navigation buttons being the opposite
+  // (rows are reversed in parent divs for horizontal drawers)
+  const [firstButton, secondButton] = isHorizontal
+    ? [
+        { onClick: onNext, label: "Next", chevron: "right" as const },
+        { onClick: onPrev, label: "Previous", chevron: "left" as const },
+      ]
+    : [
+        { onClick: onPrev, label: "Previous", chevron: "up" as const },
+        { onClick: onNext, label: "Next", chevron: "down" as const },
+      ];
+
   /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
   const navigationContainerJSX = isVerticalMobileDrawer ? null : (
     <div
@@ -156,47 +169,16 @@ const Drawer = ({
         )}
         {showControls && (
           <>
-            <button
-              className={cc([
-                `button--reset navigation-button navigation-button--${position} alignChild--center--center`,
-                {
-                  // Navigation buttons on vertical drawers are the opposite compared to
-                  // horizontal ones due to the order of navigation buttons being the opposite
-                  // (rows are reversed in parent divs for horizontal drawers)
-                  "navigation-button--disabled": isHorizontal
-                    ? onNext === undefined
-                    : onPrev === undefined,
-                },
-              ])}
-              onClick={isHorizontal ? onNext : onPrev}
-              aria-controls={panelId}
-              aria-label={isHorizontal ? "Next" : "Previous"}
-            >
-              <span
-                className={`narmi-icon-chevron-${
-                  isHorizontal ? "right" : "up"
-                } fontSize--heading3`}
-              />
-            </button>
-            <button
-              className={cc([
-                `button--reset navigation-button navigation-button--${position} alignChild--center--center`,
-                {
-                  "navigation-button--disabled": isHorizontal
-                    ? onPrev === undefined
-                    : onNext === undefined,
-                },
-              ])}
-              onClick={isHorizontal ? onPrev : onNext}
-              aria-controls={panelId}
-              aria-label={isHorizontal ? "Previous" : "Next"}
-            >
-              <span
-                className={`narmi-icon-chevron-${
-                  isHorizontal ? "left" : "down"
-                } fontSize--heading3`}
-              />
-            </button>
+            <NavigationButton
+              position={position}
+              panelId={panelId}
+              {...firstButton}
+            />
+            <NavigationButton
+              position={position}
+              panelId={panelId}
+              {...secondButton}
+            />
           </>
         )}
       </div>
@@ -307,5 +289,36 @@ const Drawer = ({
 
   return <>{document ? renderDrawerInOutlet() : null}</>;
 };
+
+type Position = NonNullable<DrawerProps["position"]>;
+type ChevronDirection = "up" | "down" | "left" | "right";
+
+interface NavigationButtonProps {
+  position: Position;
+  onClick?: () => void;
+  label: string;
+  chevron: ChevronDirection;
+  panelId: string;
+}
+
+const NavigationButton = ({
+  position,
+  onClick,
+  label,
+  chevron,
+  panelId,
+}: NavigationButtonProps) => (
+  <button
+    className={cc([
+      `button--reset navigation-button navigation-button--${position} alignChild--center--center`,
+      { "navigation-button--disabled": onClick === undefined },
+    ])}
+    onClick={onClick}
+    aria-controls={panelId}
+    aria-label={label}
+  >
+    <span className={`narmi-icon-chevron-${chevron} fontSize--heading3`} />
+  </button>
+);
 
 export default Drawer;

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -87,6 +87,7 @@ const Drawer = ({
   const navRef = useRef<HTMLDivElement>(null);
 
   const isTransitioning = useMountTransition(isOpen, 300);
+  const isShown = isOpen && isTransitioning;
   const { m } = useBreakpoints();
   const isHorizontal = position === "bottom" || position === "top";
   const isVerticalMobileDrawer = !m && !isHorizontal;
@@ -132,7 +133,7 @@ const Drawer = ({
       onClick={handleShimClick}
       style={depthStyle}
       className={`drawer padding--all--xxl drawer--${position} navigation  ${
-        isOpen && isTransitioning ? `navigation--open--${position}` : ""
+        isShown ? `navigation--open--${position}` : ""
       }`}
       data-testid={testId}
     >
@@ -209,7 +210,7 @@ const Drawer = ({
         "drawer",
         `drawer--${position}`,
         {
-          [`drawer--open--${position}`]: isOpen && isTransitioning,
+          [`drawer--open--${position}`]: isShown,
           "drawer--vertical--mobile": isVerticalMobileDrawer,
         },
       ])}
@@ -273,10 +274,7 @@ const Drawer = ({
       <FocusLock>
         <div
           ref={shimRef}
-          className={cc([
-            "backdrop",
-            { "backdrop--open": isOpen && isTransitioning },
-          ])}
+          className={cc(["backdrop", { "backdrop--open": isShown }])}
           onClick={handleShimClick}
         />
         {navigationContainerJSX}

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -126,65 +126,6 @@ const Drawer = ({
     }
   };
 
-  // Navigation buttons on vertical drawers are the opposite compared to
-  // horizontal ones due to the order of navigation buttons being the opposite
-  // (rows are reversed in parent divs for horizontal drawers)
-  const [firstButton, secondButton] = isHorizontal
-    ? [
-        { onClick: onNext, label: "Next", chevron: "right" as const },
-        { onClick: onPrev, label: "Previous", chevron: "left" as const },
-      ]
-    : [
-        { onClick: onPrev, label: "Previous", chevron: "up" as const },
-        { onClick: onNext, label: "Next", chevron: "down" as const },
-      ];
-
-  /* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
-  const navigationContainerJSX = isVerticalMobileDrawer ? null : (
-    <div
-      ref={navRef}
-      onClick={handleShimClick}
-      style={depthStyle}
-      className={`drawer padding--all--xxl drawer--${position} navigation  ${
-        isShown ? `navigation--open--${position}` : ""
-      }`}
-      data-testid={testId}
-    >
-      <div className={`navigation-container--${position}`}>
-        {showClose && (
-          <button
-            className={`button--reset navigation-button navigation-button--${position} alignChild--center--center`}
-            onClick={onUserDismiss}
-            aria-label="Close"
-          >
-            <span className="narmi-icon-x clickable fontSize--heading3" />
-          </button>
-        )}
-        {showClose && showControls && (
-          <div
-            className={
-              isHorizontal ? "margin--right--xl" : "margin--bottom--xl"
-            }
-          />
-        )}
-        {showControls && (
-          <>
-            <NavigationButton
-              position={position}
-              panelId={panelId}
-              {...firstButton}
-            />
-            <NavigationButton
-              position={position}
-              panelId={panelId}
-              {...secondButton}
-            />
-          </>
-        )}
-      </div>
-    </div>
-  );
-
   const childrenJSX = (
     <div
       style={depthStyle}
@@ -238,7 +179,23 @@ const Drawer = ({
           className={cc(["backdrop", { "backdrop--open": isShown }])}
           onClick={handleShimClick}
         />
-        {navigationContainerJSX}
+        {!isVerticalMobileDrawer && (
+          <DrawerNavigation
+            navRef={navRef}
+            onClick={handleShimClick}
+            depthStyle={depthStyle}
+            position={position}
+            isHorizontal={isHorizontal}
+            isShown={isShown}
+            showClose={showClose}
+            showControls={showControls}
+            onUserDismiss={onUserDismiss}
+            onNext={onNext}
+            onPrev={onPrev}
+            panelId={panelId}
+            testId={testId}
+          />
+        )}
         {!showControls ? (
           childrenJSX
         ) : (
@@ -299,6 +256,97 @@ const NavigationButton = ({
     <span className={`narmi-icon-chevron-${chevron} fontSize--heading3`} />
   </button>
 );
+
+interface DrawerNavigationProps {
+  navRef: React.RefObject<HTMLDivElement>;
+  onClick: (event: React.MouseEvent) => void;
+  depthStyle: React.CSSProperties;
+  position: Position;
+  isHorizontal: boolean;
+  isShown: boolean;
+  showClose: boolean;
+  showControls: boolean;
+  onUserDismiss: () => void;
+  onNext?: () => void;
+  onPrev?: () => void;
+  panelId: string;
+  testId?: string;
+}
+
+/* eslint-disable jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events */
+const DrawerNavigation = ({
+  navRef,
+  onClick,
+  depthStyle,
+  position,
+  isHorizontal,
+  isShown,
+  showClose,
+  showControls,
+  onUserDismiss,
+  onNext,
+  onPrev,
+  panelId,
+  testId,
+}: DrawerNavigationProps) => {
+  // Navigation buttons on vertical drawers are the opposite compared to
+  // horizontal ones due to the order of navigation buttons being the opposite
+  // (rows are reversed in parent divs for horizontal drawers)
+  const [firstButton, secondButton] = isHorizontal
+    ? [
+        { onClick: onNext, label: "Next", chevron: "right" as const },
+        { onClick: onPrev, label: "Previous", chevron: "left" as const },
+      ]
+    : [
+        { onClick: onPrev, label: "Previous", chevron: "up" as const },
+        { onClick: onNext, label: "Next", chevron: "down" as const },
+      ];
+
+  return (
+    <div
+      ref={navRef}
+      onClick={onClick}
+      style={depthStyle}
+      className={`drawer padding--all--xxl drawer--${position} navigation  ${
+        isShown ? `navigation--open--${position}` : ""
+      }`}
+      data-testid={testId}
+    >
+      <div className={`navigation-container--${position}`}>
+        {showClose && (
+          <button
+            className={`button--reset navigation-button navigation-button--${position} alignChild--center--center`}
+            onClick={onUserDismiss}
+            aria-label="Close"
+          >
+            <span className="narmi-icon-x clickable fontSize--heading3" />
+          </button>
+        )}
+        {showClose && showControls && (
+          <div
+            className={
+              isHorizontal ? "margin--right--xl" : "margin--bottom--xl"
+            }
+          />
+        )}
+        {showControls && (
+          <>
+            <NavigationButton
+              position={position}
+              panelId={panelId}
+              {...firstButton}
+            />
+            <NavigationButton
+              position={position}
+              panelId={panelId}
+              {...secondButton}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
 
 interface MobileNavigationProps {
   showControls: boolean;

--- a/src/Drawer/index.tsx
+++ b/src/Drawer/index.tsx
@@ -201,34 +201,13 @@ const Drawer = ({
     >
       <div className={cc(["drawer-content", `padding--all--${paddingSize}`])}>
         {isVerticalMobileDrawer && (
-          <>
-            {showControls && (
-              <>
-                <button
-                  className="button--reset mobile-navigation-button mobile-navigation-button--prev"
-                  onClick={onPrev}
-                  aria-controls={panelId}
-                  aria-label="Previous"
-                >
-                  <span className="narmi-icon-chevron-left fontSize--heading3" />
-                </button>
-                <button
-                  className="button--reset mobile-navigation-button mobile-navigation-button--next"
-                  onClick={onNext}
-                  aria-controls={panelId}
-                  aria-label="Next"
-                >
-                  <span className="narmi-icon-chevron-right fontSize--heading3" />
-                </button>
-              </>
-            )}
-            <button
-              className="button--reset mobile-navigation-button mobile-navigation-button--close"
-              onClick={onUserDismiss}
-            >
-              <span className="narmi-icon-x clickable fontSize--heading3" />
-            </button>
-          </>
+          <MobileNavigation
+            showControls={showControls}
+            onUserDismiss={onUserDismiss}
+            onNext={onNext}
+            onPrev={onPrev}
+            panelId={panelId}
+          />
         )}
         {typeof children === "function"
           ? children({ isVisible: isTransitioning })
@@ -319,6 +298,51 @@ const NavigationButton = ({
   >
     <span className={`narmi-icon-chevron-${chevron} fontSize--heading3`} />
   </button>
+);
+
+interface MobileNavigationProps {
+  showControls: boolean;
+  onUserDismiss: () => void;
+  onNext?: () => void;
+  onPrev?: () => void;
+  panelId: string;
+}
+
+const MobileNavigation = ({
+  showControls,
+  onUserDismiss,
+  onNext,
+  onPrev,
+  panelId,
+}: MobileNavigationProps) => (
+  <>
+    {showControls && (
+      <>
+        <button
+          className="button--reset mobile-navigation-button mobile-navigation-button--prev"
+          onClick={onPrev}
+          aria-controls={panelId}
+          aria-label="Previous"
+        >
+          <span className="narmi-icon-chevron-left fontSize--heading3" />
+        </button>
+        <button
+          className="button--reset mobile-navigation-button mobile-navigation-button--next"
+          onClick={onNext}
+          aria-controls={panelId}
+          aria-label="Next"
+        >
+          <span className="narmi-icon-chevron-right fontSize--heading3" />
+        </button>
+      </>
+    )}
+    <button
+      className="button--reset mobile-navigation-button mobile-navigation-button--close"
+      onClick={onUserDismiss}
+    >
+      <span className="narmi-icon-x clickable fontSize--heading3" />
+    </button>
+  </>
 );
 
 export default Drawer;


### PR DESCRIPTION
## Summary

Follow-up to #2273. Drawer was the top complexity offender at 31; the next-highest function is CollapsibleCard at 17.

- Extract `NavigationButton`, `DrawerNavigation`, and `MobileNavigation` sub-components (same file, not exported). The two desktop nav buttons were near-duplicates each carrying four `isHorizontal` ternaries; one ternary now picks the ordered pair of button configs.
- Hoist `isOpen && isTransitioning` into a single `isShown` constant.
- Drawer's main function: complexity **31 → 14**.
- Lower the `complexity` rule from 31 to **17**.
- Add `src/Drawer/index.test.tsx` (26 tests). Drawer previously had no tests.

## Reviewing

The whole-PR diff is large because ~110 lines move out of Drawer into helpers at the bottom of the file. It's much easier commit by commit; each step is independently lint/typecheck/test clean:

1. `hoist repeated isOpen && isTransitioning check` — 4+/6-
2. `dedupe desktop navigation buttons` — the only commit with real logic change (one ternary replaces eight)
3. `extract MobileNavigation` — pure move
4. `extract DrawerNavigation` — pure move
5. `lower complexity threshold from 31 to 17`
6. `test(Drawer): add tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
