### PR TITLE
fix(Select): keep typeahead visible and stop stale-highlight selection

### DIFF
--- a/src/Select/index.test.js
+++ b/src/Select/index.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import Select, {
   isAction,
   getSelectedItemDisplay,
@@ -7,6 +7,7 @@ import Select, {
   getItemIndex,
   isHighlightedInCategory,
   isSelectedItemInCategory,
+  getTypeaheadMatch,
 } from "./";
 
 const MOCK_ITEMS = [
@@ -211,5 +212,175 @@ describe("Select", () => {
     // dropdown should be closed at this point, so the text "Action"
     // should no longer be in the DOM (including in the trigger label)
     expect(screen.queryByText("Action")).not.toBeInTheDocument();
+  });
+
+  describe("typeahead", () => {
+    const STATES = [
+      <Select.Item key=".0" value="Mississippi">
+        Mississippi
+      </Select.Item>,
+      <Select.Item key=".1" value="Missouri">
+        Missouri
+      </Select.Item>,
+      <Select.Item key=".2" value="Alabama">
+        Alabama
+      </Select.Item>,
+    ];
+
+    /** Types `str` at the (focused) trigger, one character event per letter */
+    const typeahead = (trigger, str) => {
+      for (const key of str) fireEvent.keyDown(trigger, { key });
+    };
+
+    const renderStates = (props = {}, children = STATES) => {
+      const onChange = vi.fn();
+      render(
+        <Select label="State" onChange={onChange} {...props}>
+          {children}
+        </Select>,
+      );
+      return { onChange, trigger: screen.getByRole("combobox") };
+    };
+
+    it("previews the matched item in the trigger while typing", () => {
+      const { trigger, onChange } = renderStates();
+      typeahead(trigger, "mis");
+
+      // the trigger shows the match, not the raw keystrokes
+      expect(trigger).toHaveTextContent("Mississippi");
+      expect(trigger).not.toHaveTextContent("mis");
+      // previewing is not committing
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("keeps the preview after downshift's typeahead buffer expires", () => {
+      vi.useFakeTimers();
+      try {
+        const { trigger, onChange } = renderStates();
+        typeahead(trigger, "mis");
+        expect(trigger).toHaveTextContent("Mississippi");
+
+        // downshift clears its typeahead buffer 500ms after the last
+        // keystroke. That resets `inputValue` but leaves the highlight — and
+        // so the item a blur would commit — in place, so the trigger must
+        // keep showing it.
+        act(() => vi.advanceTimersByTime(1000));
+        expect(trigger).toHaveTextContent("Mississippi");
+
+        fireEvent.blur(trigger);
+        expect(onChange).toHaveBeenCalledWith("Mississippi");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("commits the matched item on blur, and it persists", () => {
+      const { trigger, onChange } = renderStates();
+      typeahead(trigger, "mis");
+      fireEvent.blur(trigger);
+
+      expect(onChange).toHaveBeenCalledWith("Mississippi");
+      expect(trigger).toHaveTextContent("Mississippi");
+    });
+
+    it("does not select when nothing matches", () => {
+      const { trigger, onChange } = renderStates();
+      typeahead(trigger, "zz");
+      fireEvent.blur(trigger);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(trigger).not.toHaveTextContent("Mississippi");
+    });
+
+    it("does not commit a stale highlight after a non-matching keystroke", () => {
+      const { trigger, onChange } = renderStates();
+      typeahead(trigger, "mis"); // Mississippi is highlighted
+      typeahead(trigger, "zz"); // ...matches nothing
+      fireEvent.blur(trigger);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("leaves an existing selection untouched when nothing matches", () => {
+      const { trigger, onChange } = renderStates({ defaultValue: "Alabama" });
+      typeahead(trigger, "zz");
+      fireEvent.blur(trigger);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(trigger).toHaveTextContent("Alabama");
+    });
+
+    it("discards the typeahead on Escape", () => {
+      const { trigger, onChange } = renderStates();
+      typeahead(trigger, "mis");
+      fireEvent.keyDown(trigger, { key: "Escape" });
+
+      expect(trigger).not.toHaveTextContent("Mississippi");
+      fireEvent.blur(trigger);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("matches on searchValue when provided", () => {
+      const { trigger } = renderStates({}, [
+        <Select.Item key=".0" value="MO" searchValue="Missouri">
+          Missouri (MO)
+        </Select.Item>,
+      ]);
+      typeahead(trigger, "miss");
+      expect(trigger).toHaveTextContent("Missouri (MO)");
+    });
+
+    it("never typeahead-selects a Select.Action", () => {
+      const onSelect = vi.fn();
+      const { trigger, onChange } = renderStates({}, [
+        ...STATES,
+        <Select.Action key=".a" onSelect={onSelect}>
+          Add a state
+        </Select.Action>,
+      ]);
+      typeahead(trigger, "add");
+      fireEvent.blur(trigger);
+
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("commits through the controlled `value` path", () => {
+      const onChange = vi.fn();
+      const Controlled = () => {
+        const [value, setValue] = React.useState("");
+        return (
+          <Select
+            label="State"
+            value={value}
+            onChange={(next) => {
+              onChange(next);
+              setValue(next);
+            }}
+          >
+            {STATES}
+          </Select>
+        );
+      };
+      render(<Controlled />);
+      const trigger = screen.getByRole("combobox");
+
+      typeahead(trigger, "mis");
+      fireEvent.blur(trigger);
+
+      expect(onChange).toHaveBeenCalledWith("Mississippi");
+      expect(trigger).toHaveTextContent("Mississippi");
+    });
+
+    it("getTypeaheadMatch: rejects a candidate that does not match", () => {
+      const [mississippi] = STATES;
+      expect(getTypeaheadMatch("mis", mississippi)).toBe(mississippi);
+      expect(getTypeaheadMatch("zz", mississippi)).toBe(null);
+      expect(getTypeaheadMatch("", mississippi)).toBe(null);
+      expect(getTypeaheadMatch("mis", undefined)).toBe(null);
+      expect(
+        getTypeaheadMatch("add", <Select.Action onSelect={() => {}} />),
+      ).toBe(null);
+    });
   });
 });

--- a/src/Select/index.tsx
+++ b/src/Select/index.tsx
@@ -140,6 +140,30 @@ const defaultGetTypeAheadString = (
   return selectItem.props.searchValue || selectItem.props.value;
 };
 
+/**
+ * Resolves the item a typeahead keystroke actually matched.
+ *
+ * downshift returns the _previous_ `highlightedIndex` when a keystroke
+ * matches nothing, so the highlight alone cannot be trusted. This re-checks
+ * the candidate against the same typeahead string downshift matched on.
+ *
+ * @param userInput the accumulated typeahead string
+ * @param candidate the item downshift highlighted, if any
+ * @param getTypeaheadString the typeahead accessor in use
+ * @returns the matched Select.Item, or `null` when nothing matched
+ */
+export const getTypeaheadMatch = (
+  userInput: string,
+  candidate: SelectChild | undefined,
+  getTypeaheadString: SelectProps["getTypeaheadString"] = defaultGetTypeAheadString,
+): SelectItemElement | null => {
+  if (!userInput || !candidate || isAction(candidate)) return null;
+  const matches = getTypeaheadString(userInput, candidate)
+    .toLowerCase()
+    .startsWith(userInput.toLowerCase());
+  return matches ? candidate : null;
+};
+
 interface SelectCategoryConfig {
   label?: string;
   categoryChildren: SelectItemElement[];
@@ -234,6 +258,12 @@ function Select({
   );
   const actions = React.Children.toArray(children).filter(isAction); // All Select.Action items
   const [userInput, setUserInput] = useState(""); // most recent val the user typed while focused on this input
+  // Item the in-progress typeahead resolved to. Previewed in the trigger so
+  // it survives downshift's 500ms typeahead-buffer expiry, which clears
+  // `userInput` but leaves the highlight (and so the pending selection) intact.
+  const [typeaheadItem, setTypeaheadItem] = useState<SelectItemElement | null>(
+    null,
+  );
 
   // If categories are being used, extract items from categories
   if (
@@ -290,11 +320,27 @@ function Select({
       let isOpen = changes.isOpen;
 
       if (type === useSelect.stateChangeTypes.ToggleButtonKeyDownCharacter) {
-        const { inputValue } = changes;
-        setUserInput(inputValue ?? "");
+        const { inputValue = "", highlightedIndex = -1 } = changes;
+        const match = getTypeaheadMatch(
+          inputValue,
+          highlightedIndex >= 0 ? items[highlightedIndex] : undefined,
+          getTypeaheadString,
+        );
+        setUserInput(inputValue);
+        setTypeaheadItem(match);
         isOpen = true;
+
+        if (!match) {
+          // Drop the stale highlight downshift falls back to, so blurring
+          // cannot commit an item the user never typed toward.
+          return { ...changes, isOpen, highlightedIndex: -1 };
+        }
       } else {
         setUserInput(""); // reset input after any other event
+        // The buffer expiry is not a user action; it must not clear the preview
+        if (type !== useSelect.stateChangeTypes.FunctionSetInputValue) {
+          setTypeaheadItem(null);
+        }
       }
 
       // When an action is selected, execute it and handle clearing if needed
@@ -400,7 +446,13 @@ function Select({
           isOpen={showMenu}
           labelText={label}
           disabled={disabled}
-          displayValue={getSelectedItemDisplay(selectedItem) || userInput}
+          displayValue={
+            // Preview the pending typeahead match ahead of the committed
+            // selection, so the trigger shows what blurring will select
+            getSelectedItemDisplay(typeaheadItem) ||
+            getSelectedItemDisplay(selectedItem) ||
+            userInput
+          }
           labelProps={{ ...getLabelProps() }}
           hasError={Boolean(errorText)}
           {...getToggleButtonProps()}


### PR DESCRIPTION
## Problem

Typing at a closed `Select` echoes your keystrokes in the trigger, then blanks them about half a second later. It reads as a field that discarded your input. Reported from FI UAT on a US-state dropdown (LNDG-1600).

The original triage blamed the downshift v7 bump (`2b61c7f51`) for removing select-on-type, concluding that typing never selects anything. That part doesn't hold up: downshift v9's `ToggleButtonBlur` case commits `props.items[state.highlightedIndex]`, and since `Select` forces `isOpen = true` on character input, that path is always armed. Typing does select — it commits on blur rather than per keystroke. Verified in Chromium: type `tr`, click away, "Truck" is selected.

What's actually wrong is two smaller things.

**1. The preview disappears.** downshift clears its typeahead buffer 500ms after the last keystroke. That dispatch only resets `inputValue`; `highlightedIndex` — and so the item a blur will commit — survives it. Because the trigger rendered `userInput`, the display went empty while the pending selection was still live. Native `<select>` has the same buffer but never shows it, so nothing appears to vanish.

**2. A non-matching keystroke could commit a stale item.** `getItemIndexByCharacterKey` returns the *previous* `highlightedIndex` when nothing matches, rather than `-1`. Type `t` (highlights Truck), pause past the buffer expiry, type `z` — Truck stays highlighted, and clicking away selects it. The user typed a letter matching nothing and got a selection.

## Change

- The trigger previews the item the typeahead actually resolved to, tracked in its own state so it survives the buffer expiry. The trigger now shows exactly what blurring will commit.
- A non-matching keystroke clears the highlight, so blur can't commit an item the user never typed toward. `getTypeaheadMatch` re-checks the candidate against the same typeahead string downshift matched on.
- `userInput` keeps its existing lifecycle, so `getTypeaheadString` consumers — which branch on it, as in the **Changing Typeahead Behavior** story — are unaffected.

Deliberately **not** restoring v6's per-keystroke `selectedItem`: it would fire `onChange` on every keystroke toward a match, and the end state is already correct without it.

## Scope

`MultiSelect` was checked and is unaffected — its `onStateChange` only toggles on `ToggleButtonKeyDownEnter`/`SpaceButton`/`ItemClick`, so it ignored v6's character-key selection too. `Combobox` uses `useCombobox` with a real `<input>` and is unaffected.

## Testing

9 new tests in `src/Select/index.test.js` driving the real component: preview while typing, preview surviving the buffer expiry (fake timers), commit-on-blur, no-match inertness, the stale-highlight guard, an existing selection left untouched, Escape discarding, `searchValue` matching, `Select.Action` never typeahead-selected, and the controlled `value` path. 6 of them fail on `main`.

Also verified by hand in Chromium against the Select stories, since jsdom's focus/blur simulation doesn't faithfully model the click-away path.

`src/index.test.js` fails locally for both `main` and this branch — it imports `../dist`, which needs a full `npm run build`. Unrelated.